### PR TITLE
Check for ADDED trip in vehicle position E003 check

### DIFF
--- a/rt/validator.go
+++ b/rt/validator.go
@@ -625,7 +625,10 @@ func (fi *Validator) ValidateVehiclePosition(ent *pb.VehiclePosition) (errs []er
 			tripId := td.GetTripId()
 			trip, tripOk := fi.tripInfo[tripId]
 			shp := fi.geomCache.GetShape(trip.ShapeID)
-			if !tripOk {
+			// Check trip exists
+			if !tripOk && td.GetScheduleRelationship() == pb.TripDescriptor_ADDED {
+				// ADDED trip - allowed
+			} else if !tripOk {
 				errs = append(errs, withFieldAndJson(
 					E003,
 					"vehicle_position.trip.trip_id",


### PR DESCRIPTION
## Summary
Fix a false-positive `E003` in `Validator.ValidateVehiclePosition` when the referenced trip has `schedule_relationship = ADDED`. Per the GTFS-RT spec, an ADDED trip is one that does not exist in the static feed by design; raising "trip_id does not exist in GTFS data" against it is incorrect.

### Behavior
- Before: any VehiclePosition whose `trip.trip_id` is not in static `tripInfo` produced `E003`, including ADDED trips.
- After: the `!tripOk` branch in `ValidateVehiclePosition` only emits `E003` when `trip.schedule_relationship` is not `ADDED`. ADDED trips fall through silently.

## Test plan
- Feed a VehiclePosition referencing a `trip_id` that is not in the static feed with `schedule_relationship = SCHEDULED` (default) — confirm `E003` still fires.
- Feed the same VehiclePosition with `schedule_relationship = ADDED` — confirm `E003` is suppressed and no other validator output regresses.
- Existing `rt/` test fixtures should still pass; if a fixture asserted `E003` on an ADDED trip, update it to match the new (correct) behavior.