### PR TITLE
Additional indexes

### DIFF
--- a/internal/schema/postgres/migrations/20240507212440_additional_indexes.up.pgsql
+++ b/internal/schema/postgres/migrations/20240507212440_additional_indexes.up.pgsql
@@ -1,0 +1,7 @@
+BEGIN;
+
+create index on feed_states(feed_id) include (feed_version_id,public);
+create index on feed_versions(feed_id) include (id,sha1);
+create unique index on tl_route_geometries(route_id);
+
+COMMIT;


### PR DESCRIPTION
- Unique index needed on tl_route_geometries to enable use of pg_repack
- Additional indexes on feed_state, feed_versions to increase use of "index only" scans