### PR TITLE
read and write `supersedes_ids` field in DMFR files

### DIFF
--- a/dmfr/raw_registry_test.go
+++ b/dmfr/raw_registry_test.go
@@ -110,6 +110,16 @@ func TestRawRegistry_Write(t *testing.T) {
 			`{"feeds":[{"id":"test", "name":"a&b"}]}`,
 			`{"feeds":[{"id":"test", "name":"a&b"}]}`,
 		},
+		{
+			"supersedes_ids",
+			`{"feeds":[{"id":"test", "supersedes_ids":["previous","first"]}]}`,
+			`{"feeds":[{"id":"test", "supersedes_ids":["previous","first"]}]}`,
+		},
+		{
+			"supersedes_ids empty",
+			`{"feeds":[{"id":"test", "supersedes_ids":[]}]}`,
+			`{"feeds":[{"id":"test"}]}`,
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {

--- a/tl/feed.go
+++ b/tl/feed.go
@@ -12,7 +12,7 @@ import (
 type Feed struct {
 	ID            int               `json:"-"`
 	FeedID        string            `json:"id" db:"onestop_id"`
-	SupersedesIds []string          `json:"supersedes_ids,omitempty"`
+	SupersedesIDs Strings           `json:"supersedes_ids,omitempty" db:"-"`
 	Name          String            `json:"name,omitempty"`
 	Spec          string            `json:"spec,omitempty"`
 	URLs          FeedUrls          `json:"urls,omitempty" db:"urls"`

--- a/tl/feed.go
+++ b/tl/feed.go
@@ -10,18 +10,19 @@ import (
 
 // Feed listed in a parsed DMFR file
 type Feed struct {
-	ID              int               `json:"-"`
-	FeedID          string            `json:"id" db:"onestop_id"`
-	Name            String            `json:"name,omitempty"`
-	Spec            string            `json:"spec,omitempty"`
-	URLs            FeedUrls          `json:"urls,omitempty" db:"urls"`
-	Languages       FeedLanguages     `json:"languages,omitempty"`
-	License         FeedLicense       `json:"license,omitempty"`
-	Authorization   FeedAuthorization `json:"authorization,omitempty" db:"auth"`
-	Tags            Tags              `json:"tags,omitempty" db:"feed_tags" `
-	File            string            `json:"-"` // internal
-	DeletedAt       Time              `json:"-"` // internal
-	Timestamps      `json:"-"`        // internal
+	ID            int               `json:"-"`
+	FeedID        string            `json:"id" db:"onestop_id"`
+	SupersedesIds []string          `json:"supersedes_ids,omitempty"`
+	Name          String            `json:"name,omitempty"`
+	Spec          string            `json:"spec,omitempty"`
+	URLs          FeedUrls          `json:"urls,omitempty" db:"urls"`
+	Languages     FeedLanguages     `json:"languages,omitempty"`
+	License       FeedLicense       `json:"license,omitempty"`
+	Authorization FeedAuthorization `json:"authorization,omitempty" db:"auth"`
+	Tags          Tags              `json:"tags,omitempty" db:"feed_tags" `
+	File          string            `json:"-"` // internal
+	DeletedAt     Time              `json:"-"` // internal
+	Timestamps    `json:"-"`        // internal
 }
 
 func (ent *Feed) MatchSecrets(secrets []Secret) (Secret, error) {

--- a/tl/operator.go
+++ b/tl/operator.go
@@ -10,7 +10,7 @@ import (
 type Operator struct {
 	ID              int                     `json:"-"`
 	OnestopID       String                  `json:"onestop_id"`
-	SupersedesIds   []string                `json:"supersedes_ids,omitempty"`
+	SupersedesIDs   Strings                 `json:"supersedes_ids,omitempty" db:"-"`
 	Name            String                  `json:"name,omitempty"`
 	ShortName       String                  `json:"short_name,omitempty"`
 	Website         String                  `json:"website,omitempty"`

--- a/tl/operator.go
+++ b/tl/operator.go
@@ -10,6 +10,7 @@ import (
 type Operator struct {
 	ID              int                     `json:"-"`
 	OnestopID       String                  `json:"onestop_id"`
+	SupersedesIds   []string                `json:"supersedes_ids,omitempty"`
 	Name            String                  `json:"name,omitempty"`
 	ShortName       String                  `json:"short_name,omitempty"`
 	Website         String                  `json:"website,omitempty"`

--- a/tl/types.go
+++ b/tl/types.go
@@ -81,6 +81,23 @@ func (r String) MarshalGQL(w io.Writer) {
 	w.Write(b)
 }
 
+//////////
+
+// Strings helps read and write []String as JSON
+type Strings []String
+
+func (a Strings) Value() (driver.Value, error) {
+	return json.Marshal(a)
+}
+
+func (a *Strings) Scan(value interface{}) error {
+	b, ok := value.([]byte)
+	if !ok {
+		return errors.New("type assertion to []byte failed")
+	}
+	return json.Unmarshal(b, &a)
+}
+
 /////////////////////
 
 type Int struct {


### PR DESCRIPTION
`feed.supersedes_ids` and `operator.supersedes_ids` arrays were being removed when using the `transitland format --save` command