### PR TITLE
currently the "opinionated" DMFR format does not include a trailing line break; change this so that it makes POSIX style

### DIFF
--- a/dmfr/raw_registry.go
+++ b/dmfr/raw_registry.go
@@ -93,7 +93,10 @@ func (r *RawRegistry) Write(w io.Writer) error {
 	if err := json.Indent(&mbi, mb, "", "  "); err != nil {
 		return err
 	}
-	_, err = w.Write(mbi.Bytes())
+	if _, err = w.Write(mbi.Bytes()); err != nil {
+		return err
+	}
+	_, err = w.Write([]byte{'\n'})
 	return err
 }
 


### PR DESCRIPTION
NOTE: at the same time as making this change, we'll have to reformat all of the DMFR files in Transitland Atlas