### PR TITLE
Improve User-Agent for http requests

### DIFF
--- a/tl/request/http.go
+++ b/tl/request/http.go
@@ -51,6 +51,8 @@ func (r Http) Download(ctx context.Context, ustr string, secret tl.Secret, auth 
 
 	// Make HTTP request
 	req = req.WithContext(ctx)
+	req.Header.Set("User-Agent", fmt.Sprintf("transitland/%s", tl.VERSION))
+
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/tl/request/request.go
+++ b/tl/request/request.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -142,7 +142,7 @@ func AuthenticatedRequestDownload(address string, opts ...RequestOption) (FetchR
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(time.Second*600))
 	defer cancel()
 	// Create temp file
-	tmpfile, err := ioutil.TempFile("", "fetch")
+	tmpfile, err := os.CreateTemp("", "fetch")
 	if err != nil {
 		return fr, errors.New("could not create temporary file")
 	}


### PR DESCRIPTION
A small number of http servers reject the default go http user agent.