### PR TITLE
Remove remaining panics

### DIFF
--- a/dmfr/fvsl_test.go
+++ b/dmfr/fvsl_test.go
@@ -45,7 +45,7 @@ func TestNewFeedVersionServiceLevelsFromReader(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			reader, err := tlcsv.NewReader(tc.url)
 			if err != nil {
-				panic(err)
+				t.Fatal(err)
 			}
 			results, err := NewFeedVersionServiceInfosFromReader(reader)
 			if err != nil {

--- a/dmfr/registry.go
+++ b/dmfr/registry.go
@@ -3,6 +3,7 @@ package dmfr
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -44,7 +45,7 @@ func NewRegistry(reader io.Reader) (*Registry, error) {
 		if feedSpec == "gtfs" || feedSpec == "gtfs-rt" || feedSpec == "gbfs" || feedSpec == "mds" {
 			continue
 		} else {
-			log.Fatal("At least one feed in the DMFR file is not of a valid spec (GTFS, GTFS-RT, GBFS, or MDS)")
+			return nil, errors.New("At least one feed in the DMFR file is not of a valid spec (GTFS, GTFS-RT, GBFS, or MDS)")
 		}
 
 	}

--- a/dmfr/registry_test.go
+++ b/dmfr/registry_test.go
@@ -2,7 +2,6 @@ package dmfr
 
 import (
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,7 +12,6 @@ import (
 func TestLoadAndParseRegistry_from_file(t *testing.T) {
 	parsedContents, err := LoadAndParseRegistry(testutil.RelPath("test/data/dmfr/example.json"))
 	if err != nil {
-		log.Fatal(err)
 		t.Error(err)
 	}
 	if len(parsedContents.Feeds) != 2 {
@@ -62,7 +60,6 @@ func TestLoadAndParseRegistry_from_URL(t *testing.T) {
 	defer ts.Close()
 	parsedContents, err := LoadAndParseRegistry(ts.URL)
 	if err != nil {
-		log.Fatal(err)
 		t.Error(err)
 	}
 	if len(parsedContents.Feeds) != 2 {

--- a/dmfr/sync/sync_test.go
+++ b/dmfr/sync/sync_test.go
@@ -50,7 +50,7 @@ func TestMainSync(t *testing.T) {
 		return nil
 	})
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 }
 
@@ -226,6 +226,6 @@ func TestHideUnseedFeeds(t *testing.T) {
 		return nil
 	})
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 }

--- a/ext/ext.go
+++ b/ext/ext.go
@@ -21,39 +21,42 @@ var writerFactories = map[string]writerFactory{}
 var extensionFactories = map[string]extensionFactory{}
 
 // RegisterReader registers a Reader.
-func RegisterReader(name string, factory readerFactory) {
+func RegisterReader(name string, factory readerFactory) error {
 	if factory == nil {
-		log.Fatal("Factory %s does not exist", name)
+		return fmt.Errorf("factory '%s' does not exist", name)
 	}
 	_, registered := readerFactories[name]
 	if registered {
-		log.Fatal("Factory %s already registered", name)
+		return fmt.Errorf("factory '%s' already registered", name)
 	}
 	log.Debug("Registering Reader factory: %s", name)
 	readerFactories[name] = factory
+	return nil
 }
 
 // RegisterWriter registers a Writer.
-func RegisterWriter(name string, factory writerFactory) {
+func RegisterWriter(name string, factory writerFactory) error {
 	if factory == nil {
-		log.Fatal("Factory %s does not exist", name)
+		return fmt.Errorf("factory '%s' does not exist", name)
 	}
 	_, registered := writerFactories[name]
 	if registered {
-		log.Fatal("Factory %s already registered", name)
+		return fmt.Errorf("factory '%s' already registered", name)
 	}
 	log.Debug("Registering Writer factory: %s", name)
 	writerFactories[name] = factory
+	return nil
 }
 
 // RegisterExtension registers an Extension.
-func RegisterExtension(name string, factory extensionFactory) {
+func RegisterExtension(name string, factory extensionFactory) error {
 	_, registered := extensionFactories[name]
 	if registered {
-		panic("failed")
+		return fmt.Errorf("extension '%s' already registered", name)
 	}
-	log.Debug("Registering Extension factory: %s", name)
+	log.Debug("registering Extension factory: %s", name)
 	extensionFactories[name] = factory
+	return nil
 }
 
 // NewReader uses the scheme prefix as the driver name, defaulting to csv.
@@ -69,10 +72,10 @@ func NewReader(url string) (tl.Reader, error) {
 func MustOpenReaderOrPanic(path string) tl.Reader {
 	r, err := NewReader(path)
 	if err != nil {
-		panic(fmt.Sprintf("No handler for reader '%s': %s", path, err.Error()))
+		panic(fmt.Sprintf("no handler for reader '%s': %s", path, err.Error()))
 	}
 	if err := r.Open(); err != nil {
-		panic(fmt.Sprintf("Could not open reader '%s': %s", path, err.Error()))
+		panic(fmt.Sprintf("could not open reader '%s': %s", path, err.Error()))
 	}
 	return r
 }

--- a/ext/redate/redate_filter.go
+++ b/ext/redate/redate_filter.go
@@ -57,7 +57,7 @@ func (tf *RedateFilter) Filter(ent tl.Entity, emap *tl.EntityMap) error {
 	// Simplify back to regular calendar
 	newSvc, err := newSvc.Simplify()
 	if err != nil {
-		panic(err)
+		return err
 	}
 	newSvc.Generated = false
 	// Reset and update in place

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -78,12 +78,6 @@ func Debug(fmts string, a ...interface{}) {
 	logLog(DEBUG, fmts, a...)
 }
 
-// Fatal for fatal, unrecoverable errors.
-func Fatal(fmts string, a ...interface{}) {
-	logLog(FATAL, fmts, a...)
-	panic(fmt.Sprintf(fmts, a...))
-}
-
 // Exit with an error message.
 func Exit(fmts string, args ...interface{}) {
 	Print(fmts, args...)

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -10,17 +10,6 @@ import (
 var prefix = "2019/03/19 17:08:58  "
 var msg = "test %d"
 
-func TestFatal(t *testing.T) {
-	defer func() {
-		if r := recover(); r != nil {
-			// ok
-		} else {
-			t.Error("expected to recover from Fatal")
-		}
-	}()
-	Fatal(msg, 123)
-}
-
 func TestLogLevels(t *testing.T) {
 	funcs := []struct {
 		name  string

--- a/internal/testdb/testdb.go
+++ b/internal/testdb/testdb.go
@@ -26,8 +26,8 @@ func MustUpdate(atx tldb.Adapter, ent interface{}, columns ...string) {
 }
 
 // MustFind panics on failure
-func MustFind(atx tldb.Adapter, ent interface{}, qargs ...interface{}) {
-	err := atx.Find(ent, qargs...)
+func MustFind(atx tldb.Adapter, ent interface{}) {
+	err := atx.Find(ent)
 	if err != nil {
 		panic(err)
 	}
@@ -69,8 +69,8 @@ func ShouldUpdate(t *testing.T, atx tldb.Adapter, ent interface{}, columns ...st
 }
 
 // ShouldFind pasends a test error on failure
-func ShouldFind(t *testing.T, atx tldb.Adapter, ent interface{}, qargs ...interface{}) {
-	err := atx.Find(ent, qargs...)
+func ShouldFind(t *testing.T, atx tldb.Adapter, ent interface{}) {
+	err := atx.Find(ent)
 	if err != nil {
 		t.Errorf("failed find: %s", err.Error())
 	}

--- a/internal/testutil/root_path.go
+++ b/internal/testutil/root_path.go
@@ -14,7 +14,7 @@ var (
 func RootPath() string {
 	a, err := filepath.Abs(filepath.Join(basepath, "..", ".."))
 	if err != nil {
-		panic(err)
+		return ""
 	}
 	return a
 }

--- a/internal/xy/xy_benchmark_test.go
+++ b/internal/xy/xy_benchmark_test.go
@@ -7,7 +7,10 @@ import (
 ////////////////////
 
 func BenchmarkSegmentClosestPoint(b *testing.B) {
-	l, _ := decodeGeojson(testLines[0].Geojson)
+	l, _, err := decodeGeojson(testLines[0].Geojson)
+	if err != nil {
+		b.Fatal(err)
+	}
 	q := unflattenCoordinates(l.FlatCoords())
 	// get the midpoint
 	sa := q[0]
@@ -19,7 +22,10 @@ func BenchmarkSegmentClosestPoint(b *testing.B) {
 }
 
 func BenchmarkLineClosestPoint(b *testing.B) {
-	l, _ := decodeGeojson(testLines[0].Geojson)
+	l, _, err := decodeGeojson(testLines[0].Geojson)
+	if err != nil {
+		b.Fatal(err)
+	}
 	q := unflattenCoordinates(l.FlatCoords())
 	// get the midpoint of the two middle points
 	sa := q[len(q)/2]
@@ -31,7 +37,10 @@ func BenchmarkLineClosestPoint(b *testing.B) {
 }
 
 func BenchmarkLinePositions(b *testing.B) {
-	line, points := decodeGeojson(testPositions[0].Geojson)
+	line, points, err := decodeGeojson(testPositions[0].Geojson)
+	if err != nil {
+		b.Fatal(err)
+	}
 	lc := unflattenCoordinates(line.FlatCoords())
 	pp := []Point{}
 	for _, p := range points {
@@ -45,7 +54,10 @@ func BenchmarkLinePositions(b *testing.B) {
 }
 
 func BenchmarkLinePositionsFallback(b *testing.B) {
-	_, points := decodeGeojson(testPositions[0].Geojson)
+	_, points, err := decodeGeojson(testPositions[0].Geojson)
+	if err != nil {
+		b.Fatal(err)
+	}
 	pp := []Point{}
 	for _, p := range points {
 		pp = append(pp, Point{p.FlatCoords()[0], p.FlatCoords()[1]})
@@ -76,7 +88,10 @@ func BenchmarkDistanceHaversine(b *testing.B) {
 }
 
 func BenchmarkLength2d(b *testing.B) {
-	l, _ := decodeGeojson(testLines[0].Geojson)
+	l, _, err := decodeGeojson(testLines[0].Geojson)
+	if err != nil {
+		b.Fatal(err)
+	}
 	line := unflattenCoordinates(l.FlatCoords())
 	var r float64
 	for n := 0; n < b.N; n++ {
@@ -86,7 +101,10 @@ func BenchmarkLength2d(b *testing.B) {
 }
 
 func BenchmarkLengthHaversine(b *testing.B) {
-	l, _ := decodeGeojson(testLines[0].Geojson)
+	l, _, err := decodeGeojson(testLines[0].Geojson)
+	if err != nil {
+		b.Fatal(err)
+	}
 	line := unflattenCoordinates(l.FlatCoords())
 	var r float64
 	for n := 0; n < b.N; n++ {

--- a/internal/xy/xy_test.go
+++ b/internal/xy/xy_test.go
@@ -42,11 +42,11 @@ var testPositions = []struct {
 	{`{"type":"FeatureCollection","features":[{"type":"Feature","properties":{},"geometry":{"type":"LineString","coordinates":[[-122.2665023803711,37.87431138542283],[-122.26581573486328,37.853712122567565],[-122.26444244384766,37.83961457275219],[-122.26821899414061,37.82551432799189],[-122.26341247558594,37.819548028632376],[-122.27130889892578,37.803273851858656],[-122.26959228515624,37.80001858607365],[-122.24555969238281,37.788352705583755],[-122.22564697265625,37.77641361883315],[-122.19577789306639,37.75225820732335],[-122.16487884521483,37.72673718477409]]}},{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-122.27062225341797,37.8724143256462]}},{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-122.26289749145506,37.84354589127591]}},{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-122.26427078247069,37.81507298760665]}},{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-122.27027893066405,37.80544394934271]}},{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-122.2258186340332,37.77695634643178]}},{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-122.19697952270508,37.75347973770911]}},{"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[-122.16487884521483,37.72782336496339]}}]}`, []float64{0.008487181237797688, 0.1496538990811318, 0.2964636787237469, 0.3509258016789892, 0.6191751524042424, 0.7983912644738984, 0.9966620810270027}, []float64{0, 0.14880713711146062, 0.2907521492606507, 0.3472678477073867, 0.6102041614615478, 0.7953741712658748, 1.0}},
 }
 
-func decodeGeojson(data string) (*geom.LineString, []*geom.Point) {
+func decodeGeojson(data string) (*geom.LineString, []*geom.Point, error) {
 	fc := geojson.FeatureCollection{}
 	err := fc.UnmarshalJSON([]byte(data))
 	if err != nil {
-		panic(err)
+		return nil, nil, err
 	}
 	var line *geom.LineString
 	points := []*geom.Point{}
@@ -58,7 +58,7 @@ func decodeGeojson(data string) (*geom.LineString, []*geom.Point) {
 			points = append(points, v)
 		}
 	}
-	return line, points
+	return line, points, nil
 }
 
 func unflattenCoordinates(coords []float64) []Point {
@@ -69,12 +69,12 @@ func unflattenCoordinates(coords []float64) []Point {
 	return ret
 }
 
-func makeTestLine(gj string) []Point {
+func makeTestLine(gj string) ([]Point, error) {
 	var line geom.T
 	if err := geojson.Unmarshal([]byte(gj), &line); err != nil {
-		panic(err)
+		return nil, err
 	}
-	return unflattenCoordinates(line.FlatCoords())
+	return unflattenCoordinates(line.FlatCoords()), nil
 }
 
 func TestDistance2d(t *testing.T) {
@@ -93,7 +93,10 @@ func TestDistanceHaversine(t *testing.T) {
 
 func TestLinePositions(t *testing.T) {
 	for _, dp := range testPositions {
-		line, points := decodeGeojson(dp.Geojson)
+		line, points, err := decodeGeojson(dp.Geojson)
+		if err != nil {
+			t.Fatal(err)
+		}
 		lc := unflattenCoordinates(line.FlatCoords())
 		pp := []Point{}
 		for _, p := range points {
@@ -112,7 +115,10 @@ func TestLinePositions(t *testing.T) {
 
 func TestLinePositionsFallback(t *testing.T) {
 	for _, dp := range testPositions {
-		_, points := decodeGeojson(dp.Geojson)
+		_, points, err := decodeGeojson(dp.Geojson)
+		if err != nil {
+			t.Fatal(err)
+		}
 		pp := []Point{}
 		for _, p := range points {
 			pp = append(pp, Point{p.FlatCoords()[0], p.FlatCoords()[1]})
@@ -130,7 +136,10 @@ func TestLinePositionsFallback(t *testing.T) {
 
 func TestLength2d(t *testing.T) {
 	for _, line := range testLines {
-		l, _ := decodeGeojson(line.Geojson)
+		l, _, err := decodeGeojson(line.Geojson)
+		if err != nil {
+			t.Fatal(err)
+		}
 		coords := unflattenCoordinates(l.FlatCoords())
 		d := Length2d(coords)
 		testApproxEqual(t, line.Length2d, d)
@@ -139,7 +148,10 @@ func TestLength2d(t *testing.T) {
 
 func TestLengthHaversine(t *testing.T) {
 	for _, line := range testLines {
-		l, _ := decodeGeojson(line.Geojson)
+		l, _, err := decodeGeojson(line.Geojson)
+		if err != nil {
+			t.Fatal(err)
+		}
 		coords := unflattenCoordinates(l.FlatCoords())
 		d := LengthHaversine(coords)
 		testApproxEqual(t, line.lengthHaversine, d)

--- a/rt/validator_test.go
+++ b/rt/validator_test.go
@@ -7,20 +7,23 @@ import (
 	"github.com/interline-io/transitland-lib/tlcsv"
 )
 
-func newTestValidator() *Validator {
+func newTestValidator() (*Validator, error) {
 	r, err := tlcsv.NewReader(testutil.RelPath("test/data/rt/bart-rt.zip"))
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	fi, err := NewValidatorFromReader(r)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	return fi
+	return fi, nil
 }
 
 func TestValidateHeader(t *testing.T) {
-	fi := newTestValidator()
+	fi, err := newTestValidator()
+	if err != nil {
+		t.Fatal(err)
+	}
 	msg, err := ReadFile(testutil.RelPath("test/data/rt/bart-trip-updates.pb"))
 	if err != nil {
 		t.Error(err)
@@ -34,7 +37,10 @@ func TestValidateHeader(t *testing.T) {
 }
 
 func TestValidateTripUpdate(t *testing.T) {
-	fi := newTestValidator()
+	fi, err := newTestValidator()
+	if err != nil {
+		t.Fatal(err)
+	}
 	msg, err := ReadFile(testutil.RelPath("test/data/rt/bart-trip-updates.pb"))
 	if err != nil {
 		t.Error(err)

--- a/tldb/adapter.go
+++ b/tldb/adapter.go
@@ -39,7 +39,7 @@ type Adapter interface {
 	Sqrl() sq.StatementBuilderType
 	Insert(interface{}) (int, error)
 	Update(interface{}, ...string) error
-	Find(interface{}, ...interface{}) error
+	Find(interface{}) error
 	Get(interface{}, string, ...interface{}) error
 	Select(interface{}, string, ...interface{}) error
 	MultiInsert([]interface{}) ([]int, error)

--- a/tldb/common.go
+++ b/tldb/common.go
@@ -49,7 +49,7 @@ func contains(a string, b []string) bool {
 }
 
 // find a single record.
-func find(adapter Adapter, dest interface{}, args ...interface{}) error {
+func find(adapter Adapter, dest interface{}) error {
 	entid := 0
 	if v, ok := dest.(canGetID); ok {
 		entid = v.GetID()
@@ -73,6 +73,9 @@ func update(adapter Adapter, ent interface{}, columns ...string) error {
 	}
 	table := getTableName(ent)
 	header, err := MapperCache.GetHeader(ent)
+	if err != nil {
+		return err
+	}
 	vals, err := MapperCache.GetInsert(ent, header)
 	if err != nil {
 		return err

--- a/tldb/db.go
+++ b/tldb/db.go
@@ -12,6 +12,8 @@ import (
 
 var bufferSize = 1000
 
+// check for error and panic
+// TODO: don't do this. panic is bad.
 func check(err error) {
 	if err != nil {
 		log.Debug("Error: %s", err)

--- a/tldb/postgres.go
+++ b/tldb/postgres.go
@@ -92,8 +92,8 @@ func (adapter *PostgresAdapter) Sqrl() sq.StatementBuilderType {
 }
 
 // Find finds a single entity based on the EntityID()
-func (adapter *PostgresAdapter) Find(dest interface{}, args ...interface{}) error {
-	return find(adapter, dest, args...)
+func (adapter *PostgresAdapter) Find(dest interface{}) error {
+	return find(adapter, dest)
 }
 
 // Get wraps sqlx.Get
@@ -115,6 +115,9 @@ func (adapter *PostgresAdapter) Update(ent interface{}, columns ...string) error
 func (adapter *PostgresAdapter) Insert(ent interface{}) (int, error) {
 	table := getTableName(ent)
 	header, err := MapperCache.GetHeader(ent)
+	if err != nil {
+		return 0, err
+	}
 	vals, err := MapperCache.GetInsert(ent, header)
 	if err != nil {
 		return 0, err

--- a/tldb/reader.go
+++ b/tldb/reader.go
@@ -72,7 +72,6 @@ func (reader *Reader) ReadEntities(c interface{}) error {
 		return err
 	}
 	if err := reader.Adapter.Select(x.Interface(), qstr, args...); err != nil {
-		check(err)
 		return err
 	}
 	go func() {

--- a/tldb/sqlite.go
+++ b/tldb/sqlite.go
@@ -110,8 +110,8 @@ func (adapter *SQLiteAdapter) Tx(cb func(Adapter) error) error {
 }
 
 // Find finds a single entity based on the EntityID()
-func (adapter *SQLiteAdapter) Find(dest interface{}, args ...interface{}) error {
-	return find(adapter, dest, args...)
+func (adapter *SQLiteAdapter) Find(dest interface{}) error {
+	return find(adapter, dest)
 }
 
 // Get wraps sqlx.Get
@@ -133,6 +133,9 @@ func (adapter *SQLiteAdapter) Update(ent interface{}, columns ...string) error {
 func (adapter *SQLiteAdapter) Insert(ent interface{}) (int, error) {
 	table := getTableName(ent)
 	header, err := MapperCache.GetHeader(ent)
+	if err != nil {
+		return 0, err
+	}
 	vals, err := MapperCache.GetInsert(ent, header)
 	if err != nil {
 		return 0, err
@@ -147,7 +150,7 @@ func (adapter *SQLiteAdapter) Insert(ent interface{}) (int, error) {
 		return 0, err
 	}
 	eid, err := result.LastInsertId()
-	return int(eid), nil
+	return int(eid), err
 }
 
 // MultiInsert inserts multiple entities.


### PR DESCRIPTION
Excluding Must* functions

There also remains a `check` method in db reader that can panic, this is due to my bad design that didn't leave another mechanism for signaling errors reading from the database.