### PR TITLE
Remove shapes, calendars, frequency, transfers when deleting schedule

### DIFF
--- a/dmfr/unimporter/unimporter.go
+++ b/dmfr/unimporter/unimporter.go
@@ -15,11 +15,16 @@ func feedVersionTableDelete(atx tldb.Adapter, table string, fvid int) error {
 }
 
 // UnimportSchedule removes schedule data for a feed version and updates the import record.
-// gtfs_trips and gtfs_stop_times tables are affected.
+// stops, routes, agencies, pathways, levels are not affected.
 func UnimportSchedule(atx tldb.Adapter, id int) error {
 	tables := []string{
 		"gtfs_stop_times",
+		"gtfs_transfers",
+		"gtfs_calendar_dates",
+		"gtfs_frequencies",
 		"gtfs_trips",
+		"gtfs_shapes",
+		"gtfs_calendars",
 	}
 	where := sq.Eq{"feed_version_id": id}
 	for _, table := range tables {
@@ -55,9 +60,9 @@ func UnimportFeedVersion(atx tldb.Adapter, id int, extraTables []string) error {
 		"gtfs_calendar_dates",
 		"gtfs_feed_infos",
 		"gtfs_frequencies",
-		"gtfs_pathways",
 		"gtfs_fare_rules",
 		// named entities
+		"gtfs_pathways",
 		"gtfs_fare_attributes",
 		"gtfs_trips",
 		"gtfs_shapes",

--- a/dmfr/unimporter/unimporter_cmd.go
+++ b/dmfr/unimporter/unimporter_cmd.go
@@ -39,7 +39,7 @@ func (cmd *Command) Parse(args []string) error {
 	// fl.Var(&cmd.Extensions, "ext", "Include GTFS Extension") // TODO
 	fl.StringVar(&cmd.DBURL, "dburl", "", "Database URL (default: $TL_DATABASE_URL)")
 	fl.BoolVar(&cmd.DryRun, "dryrun", false, "Dry run; print feeds that would be imported and exit")
-	fl.BoolVar(&cmd.ScheduleOnly, "schedule-only", false, "Unimport only trips and stop times")
+	fl.BoolVar(&cmd.ScheduleOnly, "schedule-only", false, "Unimport stop times, trips, transfers, shapes, frequencies, and transfers")
 	fl.Parse(args)
 	cmd.Workers = 1
 	cmd.FVIDs = fl.Args()

--- a/dmfr/unimporter/unimporter_cmd.go
+++ b/dmfr/unimporter/unimporter_cmd.go
@@ -95,7 +95,7 @@ func (cmd *Command) Run() error {
 		return err
 	}
 	if cmd.ScheduleOnly {
-		log.Info("Unmporting trips and stop times from %d feed versions", len(qrs))
+		log.Info("Unmporting schedule data from %d feed versions", len(qrs))
 	} else {
 		log.Info("Unmporting %d feed versions", len(qrs))
 	}

--- a/internal/schema/postgres/migrations/20211219234448_remove_tlrg_shape_id.up.pgsql
+++ b/internal/schema/postgres/migrations/20211219234448_remove_tlrg_shape_id.up.pgsql
@@ -1,0 +1,5 @@
+BEGIN;
+
+alter table tl_route_geometries drop column shape_id;
+
+COMMIT;


### PR DESCRIPTION
These are not useful or informative when trips and stop_times are not present.