### PR TITLE
[EXP] Clarify extension order vs. UpdateKeys

### DIFF
--- a/ext/bestpractices/flex_location_group_empty.go
+++ b/ext/bestpractices/flex_location_group_empty.go
@@ -25,7 +25,7 @@ type FlexLocationGroupEmptyCheck struct {
 	locationGroupStops map[string]int // location_group_id -> count of stops
 }
 
-func (e *FlexLocationGroupEmptyCheck) AfterWrite(eid string, ent tt.Entity, emap *tt.EntityMap) error {
+func (e *FlexLocationGroupEmptyCheck) AfterWrite(eid string, ent tt.Entity, _ *tt.EntityMap) error {
 	if e.locationGroupStops == nil {
 		e.locationGroupStops = map[string]int{}
 	}
@@ -54,4 +54,3 @@ func (e *FlexLocationGroupEmptyCheck) Validate(ent tt.Entity) []error {
 
 	return nil
 }
-

--- a/ext/builders/agency_place_builder.go
+++ b/ext/builders/agency_place_builder.go
@@ -50,7 +50,7 @@ func NewAgencyPlaceBuilder() *AgencyPlaceBuilder {
 	}
 }
 
-func (pp *AgencyPlaceBuilder) AfterWrite(eid string, ent tt.Entity, emap *tt.EntityMap) error {
+func (pp *AgencyPlaceBuilder) AfterWrite(eid string, ent tt.Entity, _ *tt.EntityMap) error {
 	switch v := ent.(type) {
 	case *gtfs.Agency:
 		pp.agencyStops[eid] = map[string]int{}

--- a/ext/builders/convex_hull_builder.go
+++ b/ext/builders/convex_hull_builder.go
@@ -59,7 +59,7 @@ func NewConvexHullBuilder() *ConvexHullBuilder {
 }
 
 // AfterWrite keeps track of which routes/agencies visit which stops
-func (pp *ConvexHullBuilder) AfterWrite(eid string, ent tt.Entity, emap *tt.EntityMap) error {
+func (pp *ConvexHullBuilder) AfterWrite(eid string, ent tt.Entity, _ *tt.EntityMap) error {
 	switch v := ent.(type) {
 	case *gtfs.Stop:
 		pp.stops[eid] = &stopGeom{

--- a/ext/builders/onestop_id_builder.go
+++ b/ext/builders/onestop_id_builder.go
@@ -71,7 +71,7 @@ func NewOnestopIDBuilder() *OnestopIDBuilder {
 	}
 }
 
-func (pp *OnestopIDBuilder) AfterWrite(eid string, ent tt.Entity, emap *tt.EntityMap) error {
+func (pp *OnestopIDBuilder) AfterWrite(eid string, ent tt.Entity, _ *tt.EntityMap) error {
 	switch v := ent.(type) {
 	case *gtfs.Agency:
 		pp.agencyNames[eid] = v.AgencyName.Val

--- a/ext/builders/route_geometry_builder.go
+++ b/ext/builders/route_geometry_builder.go
@@ -61,7 +61,7 @@ func NewRouteGeometryBuilder() *RouteGeometryBuilder {
 }
 
 // Counts the number of times a shape is used for each route,direction_id
-func (pp *RouteGeometryBuilder) AfterWrite(eid string, ent tt.Entity, emap *tt.EntityMap) error {
+func (pp *RouteGeometryBuilder) AfterWrite(eid string, ent tt.Entity, _ *tt.EntityMap) error {
 	switch v := ent.(type) {
 	case *service.ShapeLine:
 		pts := make([]tlxy.Point, v.Geometry.Val.NumCoords())

--- a/ext/builders/route_stop_builder.go
+++ b/ext/builders/route_stop_builder.go
@@ -38,7 +38,7 @@ func NewRouteStopBuilder() *RouteStopBuilder {
 	}
 }
 
-func (pp *RouteStopBuilder) AfterWrite(eid string, ent tt.Entity, emap *tt.EntityMap) error {
+func (pp *RouteStopBuilder) AfterWrite(eid string, ent tt.Entity, _ *tt.EntityMap) error {
 	switch v := ent.(type) {
 	case *gtfs.Route:
 		pp.routeAgencies[eid] = v.AgencyID.Val

--- a/ext/filters/apply_default_agency_filter.go
+++ b/ext/filters/apply_default_agency_filter.go
@@ -12,7 +12,7 @@ type ApplyDefaultAgencyFilter struct {
 	agencyCount     int
 }
 
-func (e *ApplyDefaultAgencyFilter) Filter(ent tt.Entity, emap *tt.EntityMap) error {
+func (e *ApplyDefaultAgencyFilter) Filter(ent tt.Entity, _ *tt.EntityMap) error {
 	switch v := ent.(type) {
 	case *gtfs.Agency:
 		if e.defaultAgencyId == "" {

--- a/ext/filters/apply_parent_timezone_filter.go
+++ b/ext/filters/apply_parent_timezone_filter.go
@@ -12,7 +12,7 @@ type ApplyParentTimezoneFilter struct {
 	parentStopTimezones   map[string]string
 }
 
-func (e *ApplyParentTimezoneFilter) Filter(ent tt.Entity, emap *tt.EntityMap) error {
+func (e *ApplyParentTimezoneFilter) Filter(ent tt.Entity, _ *tt.EntityMap) error {
 	// Remember filter happens before UpdateKeys or final ID available
 	switch v := ent.(type) {
 	case *gtfs.Agency:

--- a/ext/filters/apply_timezone_filter.go
+++ b/ext/filters/apply_timezone_filter.go
@@ -36,7 +36,7 @@ type ApplyTimezoneFilter struct {
 	timezone string
 }
 
-func (e *ApplyTimezoneFilter) Filter(ent tt.Entity, emap *tt.EntityMap) error {
+func (e *ApplyTimezoneFilter) Filter(ent tt.Entity, _ *tt.EntityMap) error {
 	switch v := ent.(type) {
 	case *gtfs.Agency:
 		v.AgencyTimezone.Set(e.timezone)

--- a/ext/filters/basic_route_type_fliter.go
+++ b/ext/filters/basic_route_type_fliter.go
@@ -12,7 +12,7 @@ import (
 type BasicRouteTypeFilter struct{}
 
 // Filter converts extended route_types to basic route_types.
-func (e *BasicRouteTypeFilter) Filter(ent tt.Entity, emap *tt.EntityMap) error {
+func (e *BasicRouteTypeFilter) Filter(ent tt.Entity, _ *tt.EntityMap) error {
 	// Filters can edit in place, add entity errors, etc.
 	v, ok := ent.(*gtfs.Route)
 	if !ok {

--- a/ext/filters/normalize_timezone_filter.go
+++ b/ext/filters/normalize_timezone_filter.go
@@ -10,7 +10,7 @@ import (
 type NormalizeTimezoneFilter struct{}
 
 // Validate .
-func (e *NormalizeTimezoneFilter) Filter(ent tt.Entity, emap *tt.EntityMap) error {
+func (e *NormalizeTimezoneFilter) Filter(ent tt.Entity, _ *tt.EntityMap) error {
 	switch v := ent.(type) {
 	case *gtfs.Agency:
 		n, ok := tt.IsValidTimezone(v.AgencyTimezone.Val)

--- a/ext/filters/prefix_filter.go
+++ b/ext/filters/prefix_filter.go
@@ -65,7 +65,7 @@ func (filter *PrefixFilter) UnprefixFile(fn string) {
 	filter.setPrefixFile(fn, false)
 }
 
-func (filter *PrefixFilter) Filter(ent tt.Entity, emap *tt.EntityMap) error {
+func (filter *PrefixFilter) Filter(ent tt.Entity, _ *tt.EntityMap) error {
 	ok := filter.prefixFileDefault
 	if prefixFile, prefixFileOk := filter.prefixFiles[ent.Filename()]; prefixFileOk {
 		ok = prefixFile

--- a/ext/filters/redate_filter.go
+++ b/ext/filters/redate_filter.go
@@ -76,7 +76,7 @@ func newRedateFilterFromJson(args string) (*RedateFilter, error) {
 	return NewRedateFilter(opts.SourceDate.Val, opts.TargetDate.Val, int(a), int(b), opts.DOWAlign.Val)
 }
 
-func (tf *RedateFilter) Filter(ent tt.Entity, emap *tt.EntityMap) error {
+func (tf *RedateFilter) Filter(ent tt.Entity, _ *tt.EntityMap) error {
 	ctx := context.TODO()
 	switch v := ent.(type) {
 	case *gtfs.Trip:

--- a/ext/filters/route_network_id.go
+++ b/ext/filters/route_network_id.go
@@ -32,7 +32,7 @@ func (e *RouteNetworkIDFilter) Expand(ent tt.Entity, emap *tt.EntityMap) ([]tt.E
 	return ret, true, nil
 }
 
-func (e *RouteNetworkIDFilter) Filter(ent tt.Entity, emap *tt.EntityMap) error {
+func (e *RouteNetworkIDFilter) Filter(ent tt.Entity, _ *tt.EntityMap) error {
 	// Unset any set NetworkID
 	if v, ok := ent.(*gtfs.Route); ok {
 		v.NetworkID = tt.String{}

--- a/ext/filters/simplify_calendar_filter.go
+++ b/ext/filters/simplify_calendar_filter.go
@@ -9,7 +9,7 @@ import (
 type SimplifyCalendarFilter struct {
 }
 
-func (e *SimplifyCalendarFilter) Filter(ent tt.Entity, emap *tt.EntityMap) error {
+func (e *SimplifyCalendarFilter) Filter(ent tt.Entity, _ *tt.EntityMap) error {
 	v, ok := ent.(*gtfs.Calendar)
 	if !ok {
 		return nil

--- a/ext/filters/simplify_shape_filter.go
+++ b/ext/filters/simplify_shape_filter.go
@@ -10,7 +10,7 @@ type SimplifyShapeFilter struct {
 	SimplifyValue float64
 }
 
-func (e *SimplifyShapeFilter) Filter(ent tt.Entity, emap *tt.EntityMap) error {
+func (e *SimplifyShapeFilter) Filter(ent tt.Entity, _ *tt.EntityMap) error {
 	v, ok := ent.(*service.ShapeLine)
 	if !ok {
 		return nil

--- a/ext/plus/plus.go
+++ b/ext/plus/plus.go
@@ -32,7 +32,7 @@ func (ext Ext) Entities() []tt.Entity {
 	}
 }
 
-func (ext *Ext) Filter(ent tt.Entity, emap *tt.EntityMap) error {
+func (ext *Ext) Filter(ent tt.Entity, _ *tt.EntityMap) error {
 	switch v := ent.(type) {
 	case *gtfs.Agency:
 		ext.defaultAgency = v.AgencyID.Val

--- a/extract/setterfilter.go
+++ b/extract/setterfilter.go
@@ -54,7 +54,7 @@ type hasEntityKey interface {
 }
 
 // Filter overrides values on entities.
-func (tx *SetterFilter) Filter(ent tt.Entity, emap *tt.EntityMap) error {
+func (tx *SetterFilter) Filter(ent tt.Entity, _ *tt.EntityMap) error {
 	v, ok := ent.(hasEntityKey)
 	if !ok {
 		return nil

--- a/extract/transform_filter.go
+++ b/extract/transform_filter.go
@@ -74,7 +74,7 @@ func (tx *TransformFilter) AddValue(filename string, eid string, key string, fun
 	tx.nodes[*n] = entv
 }
 
-func (tx *TransformFilter) Filter(ent tt.Entity, emap *tt.EntityMap) error {
+func (tx *TransformFilter) Filter(ent tt.Entity, _ *tt.EntityMap) error {
 	v, ok := ent.(hasEntityKey)
 	if !ok {
 		return nil

--- a/rules/flex_geography_id_unique.go
+++ b/rules/flex_geography_id_unique.go
@@ -34,7 +34,7 @@ type FlexGeographyIDUniqueCheck struct {
 	geographyIDs map[string]string // geography_id -> filename
 }
 
-func (e *FlexGeographyIDUniqueCheck) AfterWrite(eid string, ent tt.Entity, emap *tt.EntityMap) error {
+func (e *FlexGeographyIDUniqueCheck) AfterWrite(eid string, ent tt.Entity, _ *tt.EntityMap) error {
 	if e.geographyIDs == nil {
 		e.geographyIDs = map[string]string{}
 	}
@@ -99,4 +99,3 @@ func (e *FlexGeographyIDUniqueCheck) Validate(ent tt.Entity) []error {
 
 	return nil
 }
-

--- a/rules/flex_stop_location_type.go
+++ b/rules/flex_stop_location_type.go
@@ -30,7 +30,7 @@ type FlexStopLocationTypeCheck struct {
 	flexStops     map[string]bool // stops used in flex services
 }
 
-func (e *FlexStopLocationTypeCheck) AfterWrite(eid string, ent tt.Entity, emap *tt.EntityMap) error {
+func (e *FlexStopLocationTypeCheck) AfterWrite(eid string, ent tt.Entity, _ *tt.EntityMap) error {
 	if e.locationTypes == nil {
 		e.locationTypes = map[string]int{}
 	}

--- a/rules/flex_zone_id_conditional.go
+++ b/rules/flex_zone_id_conditional.go
@@ -26,7 +26,7 @@ type FlexZoneIDConditionalCheck struct {
 	checkedFiles bool
 }
 
-func (e *FlexZoneIDConditionalCheck) AfterWrite(eid string, ent tt.Entity, emap *tt.EntityMap) error {
+func (e *FlexZoneIDConditionalCheck) AfterWrite(eid string, ent tt.Entity, _ *tt.EntityMap) error {
 	// Check if fare_rules.txt has any entries
 	if _, ok := ent.(*gtfs.FareRule); ok {
 		e.hasFareRules = true
@@ -54,4 +54,3 @@ func (e *FlexZoneIDConditionalCheck) Validate(ent tt.Entity) []error {
 
 	return nil
 }
-

--- a/rules/invalid_parent_station.go
+++ b/rules/invalid_parent_station.go
@@ -31,7 +31,7 @@ type ParentStationLocationTypeCheck struct {
 	locationTypes map[string]int
 }
 
-func (e *ParentStationLocationTypeCheck) AfterWrite(eid string, ent tt.Entity, emap *tt.EntityMap) error {
+func (e *ParentStationLocationTypeCheck) AfterWrite(eid string, ent tt.Entity, _ *tt.EntityMap) error {
 	if e.locationTypes == nil {
 		e.locationTypes = map[string]int{}
 	}

--- a/rules/transfer_stop_location_type.go
+++ b/rules/transfer_stop_location_type.go
@@ -39,7 +39,7 @@ type TransferStopLocationTypeCheck struct {
 	locationTypes map[string]int
 }
 
-func (e *TransferStopLocationTypeCheck) AfterWrite(eid string, ent tt.Entity, emap *tt.EntityMap) error {
+func (e *TransferStopLocationTypeCheck) AfterWrite(eid string, ent tt.Entity, _ *tt.EntityMap) error {
 	if e.locationTypes == nil {
 		e.locationTypes = map[string]int{}
 	}

--- a/stats/fvsl.go
+++ b/stats/fvsl.go
@@ -181,7 +181,7 @@ func NewFeedVersionServiceLevelBuilder() *FeedVersionServiceLevelBuilder {
 	}
 }
 
-func (pp *FeedVersionServiceLevelBuilder) AfterWrite(eid string, ent tt.Entity, emap *tt.EntityMap) error {
+func (pp *FeedVersionServiceLevelBuilder) AfterWrite(eid string, ent tt.Entity, _ *tt.EntityMap) error {
 	switch v := ent.(type) {
 	case *gtfs.Calendar:
 		pp.services[v.ServiceID.Val] = service.NewService(*v)

--- a/stats/fvsw.go
+++ b/stats/fvsw.go
@@ -40,7 +40,7 @@ func NewFeedVersionServiceWindowBuilder() *FeedVersionServiceWindowBuilder {
 	return &FeedVersionServiceWindowBuilder{}
 }
 
-func (pp *FeedVersionServiceWindowBuilder) AfterWrite(eid string, ent tt.Entity, emap *tt.EntityMap) error {
+func (pp *FeedVersionServiceWindowBuilder) AfterWrite(eid string, ent tt.Entity, _ *tt.EntityMap) error {
 	switch v := ent.(type) {
 	case *gtfs.Agency:
 		if tz, ok := tt.IsValidTimezone(v.AgencyTimezone.Val); ok {

--- a/tldb/notnull.go
+++ b/tldb/notnull.go
@@ -11,7 +11,7 @@ import (
 type NotNullFilter struct{}
 
 // Validate .
-func (e *NotNullFilter) Filter(ent tt.Entity, emap *tt.EntityMap) error {
+func (e *NotNullFilter) Filter(ent tt.Entity, _ *tt.EntityMap) error {
 	switch v := ent.(type) {
 	case *gtfs.Agency:
 		// Used in textsearch

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -46,7 +46,7 @@ func (cr *testErrorHandler) HandleSourceErrors(fn string, errs []error, warns []
 func (cr *testErrorHandler) HandleEntityErrors(ent tt.Entity, errs []error, warns []error) {
 }
 
-func (cr *testErrorHandler) AfterWrite(eid string, ent tt.Entity, emap *tt.EntityMap) error {
+func (cr *testErrorHandler) AfterWrite(eid string, ent tt.Entity, _ *tt.EntityMap) error {
 	var errs []error
 	errs = append(errs, tt.CheckErrors(ent)...)
 	errs = append(errs, tt.CheckWarnings(ent)...)


### PR DESCRIPTION
Currently the "UpdateKeys" hook in copier happens after "Filter" but before "Validate" and other operations. This is really confusing and hard to work with. But substantial code was developed to live with this world. We need to decide if UpdateKeys happens at the VERY beginning of entity processing or the VERY END, and optionally create a new hook or deprecate one of the existing hooks.