### PR TITLE
fix for some uncommon feed URLs that were being removed when formatting DMFR files

### DIFF
--- a/dmfr/feed.go
+++ b/dmfr/feed.go
@@ -89,15 +89,15 @@ func (Feed) TableName() string {
 // FeedUrls contains URL values for a Feed.
 type FeedUrls struct {
 	StaticCurrent            string   `json:"static_current,omitempty"`
-	StaticPlanned            string   `json:"static_planner,omitempty"`
+	StaticPlanned            []string `json:"static_planned,omitempty"`
 	StaticHistoric           []string `json:"static_historic,omitempty"`
+	StaticHypothetical       []string `json:"static_hypothetical,omitempty"`
 	RealtimeVehiclePositions string   `json:"realtime_vehicle_positions,omitempty"`
 	RealtimeTripUpdates      string   `json:"realtime_trip_updates,omitempty"`
 	RealtimeAlerts           string   `json:"realtime_alerts,omitempty"`
 	GbfsAutoDiscovery        string   `json:"gbfs_auto_discovery,omitempty"`
 	GbfsSystemAlerts         string   `json:"gbfs_system_alerts,omitempty"`
 	MdsProvider              string   `json:"mds_provider,omitempty"`
-	// StaticHypothetical    string
 	// GbfsSystemInformation string
 	// GbfsStationInformation string
 	// GbfsStationStatus      string

--- a/dmfr/registry.go
+++ b/dmfr/registry.go
@@ -39,7 +39,7 @@ func ReadRegistry(reader io.Reader) (*Registry, error) {
 	reg.Operators = loadReg.Operators
 	reg.Secrets = loadReg.Secrets
 	if reg.Schema == "" {
-		reg.Schema = "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json"
+		reg.Schema = "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.1.json"
 	}
 	operators := []Operator{}
 	for _, rfeed := range loadReg.Feeds {

--- a/dmfr/registry_test.go
+++ b/dmfr/registry_test.go
@@ -139,17 +139,17 @@ func TestRegistry_Write(t *testing.T) {
 		{
 			"feed",
 			`{"feeds":[{"id":"test","spec":"gtfs"}]}`,
-			`{"$schema":"https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json","feeds":[{"id":"test","spec":"gtfs"}]}`,
+			`{"$schema":"https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.1.json","feeds":[{"id":"test","spec":"gtfs"}]}`,
 		},
 		{
 			"feed sorted",
 			`{"feeds":[{"id":"z","spec":"gtfs"},{"id":"a","spec":"gtfs"}]}`,
-			`{"$schema":"https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json","feeds":[{"id":"a","spec":"gtfs"},{"id":"z","spec":"gtfs"}]}`,
+			`{"$schema":"https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.1.json","feeds":[{"id":"a","spec":"gtfs"},{"id":"z","spec":"gtfs"}]}`,
 		},
 		{
 			"nested operators moved to top level",
 			`{"feeds": [{"id": "z","spec": "gtfs","operators": [{"onestop_id": "o"}]}]}`,
-			`{"$schema":"https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json","feeds":[{"id":"z","spec":"gtfs"}],"operators":[{"onestop_id":"o","associated_feeds":[{"feed_onestop_id":"z"}]}]}`,
+			`{"$schema":"https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.1.json","feeds":[{"id":"z","spec":"gtfs"}],"operators":[{"onestop_id":"o","associated_feeds":[{"feed_onestop_id":"z"}]}]}`,
 		},
 	}
 	for _, tc := range tcs {


### PR DESCRIPTION
closes https://github.com/transitland/transitland-atlas/issues/979

also update DMFR schema to https://github.com/transitland/distributed-mobility-feed-registry/releases/tag/v0.5.1

