### PR TITLE
export endpoint: optionally apply a sort order to the CSVs in the output zip

### DIFF
--- a/adapters/writer.go
+++ b/adapters/writer.go
@@ -18,3 +18,15 @@ type WriterWithExtraColumns interface {
 	Writer
 	WriteExtraColumns(bool)
 }
+
+type SortOptions struct {
+	StandardizedSort        string   // "asc" or "desc"
+	StandardizedSortColumns []string // Optional: specific columns to sort by. If empty, defaults are used.
+}
+
+type StandardizedSortOptions = SortOptions
+
+type WriterWithStandardizedSort interface {
+	Writer
+	SetStandardizedSortOptions(StandardizedSortOptions)
+}

--- a/adapters/writer.go
+++ b/adapters/writer.go
@@ -19,11 +19,10 @@ type WriterWithExtraColumns interface {
 	WriteExtraColumns(bool)
 }
 
-// Standardized sort directions. The empty string means no sort.
+// Standardized sort directions. The empty string (default/omitted) means no sort.
 const (
 	SortAsc  = "asc"
 	SortDesc = "desc"
-	SortNone = "none"
 )
 
 type SortOptions struct {
@@ -33,7 +32,13 @@ type SortOptions struct {
 
 type StandardizedSortOptions = SortOptions
 
+// SortableWriter is the minimal interface for accepting a sort config.
+type SortableWriter interface {
+	SetStandardizedSortOptions(StandardizedSortOptions)
+}
+
+// WriterWithStandardizedSort is a full Writer that also accepts sort config.
 type WriterWithStandardizedSort interface {
 	Writer
-	SetStandardizedSortOptions(StandardizedSortOptions)
+	SortableWriter
 }

--- a/adapters/writer.go
+++ b/adapters/writer.go
@@ -19,8 +19,15 @@ type WriterWithExtraColumns interface {
 	WriteExtraColumns(bool)
 }
 
+// Standardized sort directions. The empty string means no sort.
+const (
+	SortAsc  = "asc"
+	SortDesc = "desc"
+	SortNone = "none"
+)
+
 type SortOptions struct {
-	StandardizedSort        string   // "asc" or "desc"
+	StandardizedSort        string   // SortAsc, SortDesc, or "" (no sort).
 	StandardizedSortColumns []string // Optional: specific columns to sort by. If empty, defaults are used.
 }
 

--- a/adapters/writer.go
+++ b/adapters/writer.go
@@ -1,6 +1,10 @@
 package adapters
 
-import "github.com/interline-io/transitland-lib/tt"
+import (
+	"fmt"
+
+	"github.com/interline-io/transitland-lib/tt"
+)
 
 // Writer writes a GTFS feed.
 type Writer interface {
@@ -25,9 +29,20 @@ const (
 	SortDesc = "desc"
 )
 
+// ValidateSortDirection returns nil if s is empty, SortAsc, or SortDesc;
+// otherwise it returns an error listing the valid values. Empty is treated
+// as valid because callers conventionally use it to mean "no sort".
+func ValidateSortDirection(s string) error {
+	switch s {
+	case "", SortAsc, SortDesc:
+		return nil
+	}
+	return fmt.Errorf("invalid sort direction %q (must be %q or %q)", s, SortAsc, SortDesc)
+}
+
 type StandardizedSortOptions struct {
-	StandardizedSort        string   // SortAsc, SortDesc, or "" (no sort).
-	StandardizedSortColumns []string // Optional: specific columns to sort by. If empty, defaults are used.
+	ApplySort   string   // SortAsc, SortDesc, or "" (no sort).
+	SortColumns []string // Optional: specific columns to sort by. If empty, defaults are used.
 }
 
 // SortableWriter is the minimal interface for accepting a sort config.

--- a/adapters/writer.go
+++ b/adapters/writer.go
@@ -25,12 +25,10 @@ const (
 	SortDesc = "desc"
 )
 
-type SortOptions struct {
+type StandardizedSortOptions struct {
 	StandardizedSort        string   // SortAsc, SortDesc, or "" (no sort).
 	StandardizedSortColumns []string // Optional: specific columns to sort by. If empty, defaults are used.
 }
-
-type StandardizedSortOptions = SortOptions
 
 // SortableWriter is the minimal interface for accepting a sort config.
 type SortableWriter interface {

--- a/cmds/copy_cmd.go
+++ b/cmds/copy_cmd.go
@@ -14,17 +14,34 @@ import (
 // CopyCommand
 type CopyCommand struct {
 	copier.Options
-	fvid              int
-	create            bool
-	extensionDefs     []string
-	readerPath        string
-	writerPath        string
-	writeExtraColumns bool
+	fvid                    int
+	create                  bool
+	extensionDefs           []string
+	readerPath              string
+	writerPath              string
+	writeExtraColumns       bool
+	standardizedSort        string
+	standardizedSortColumns []string
 }
 
 func (cmd *CopyCommand) HelpDesc() (string, string) {
 	a := "Copy performs a basic copy from a reader to a writer."
-	b := "By default, any entity with errors will be skipped and not written to output. This can be ignored with `--allow-entity-errors` to ignore simple errors and `--allow-reference-errors` to ignore entity relationship errors, such as a reference to a non-existent stop."
+	b := `By default, any entity with errors will be skipped and not written to output.
+This can be ignored with --allow-entity-errors to ignore simple errors and
+--allow-reference-errors to ignore entity relationship errors, such as a
+reference to a non-existent stop.
+
+By default, the output order is determined by transitland-lib's streaming
+architecture. It generally preserves the input order, although some records
+may be reordered to maintain associations (such as ensuring parent stops are
+processed before child stops).
+
+Output can be automatically sorted using --standardized-sort (asc or desc).
+This is an optional feature and is off by default. When enabled, it applies
+an opinionated, standardized sort order to CSV files, which is useful for
+consistent diffing and human readability. By default, it uses logical primary
+GTFS columns (e.g., stop_id for stops.txt), but specific columns can be
+provided with --standardized-sort-columns.`
 	return a, b
 }
 
@@ -51,6 +68,8 @@ func (cmd *CopyCommand) AddFlags(fl *pflag.FlagSet) {
 	fl.BoolVar(&cmd.AllowEntityErrors, "allow-entity-errors", false, "Allow entities with errors to be copied")
 	fl.BoolVar(&cmd.AllowReferenceErrors, "allow-reference-errors", false, "Allow entities with reference errors to be copied")
 	fl.IntVar(&cmd.Options.ErrorLimit, "error-limit", 1000, "Max number of detailed errors per error group")
+	fl.StringVar(&cmd.standardizedSort, "standardized-sort", "", "Standardized sort order for CSV files (asc, desc, or none)")
+	fl.StringSliceVar(&cmd.standardizedSortColumns, "standardized-sort-columns", nil, "Comma-separated list of columns to sort by (optional; if empty, defaults are used)")
 }
 
 func (cmd *CopyCommand) Parse(args []string) error {
@@ -79,6 +98,16 @@ func (cmd *CopyCommand) Run(ctx context.Context) error {
 			v.WriteExtraColumns(true)
 		} else {
 			return errors.New("writer does not support extra output columns")
+		}
+	}
+	if cmd.standardizedSort != "" {
+		if v, ok := writer.(adapters.WriterWithStandardizedSort); ok {
+			v.SetStandardizedSortOptions(adapters.StandardizedSortOptions{
+				StandardizedSort:        cmd.standardizedSort,
+				StandardizedSortColumns: cmd.standardizedSortColumns,
+			})
+		} else {
+			return errors.New("writer does not support standardized sort")
 		}
 	}
 

--- a/cmds/copy_cmd.go
+++ b/cmds/copy_cmd.go
@@ -29,7 +29,7 @@ func (cmd *CopyCommand) HelpDesc() (string, string) {
 	a := "Copy performs a basic copy from a reader to a writer."
 	b := `Entities with errors are skipped by default; use --allow-entity-errors and --allow-reference-errors to override.
 
-Output preserves input order (modulo associations like parent-before-child stops). Pass --standardized-sort (asc|desc) to apply an opinionated GTFS sort by primary keys, or override columns with --standardized-sort-columns.`
+Output preserves input order (with exceptions for stop relationships). Pass --standardized-sort (asc|desc) to apply an opinionated GTFS sort by primary keys, or override columns with --standardized-sort-columns.`
 	return a, b
 }
 

--- a/cmds/copy_cmd.go
+++ b/cmds/copy_cmd.go
@@ -3,6 +3,7 @@ package cmds
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/interline-io/transitland-lib/adapters"
 	"github.com/interline-io/transitland-lib/copier"
@@ -88,10 +89,13 @@ func (cmd *CopyCommand) Run(ctx context.Context) error {
 		}
 	}
 	if cmd.standardizedSort != "" {
+		if err := adapters.ValidateSortDirection(cmd.standardizedSort); err != nil {
+			return fmt.Errorf("--standardized-sort: %w", err)
+		}
 		if v, ok := writer.(adapters.WriterWithStandardizedSort); ok {
 			v.SetStandardizedSortOptions(adapters.StandardizedSortOptions{
-				StandardizedSort:        cmd.standardizedSort,
-				StandardizedSortColumns: cmd.standardizedSortColumns,
+				ApplySort:   cmd.standardizedSort,
+				SortColumns: cmd.standardizedSortColumns,
 			})
 		} else {
 			return errors.New("writer does not support standardized sort")

--- a/cmds/copy_cmd.go
+++ b/cmds/copy_cmd.go
@@ -26,22 +26,9 @@ type CopyCommand struct {
 
 func (cmd *CopyCommand) HelpDesc() (string, string) {
 	a := "Copy performs a basic copy from a reader to a writer."
-	b := `By default, any entity with errors will be skipped and not written to output.
-This can be ignored with --allow-entity-errors to ignore simple errors and
---allow-reference-errors to ignore entity relationship errors, such as a
-reference to a non-existent stop.
+	b := `Entities with errors are skipped by default; use --allow-entity-errors and --allow-reference-errors to override.
 
-By default, the output order is determined by transitland-lib's streaming
-architecture. It generally preserves the input order, although some records
-may be reordered to maintain associations (such as ensuring parent stops are
-processed before child stops).
-
-Output can be automatically sorted using --standardized-sort (asc or desc).
-This is an optional feature and is off by default. When enabled, it applies
-an opinionated, standardized sort order to CSV files, which is useful for
-consistent diffing and human readability. By default, it uses logical primary
-GTFS columns (e.g., stop_id for stops.txt), but specific columns can be
-provided with --standardized-sort-columns.`
+Output preserves input order (modulo associations like parent-before-child stops). Pass --standardized-sort (asc|desc) to apply an opinionated GTFS sort by primary keys, or override columns with --standardized-sort-columns.`
 	return a, b
 }
 
@@ -68,7 +55,7 @@ func (cmd *CopyCommand) AddFlags(fl *pflag.FlagSet) {
 	fl.BoolVar(&cmd.AllowEntityErrors, "allow-entity-errors", false, "Allow entities with errors to be copied")
 	fl.BoolVar(&cmd.AllowReferenceErrors, "allow-reference-errors", false, "Allow entities with reference errors to be copied")
 	fl.IntVar(&cmd.Options.ErrorLimit, "error-limit", 1000, "Max number of detailed errors per error group")
-	fl.StringVar(&cmd.standardizedSort, "standardized-sort", "", "Standardized sort order for CSV files (asc, desc, or none)")
+	fl.StringVar(&cmd.standardizedSort, "standardized-sort", "", "Standardized sort order for CSV files (asc or desc; empty = no sort)")
 	fl.StringSliceVar(&cmd.standardizedSortColumns, "standardized-sort-columns", nil, "Comma-separated list of columns to sort by (optional; if empty, defaults are used)")
 }
 

--- a/doc/cli/transitland_copy.md
+++ b/doc/cli/transitland_copy.md
@@ -6,7 +6,22 @@ Copy performs a basic copy from a reader to a writer.
 
 Copy performs a basic copy from a reader to a writer.
 
-By default, any entity with errors will be skipped and not written to output. This can be ignored with `--allow-entity-errors` to ignore simple errors and `--allow-reference-errors` to ignore entity relationship errors, such as a reference to a non-existent stop.
+By default, any entity with errors will be skipped and not written to output.
+This can be ignored with --allow-entity-errors to ignore simple errors and
+--allow-reference-errors to ignore entity relationship errors, such as a
+reference to a non-existent stop.
+
+By default, the output order is determined by transitland-lib's streaming
+architecture. It generally preserves the input order, although some records
+may be reordered to maintain associations (such as ensuring parent stops are
+processed before child stops).
+
+Output can be automatically sorted using --standardized-sort (asc or desc).
+This is an optional feature and is off by default. When enabled, it applies
+an opinionated, standardized sort order to CSV files, which is useful for
+consistent diffing and human readability. By default, it uses logical primary
+GTFS columns (e.g., stop_id for stops.txt), but specific columns can be
+provided with --standardized-sort-columns.
 
 ```
 transitland copy [flags] <reader> <writer>
@@ -27,15 +42,17 @@ BART,Bay Area Rapid Transit,https://www.bart.gov/,America/Los_Angeles,,510-464-6
 ### Options
 
 ```
-      --allow-entity-errors      Allow entities with errors to be copied
-      --allow-reference-errors   Allow entities with reference errors to be copied
-      --create                   Create a basic database schema if none exists
-      --error-limit int          Max number of detailed errors per error group (default 1000)
-      --ext strings              Include GTFS Extension
-      --fvid int                 Specify FeedVersionID when writing to a database
-  -h, --help                     help for copy
-      --write-extra-columns      Include extra columns in output
-      --write-extra-files        Copy additional files found in source to destination
+      --allow-entity-errors                 Allow entities with errors to be copied
+      --allow-reference-errors              Allow entities with reference errors to be copied
+      --create                              Create a basic database schema if none exists
+      --error-limit int                     Max number of detailed errors per error group (default 1000)
+      --ext strings                         Include GTFS Extension
+      --fvid int                            Specify FeedVersionID when writing to a database
+  -h, --help                                help for copy
+      --standardized-sort string            Standardized sort order for CSV files (asc, desc, or none)
+      --standardized-sort-columns strings   Comma-separated list of columns to sort by (optional; if empty, defaults are used)
+      --write-extra-columns                 Include extra columns in output
+      --write-extra-files                   Copy additional files found in source to destination
 ```
 
 ### SEE ALSO

--- a/doc/cli/transitland_copy.md
+++ b/doc/cli/transitland_copy.md
@@ -8,7 +8,7 @@ Copy performs a basic copy from a reader to a writer.
 
 Entities with errors are skipped by default; use --allow-entity-errors and --allow-reference-errors to override.
 
-Output preserves input order (modulo associations like parent-before-child stops). Pass --standardized-sort (asc|desc) to apply an opinionated GTFS sort by primary keys, or override columns with --standardized-sort-columns.
+Output preserves input order (with exceptions for stop relationships). Pass --standardized-sort (asc|desc) to apply an opinionated GTFS sort by primary keys, or override columns with --standardized-sort-columns.
 
 ```
 transitland copy [flags] <reader> <writer>

--- a/doc/cli/transitland_copy.md
+++ b/doc/cli/transitland_copy.md
@@ -6,22 +6,9 @@ Copy performs a basic copy from a reader to a writer.
 
 Copy performs a basic copy from a reader to a writer.
 
-By default, any entity with errors will be skipped and not written to output.
-This can be ignored with --allow-entity-errors to ignore simple errors and
---allow-reference-errors to ignore entity relationship errors, such as a
-reference to a non-existent stop.
+Entities with errors are skipped by default; use --allow-entity-errors and --allow-reference-errors to override.
 
-By default, the output order is determined by transitland-lib's streaming
-architecture. It generally preserves the input order, although some records
-may be reordered to maintain associations (such as ensuring parent stops are
-processed before child stops).
-
-Output can be automatically sorted using --standardized-sort (asc or desc).
-This is an optional feature and is off by default. When enabled, it applies
-an opinionated, standardized sort order to CSV files, which is useful for
-consistent diffing and human readability. By default, it uses logical primary
-GTFS columns (e.g., stop_id for stops.txt), but specific columns can be
-provided with --standardized-sort-columns.
+Output preserves input order (modulo associations like parent-before-child stops). Pass --standardized-sort (asc|desc) to apply an opinionated GTFS sort by primary keys, or override columns with --standardized-sort-columns.
 
 ```
 transitland copy [flags] <reader> <writer>
@@ -49,7 +36,7 @@ BART,Bay Area Rapid Transit,https://www.bart.gov/,America/Los_Angeles,,510-464-6
       --ext strings                         Include GTFS Extension
       --fvid int                            Specify FeedVersionID when writing to a database
   -h, --help                                help for copy
-      --standardized-sort string            Standardized sort order for CSV files (asc, desc, or none)
+      --standardized-sort string            Standardized sort order for CSV files (asc or desc; empty = no sort)
       --standardized-sort-columns strings   Comma-separated list of columns to sort by (optional; if empty, defaults are used)
       --write-extra-columns                 Include extra columns in output
       --write-extra-files                   Copy additional files found in source to destination

--- a/doc/openapi/rest.json
+++ b/doc/openapi/rest.json
@@ -2711,6 +2711,14 @@
                   "transforms": {
                     "description": "Optional transformations to apply",
                     "properties": {
+                      "lexicographic_sort": {
+                        "description": "Sort all CSV files lexicographically before zipping. Use 'asc' for ascending or 'desc' for descending order.",
+                        "enum": [
+                          "asc",
+                          "desc"
+                        ],
+                        "type": "string"
+                      },
                       "normalize_timezones": {
                         "description": "Normalize timezone names (e.g., US/Pacific -\u003e America/Los_Angeles)",
                         "type": "boolean"

--- a/doc/openapi/rest.json
+++ b/doc/openapi/rest.json
@@ -2711,14 +2711,6 @@
                   "transforms": {
                     "description": "Optional transformations to apply",
                     "properties": {
-                      "lexicographic_sort": {
-                        "description": "Sort all CSV files lexicographically before zipping. Use 'asc' for ascending or 'desc' for descending order.",
-                        "enum": [
-                          "asc",
-                          "desc"
-                        ],
-                        "type": "string"
-                      },
                       "normalize_timezones": {
                         "description": "Normalize timezone names (e.g., US/Pacific -\u003e America/Los_Angeles)",
                         "type": "boolean"
@@ -2756,6 +2748,22 @@
                       "simplify_shapes": {
                         "description": "Tolerance value for shape simplification (in meters)",
                         "type": "number"
+                      },
+                      "standardized_sort": {
+                        "description": "Sort all CSV files before zipping. Use 'asc' (ascending), 'desc' (descending), or 'none' (default). This is an optional feature and is off by default. By default, transitland-lib's streaming architecture generally preserves input order, but may reorder some associated records (e.g., parent stations before children) to maintain integrity.",
+                        "enum": [
+                          "asc",
+                          "desc",
+                          "none"
+                        ],
+                        "type": "string"
+                      },
+                      "standardized_sort_columns": {
+                        "description": "Optional specific columns to sort by. If empty, defaults are used based on file type.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
                       },
                       "use_basic_route_types": {
                         "description": "Convert extended route types to basic GTFS route types",

--- a/doc/openapi/rest.json
+++ b/doc/openapi/rest.json
@@ -2750,11 +2750,10 @@
                         "type": "number"
                       },
                       "standardized_sort": {
-                        "description": "Sort all CSV files before zipping. Use 'asc' (ascending), 'desc' (descending), or 'none' (default). This is an optional feature and is off by default. By default, transitland-lib's streaming architecture generally preserves input order, but may reorder some associated records (e.g., parent stations before children) to maintain integrity.",
+                        "description": "Sort CSV rows before zipping. 'asc' or 'desc'; omit for no sort (default preserves copier order, modulo parent-before-child reordering). Empty cells in numeric/date columns rank as the greatest value (NULLS LAST in asc, NULLS FIRST in desc).",
                         "enum": [
                           "asc",
-                          "desc",
-                          "none"
+                          "desc"
                         ],
                         "type": "string"
                       },

--- a/gtfs/agency.go
+++ b/gtfs/agency.go
@@ -4,7 +4,7 @@ import "github.com/interline-io/transitland-lib/tt"
 
 // Agency agency.txt
 type Agency struct {
-	AgencyID       tt.String
+	AgencyID       tt.String   `standardized_sort:"1"`
 	AgencyName     tt.String   `csv:",required"`
 	AgencyURL      tt.Url      `csv:",required"`
 	AgencyTimezone tt.Timezone `csv:",required"`

--- a/gtfs/area.go
+++ b/gtfs/area.go
@@ -6,7 +6,7 @@ import (
 
 // Area fare_areas.txt
 type Area struct {
-	AreaID    tt.String `csv:",required"`
+	AreaID    tt.String `csv:",required" standardized_sort:"1"`
 	AreaName  tt.String
 	AgencyIDs tt.Strings `csv:"-" db:"agency_ids"` // interline ext
 	Geometry  tt.Polygon `csv:"-"`                 // interline ext

--- a/gtfs/attribution.go
+++ b/gtfs/attribution.go
@@ -6,14 +6,14 @@ import (
 )
 
 type Attribution struct {
-	OrganizationName tt.String `csv:",required"`
+	OrganizationName tt.String `csv:",required" standardized_sort:"2"`
 	AgencyID         tt.Key    `target:"agency.txt"`
 	RouteID          tt.Key    `target:"routes.txt"`
 	TripID           tt.Key    `target:"trips.txt"`
 	IsProducer       tt.Int    `enum:"0,1"`
 	IsOperator       tt.Int    `enum:"0,1"`
 	IsAuthority      tt.Int    `enum:"0,1"`
-	AttributionID    tt.String
+	AttributionID    tt.String `standardized_sort:"1"`
 	AttributionURL   tt.Url
 	AttributionEmail tt.Email
 	AttributionPhone tt.String

--- a/gtfs/booking_rule.go
+++ b/gtfs/booking_rule.go
@@ -7,7 +7,7 @@ import (
 
 // BookingRule booking_rules.txt
 type BookingRule struct {
-	BookingRuleID          tt.String `csv:",required"`
+	BookingRuleID          tt.String `csv:",required" standardized_sort:"1"`
 	BookingType            tt.Int    `csv:",required" enum:"0,1,2"`
 	PriorNoticeDurationMin tt.Int
 	PriorNoticeDurationMax tt.Int

--- a/gtfs/calendar.go
+++ b/gtfs/calendar.go
@@ -9,7 +9,7 @@ import (
 
 // Calendar calendar.txt
 type Calendar struct {
-	ServiceID     tt.String      `csv:",required"`
+	ServiceID     tt.String      `csv:",required" standardized_sort:"1"`
 	Monday        tt.Int         `csv:",required" enum:"0,1"`
 	Tuesday       tt.Int         `csv:",required" enum:"0,1"`
 	Wednesday     tt.Int         `csv:",required" enum:"0,1"`

--- a/gtfs/calendar_date.go
+++ b/gtfs/calendar_date.go
@@ -6,8 +6,8 @@ import (
 
 // CalendarDate calendar_dates.txt
 type CalendarDate struct {
-	ServiceID     tt.Key  `csv:",required" target:"calendar.txt"`
-	Date          tt.Date `csv:",required"`
+	ServiceID     tt.Key  `csv:",required" target:"calendar.txt" standardized_sort:"1"`
+	Date          tt.Date `csv:",required" standardized_sort:"2"`
 	ExceptionType tt.Int  `csv:",required" enum:"1,2"`
 	tt.BaseEntity
 }

--- a/gtfs/fare_attribute.go
+++ b/gtfs/fare_attribute.go
@@ -6,7 +6,7 @@ import (
 
 // FareAttribute fare_attributes.txt
 type FareAttribute struct {
-	FareID           tt.String   `csv:",required"`
+	FareID           tt.String   `csv:",required" standardized_sort:"1"`
 	Price            tt.Float    `csv:",required" range:"0,"`
 	CurrencyType     tt.Currency `csv:",required"`
 	PaymentMethod    tt.Int      `csv:",required" enum:"0,1"`

--- a/gtfs/fare_leg_rule.go
+++ b/gtfs/fare_leg_rule.go
@@ -9,12 +9,12 @@ import (
 // FareLegRule fare_leg_rules.txt
 type FareLegRule struct {
 	LegGroupID           tt.String
-	FromAreaID           tt.String `target:"areas.txt"`
-	ToAreaID             tt.String `target:"areas.txt"`
-	NetworkID            tt.String `target:"networks.txt"`
-	FareProductID        tt.String `csv:",required" target:"fare_products.txt:fare_product_id"`
-	FromTimeframeGroupID tt.String `target:"timeframes.txt:timeframe_group_id"`
-	ToTimeframeGroupID   tt.String `target:"timeframes.txt:timeframe_group_id"`
+	FromAreaID           tt.String `target:"areas.txt" standardized_sort:"2"`
+	ToAreaID             tt.String `target:"areas.txt" standardized_sort:"3"`
+	NetworkID            tt.String `target:"networks.txt" standardized_sort:"1"`
+	FareProductID        tt.String `csv:",required" target:"fare_products.txt:fare_product_id" standardized_sort:"6"`
+	FromTimeframeGroupID tt.String `target:"timeframes.txt:timeframe_group_id" standardized_sort:"4"`
+	ToTimeframeGroupID   tt.String `target:"timeframes.txt:timeframe_group_id" standardized_sort:"5"`
 	RulePriority         tt.Int    `range:"0,"`
 	TransferOnly         tt.Int    `enum:"0,1"` // interline ext
 	tt.BaseEntity

--- a/gtfs/fare_media.go
+++ b/gtfs/fare_media.go
@@ -6,7 +6,7 @@ import (
 
 // FareMedia fare_media.txt
 type FareMedia struct {
-	FareMediaID   tt.String `csv:",required"`
+	FareMediaID   tt.String `csv:",required" standardized_sort:"1"`
 	FareMediaName tt.String `csv:",required"`
 	FareMediaType tt.Int    `csv:",required" enum:"0,1,2,3,4"`
 	tt.BaseEntity

--- a/gtfs/fare_product.go
+++ b/gtfs/fare_product.go
@@ -9,16 +9,16 @@ import (
 
 // FareProduct fare_products.txt
 type FareProduct struct {
-	FareProductID   tt.String `csv:",required" `
+	FareProductID   tt.String `csv:",required" standardized_sort:"1"`
 	FareProductName tt.String
 	Amount          tt.CurrencyAmount `csv:",required"`
 	Currency        tt.Currency       `csv:",required"`
-	DurationStart   tt.Int            `enum:"0,1"`                                      // proposed extension
-	DurationAmount  tt.Float          `range:"0,"`                                      // proposed extension
-	DurationUnit    tt.Int            `enum:"0,1,2,3,4,5,6"`                            // proposed extension
-	DurationType    tt.Int            `enum:"1,2"`                                      // proposed extension
-	RiderCategoryID tt.Key            `target:"rider_categories.txt:rider_category_id"` // proposed extension
-	FareMediaID     tt.Key            `target:"fare_media.txt"`                         // proposed extension
+	DurationStart   tt.Int            `enum:"0,1"`           // proposed extension
+	DurationAmount  tt.Float          `range:"0,"`           // proposed extension
+	DurationUnit    tt.Int            `enum:"0,1,2,3,4,5,6"` // proposed extension
+	DurationType    tt.Int            `enum:"1,2"`           // proposed extension
+	RiderCategoryID tt.Key            `target:"rider_categories.txt:rider_category_id" standardized_sort:"2"`
+	FareMediaID     tt.Key            `target:"fare_media.txt" standardized_sort:"3"`
 	tt.BaseEntity
 }
 

--- a/gtfs/fare_rule.go
+++ b/gtfs/fare_rule.go
@@ -8,11 +8,11 @@ import (
 
 // FareRule fare_rules.txt
 type FareRule struct {
-	FareID        tt.String `csv:",required" target:"fare_attributes.txt"`
-	RouteID       tt.Key    `target:"routes.txt"`
-	OriginID      tt.String
-	DestinationID tt.String
-	ContainsID    tt.String
+	FareID        tt.String `csv:",required" target:"fare_attributes.txt" standardized_sort:"1"`
+	RouteID       tt.Key    `target:"routes.txt" standardized_sort:"2"`
+	OriginID      tt.String `standardized_sort:"3"`
+	DestinationID tt.String `standardized_sort:"4"`
+	ContainsID    tt.String `standardized_sort:"5"`
 	tt.BaseEntity
 }
 

--- a/gtfs/fare_transfer_rule.go
+++ b/gtfs/fare_transfer_rule.go
@@ -9,13 +9,13 @@ import (
 
 // FareTransferRule fare_transfer_rules.txt
 type FareTransferRule struct {
-	FromLegGroupID      tt.String `target:"fare_leg_rules.txt:leg_group_id"`
-	ToLegGroupID        tt.String `target:"fare_leg_rules.txt:leg_group_id"`
-	TransferCount       tt.Int    `range:"-1,"`
-	DurationLimit       tt.Int    `range:"0,"`
+	FromLegGroupID      tt.String `target:"fare_leg_rules.txt:leg_group_id" standardized_sort:"1"`
+	ToLegGroupID        tt.String `target:"fare_leg_rules.txt:leg_group_id" standardized_sort:"2"`
+	TransferCount       tt.Int    `range:"-1," standardized_sort:"4"`
+	DurationLimit       tt.Int    `range:"0," standardized_sort:"5"`
 	DurationLimitType   tt.Int    `enum:"0,1,2,3"`
 	FareTransferType    tt.Int    `csv:",required" enum:"0,1,2"`
-	FareProductID       tt.String `target:"fare_products.txt:fare_product_id"`
+	FareProductID       tt.String `target:"fare_products.txt:fare_product_id" standardized_sort:"3"`
 	FilterFareProductID tt.String `target:"fare_products.txt:fare_product_id"` // proposed extension
 	tt.BaseEntity
 }

--- a/gtfs/feed_info.go
+++ b/gtfs/feed_info.go
@@ -9,7 +9,7 @@ import (
 
 // FeedInfo feed_info.txt
 type FeedInfo struct {
-	FeedPublisherName tt.String   `csv:",required"`
+	FeedPublisherName tt.String   `csv:",required" standardized_sort:"1"`
 	FeedPublisherURL  tt.Url      `csv:",required"`
 	FeedLang          tt.Language `csv:",required"`
 	FeedVersion       tt.String   `db:"feed_version_name"`

--- a/gtfs/frequency.go
+++ b/gtfs/frequency.go
@@ -9,9 +9,9 @@ import (
 
 // Frequency frequencies.txt
 type Frequency struct {
-	TripID      tt.String  `csv:",required" target:"trips.txt"`
+	TripID      tt.String  `csv:",required" target:"trips.txt" standardized_sort:"1"`
 	HeadwaySecs tt.Int     `csv:",required" range:"1,"`
-	StartTime   tt.Seconds `csv:",required"`
+	StartTime   tt.Seconds `csv:",required" standardized_sort:"2"`
 	EndTime     tt.Seconds `csv:",required"`
 	ExactTimes  tt.Int     `enum:"0,1"`
 	tt.BaseEntity

--- a/gtfs/level.go
+++ b/gtfs/level.go
@@ -4,7 +4,7 @@ import "github.com/interline-io/transitland-lib/tt"
 
 // Level levels.txt
 type Level struct {
-	LevelID    tt.String `csv:",required"`
+	LevelID    tt.String `csv:",required" standardized_sort:"1"`
 	LevelIndex tt.Float  `csv:",required"`
 	LevelName  tt.String
 	tt.BaseEntity

--- a/gtfs/location.go
+++ b/gtfs/location.go
@@ -10,7 +10,7 @@ import (
 // where riders can request pickups or drop-offs for flexible services
 type Location struct {
 	// ID is the feature ID from the GeoJSON, shares namespace with stop_id
-	LocationID tt.String `json:"id" csv:",required"`
+	LocationID tt.String `json:"id" csv:",required" standardized_sort:"1"`
 	// Properties
 	StopName tt.String   `json:"stop_name"`
 	StopDesc tt.String   `json:"stop_desc"`

--- a/gtfs/location_group.go
+++ b/gtfs/location_group.go
@@ -6,7 +6,7 @@ import (
 
 // LocationGroup location_groups.txt
 type LocationGroup struct {
-	LocationGroupID   tt.String `csv:",required"`
+	LocationGroupID   tt.String `csv:",required" standardized_sort:"1"`
 	LocationGroupName tt.String
 	tt.BaseEntity
 }
@@ -26,4 +26,3 @@ func (ent *LocationGroup) Filename() string {
 func (ent *LocationGroup) TableName() string {
 	return "gtfs_location_groups"
 }
-

--- a/gtfs/location_group_stop.go
+++ b/gtfs/location_group_stop.go
@@ -6,8 +6,8 @@ import (
 
 // LocationGroupStop location_group_stops.txt
 type LocationGroupStop struct {
-	LocationGroupID tt.Key `csv:",required" target:"location_groups.txt"`
-	StopID          tt.Key `csv:",required" target:"stops.txt"`
+	LocationGroupID tt.Key `csv:",required" target:"location_groups.txt" standardized_sort:"1"`
+	StopID          tt.Key `csv:",required" target:"stops.txt" standardized_sort:"2"`
 	tt.BaseEntity
 }
 

--- a/gtfs/network.go
+++ b/gtfs/network.go
@@ -3,7 +3,7 @@ package gtfs
 import "github.com/interline-io/transitland-lib/tt"
 
 type Network struct {
-	NetworkID   tt.String `csv:",required"`
+	NetworkID   tt.String `csv:",required" standardized_sort:"1"`
 	NetworkName tt.String
 	tt.BaseEntity
 }

--- a/gtfs/pathway.go
+++ b/gtfs/pathway.go
@@ -9,7 +9,7 @@ import (
 
 // Pathway pathways.txt
 type Pathway struct {
-	PathwayID           tt.String `csv:",required"`
+	PathwayID           tt.String `csv:",required" standardized_sort:"1"`
 	FromStopID          tt.String `csv:",required" target:"stops.txt"`
 	ToStopID            tt.String `csv:",required" target:"stops.txt"`
 	PathwayMode         tt.Int    `csv:",required" enum:"1,2,3,4,5,6,7"`

--- a/gtfs/rider_category.go
+++ b/gtfs/rider_category.go
@@ -9,7 +9,7 @@ import (
 
 // RiderCategory rider_categories.txt
 type RiderCategory struct {
-	RiderCategoryID       tt.String `csv:",required"`
+	RiderCategoryID       tt.String `csv:",required" standardized_sort:"1"`
 	RiderCategoryName     tt.String `csv:",required"`
 	MinAge                tt.Int    `range:"0,"`
 	MaxAge                tt.Int    `range:"0,"`

--- a/gtfs/route.go
+++ b/gtfs/route.go
@@ -7,7 +7,7 @@ import (
 
 // Route routes.txt
 type Route struct {
-	RouteID           tt.String `csv:",required"`
+	RouteID           tt.String `csv:",required" standardized_sort:"1"`
 	AgencyID          tt.Key    `target:"agency.txt"`
 	RouteShortName    tt.String
 	RouteLongName     tt.String

--- a/gtfs/route_network.go
+++ b/gtfs/route_network.go
@@ -7,8 +7,8 @@ import (
 )
 
 type RouteNetwork struct {
-	NetworkID tt.Key `csv:",required" target:"networks.txt"`
-	RouteID   tt.Key `csv:",required" target:"routes.txt"`
+	NetworkID tt.Key `csv:",required" target:"networks.txt" standardized_sort:"1"`
+	RouteID   tt.Key `csv:",required" target:"routes.txt" standardized_sort:"2"`
 	tt.BaseEntity
 }
 

--- a/gtfs/shape.go
+++ b/gtfs/shape.go
@@ -9,10 +9,10 @@ import (
 
 // Shape shapes.txt
 type Shape struct {
-	ShapeID           tt.String `csv:",required"`
+	ShapeID           tt.String `csv:",required" standardized_sort:"1"`
 	ShapePtLat        tt.Float  `db:"-" csv:",required" range:"-90,90"`
 	ShapePtLon        tt.Float  `db:"-" csv:",required" range:"-180,180"`
-	ShapePtSequence   tt.Int    `db:"-" csv:",required" range:"0,"`
+	ShapePtSequence   tt.Int    `db:"-" csv:",required" range:"0," standardized_sort:"2"`
 	ShapeDistTraveled tt.Float  `db:"-" range:"0,"`
 	tt.BaseEntity
 }

--- a/gtfs/stop.go
+++ b/gtfs/stop.go
@@ -10,7 +10,7 @@ import (
 
 // Stop stops.txt
 type Stop struct {
-	StopID             tt.String `csv:",required" required:"true"`
+	StopID             tt.String `csv:",required" required:"true" standardized_sort:"1"`
 	StopName           tt.String
 	StopCode           tt.String
 	StopDesc           tt.String
@@ -20,7 +20,7 @@ type Stop struct {
 	StopURL            tt.Url
 	TtsStopName        tt.String
 	PlatformCode       tt.String
-	LocationType       tt.Int `enum:"0,1,2,3,4"`
+	LocationType       tt.Int `enum:"0,1,2,3,4" standardized_sort:"2"`
 	ParentStation      tt.Key `target:"stops.txt"`
 	StopTimezone       tt.Timezone
 	WheelchairBoarding tt.Int   `enum:"0,1,2"`

--- a/gtfs/stop.go
+++ b/gtfs/stop.go
@@ -20,7 +20,7 @@ type Stop struct {
 	StopURL            tt.Url
 	TtsStopName        tt.String
 	PlatformCode       tt.String
-	LocationType       tt.Int `enum:"0,1,2,3,4" standardized_sort:"2"`
+	LocationType       tt.Int `enum:"0,1,2,3,4"`
 	ParentStation      tt.Key `target:"stops.txt"`
 	StopTimezone       tt.Timezone
 	WheelchairBoarding tt.Int   `enum:"0,1,2"`

--- a/gtfs/stop_area.go
+++ b/gtfs/stop_area.go
@@ -6,8 +6,8 @@ import (
 
 // StopArea stop_areas.txt
 type StopArea struct {
-	AreaID tt.Key `csv:",required" target:"areas.txt"`
-	StopID tt.Key `csv:",required" target:"stops.txt"`
+	AreaID tt.Key `csv:",required" target:"areas.txt" standardized_sort:"1"`
+	StopID tt.Key `csv:",required" target:"stops.txt" standardized_sort:"2"`
 	tt.BaseEntity
 }
 

--- a/gtfs/stop_time.go
+++ b/gtfs/stop_time.go
@@ -9,11 +9,11 @@ import (
 
 // StopTime stop_times.txt
 type StopTime struct {
-	TripID            tt.String `csv:",required" target:"trips.txt"`
+	TripID            tt.String `csv:",required" target:"trips.txt" standardized_sort:"1"`
 	StopID            tt.Key    `target:"stops.txt"`
 	LocationGroupID   tt.Key    `target:"location_groups.txt"`
 	LocationID        tt.Key    `target:"locations.txt"`
-	StopSequence      tt.Int    `csv:",required"`
+	StopSequence      tt.Int    `csv:",required" standardized_sort:"2"`
 	StopHeadsign      tt.String
 	ArrivalTime       tt.Seconds
 	DepartureTime     tt.Seconds

--- a/gtfs/timeframe.go
+++ b/gtfs/timeframe.go
@@ -8,10 +8,10 @@ import (
 )
 
 type Timeframe struct {
-	TimeframeGroupID tt.String `csv:",required"`
-	StartTime        tt.Seconds
-	EndTime          tt.Seconds
-	ServiceID        tt.Key `csv:",required" target:"calendar.txt"`
+	TimeframeGroupID tt.String  `csv:",required" standardized_sort:"1"`
+	StartTime        tt.Seconds `standardized_sort:"2"`
+	EndTime          tt.Seconds `standardized_sort:"3"`
+	ServiceID        tt.Key     `csv:",required" target:"calendar.txt" standardized_sort:"4"`
 	tt.BaseEntity
 }
 

--- a/gtfs/transfer.go
+++ b/gtfs/transfer.go
@@ -6,12 +6,12 @@ import (
 
 // Transfer transfers.txt
 type Transfer struct {
-	FromStopID      tt.Key `target:"stops.txt"`
-	ToStopID        tt.Key `target:"stops.txt"`
-	FromRouteID     tt.Key `target:"routes.txt"`
-	ToRouteID       tt.Key `target:"routes.txt"`
-	FromTripID      tt.Key `target:"trips.txt"`
-	ToTripID        tt.Key `target:"trips.txt"`
+	FromStopID      tt.Key `target:"stops.txt" standardized_sort:"1"`
+	ToStopID        tt.Key `target:"stops.txt" standardized_sort:"2"`
+	FromRouteID     tt.Key `target:"routes.txt" standardized_sort:"5"`
+	ToRouteID       tt.Key `target:"routes.txt" standardized_sort:"6"`
+	FromTripID      tt.Key `target:"trips.txt" standardized_sort:"3"`
+	ToTripID        tt.Key `target:"trips.txt" standardized_sort:"4"`
 	TransferType    tt.Int `enum:"0,1,2,3,4,5"`
 	MinTransferTime tt.Int `range:"0,"`
 	tt.BaseEntity

--- a/gtfs/translation.go
+++ b/gtfs/translation.go
@@ -7,13 +7,13 @@ import (
 
 type Translation struct {
 	// "TableNameValue" because TableName is a required interface method
-	TableNameValue tt.String   `db:"table_name" csv:"table_name,required"`
-	FieldName      tt.String   `csv:",required"`
-	Language       tt.Language `csv:",required"`
+	TableNameValue tt.String   `db:"table_name" csv:"table_name,required" standardized_sort:"1"`
+	FieldName      tt.String   `csv:",required" standardized_sort:"2"`
+	Language       tt.Language `csv:",required" standardized_sort:"3"`
 	Translation    tt.String   `csv:",required"`
-	RecordID       tt.String
-	RecordSubID    tt.String
-	FieldValue     tt.String
+	RecordID       tt.String   `standardized_sort:"4"`
+	RecordSubID    tt.String   `standardized_sort:"5"`
+	FieldValue     tt.String   `standardized_sort:"6"`
 	tt.BaseEntity
 }
 

--- a/gtfs/trip.go
+++ b/gtfs/trip.go
@@ -8,7 +8,7 @@ import (
 type Trip struct {
 	RouteID              tt.Key    `csv:",required" target:"routes.txt"`
 	ServiceID            tt.Key    `csv:",required" target:"calendar.txt"`
-	TripID               tt.String `csv:",required"`
+	TripID               tt.String `csv:",required" standardized_sort:"1"`
 	TripHeadsign         tt.String
 	TripShortName        tt.String
 	DirectionID          tt.Int `enum:"0,1"`

--- a/internal/tags/tags.go
+++ b/internal/tags/tags.go
@@ -34,6 +34,7 @@ type FieldInfo struct {
 	GreaterOrEqual *float64
 	LessOrEqual    *float64
 	EnumValues     []int64
+	SortOrder      int
 }
 
 // FieldMap contains all the parsed tags for a struct.
@@ -148,6 +149,18 @@ func (c *Cache) GetStructTagMap(ent interface{}) FieldMap {
 					} else {
 						mfi.EnumValues = append(mfi.EnumValues, optParse)
 					}
+				}
+			}
+			if optVal := fi.Field.Tag.Get("standardized_sort"); optVal != "" {
+				if optParse, err := strconv.Atoi(optVal); err != nil {
+					log.For(ctx).Error().Msgf(
+						"error constructing field map for type %T: could not parse tag 'standardized_sort' with value '%s' as int: %s",
+						ent,
+						optVal,
+						err.Error(),
+					)
+				} else {
+					mfi.SortOrder = optParse
 				}
 			}
 			m[fi.Name] = &mfi

--- a/internal/tags/tags.go
+++ b/internal/tags/tags.go
@@ -216,6 +216,20 @@ func (c *Cache) GetStructTagMap(ent interface{}) FieldMap {
 	return m
 }
 
+// GetSortColumns returns the entity's fields tagged with standardized_sort,
+// sorted ascending by SortOrder.
+func (c *Cache) GetSortColumns(ent interface{}) []*FieldInfo {
+	fmap := c.GetStructTagMap(ent)
+	var cols []*FieldInfo
+	for _, fi := range fmap {
+		if fi.SortOrder > 0 {
+			cols = append(cols, fi)
+		}
+	}
+	sort.Slice(cols, func(i, j int) bool { return cols[i].SortOrder < cols[j].SortOrder })
+	return cols
+}
+
 // Header returns the field names in the same order as the struct definition.
 func (c *Cache) GetHeader(ent interface{}) ([]string, error) {
 	row := []string{}

--- a/internal/tags/tags.go
+++ b/internal/tags/tags.go
@@ -9,10 +9,53 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/interline-io/log"
 	"github.com/jmoiron/sqlx/reflectx"
 )
+
+// SortKind classifies the underlying primitive type of a struct field for
+// type-aware sorting. It looks through tt.Option[T] wrappers to the inner T.
+type SortKind int
+
+const (
+	SortKindUnknown SortKind = iota
+	SortKindString
+	SortKindInt
+	SortKindFloat
+	SortKindDate
+)
+
+// inferKind returns the SortKind for a struct field type. It handles plain
+// primitives, pointers, time.Time, and tt.Option[T]-style wrappers (any struct
+// with a "Val" field).
+func inferKind(t reflect.Type) SortKind {
+	if t == nil {
+		return SortKindUnknown
+	}
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	switch t.Kind() {
+	case reflect.String:
+		return SortKindString
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return SortKindInt
+	case reflect.Float32, reflect.Float64:
+		return SortKindFloat
+	}
+	if t.Kind() == reflect.Struct {
+		if t == reflect.TypeOf(time.Time{}) {
+			return SortKindDate
+		}
+		if vf, ok := t.FieldByName("Val"); ok {
+			return inferKind(vf.Type)
+		}
+	}
+	return SortKindUnknown
+}
 
 var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
 var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
@@ -35,6 +78,7 @@ type FieldInfo struct {
 	LessOrEqual    *float64
 	EnumValues     []int64
 	SortOrder      int
+	Kind           SortKind
 }
 
 // FieldMap contains all the parsed tags for a struct.
@@ -89,6 +133,7 @@ func (c *Cache) GetStructTagMap(ent interface{}) FieldMap {
 				Name:   fi.Name,
 				Index:  fi.Index,
 				Target: fi.Field.Tag.Get("target"),
+				Kind:   inferKind(fi.Field.Type),
 			}
 
 			_, mfi.Required = fi.Options["required"]

--- a/internal/tags/tags.go
+++ b/internal/tags/tags.go
@@ -15,8 +15,8 @@ import (
 	"github.com/jmoiron/sqlx/reflectx"
 )
 
-// SortKind classifies the underlying primitive type of a struct field for
-// type-aware sorting. It looks through tt.Option[T] wrappers to the inner T.
+// SortKind is the underlying primitive class of a struct field, used
+// to drive type-aware sorting on serialized CSV cells.
 type SortKind int
 
 const (
@@ -27,9 +27,12 @@ const (
 	SortKindDate
 )
 
-// inferKind returns the SortKind for a struct field type. It handles plain
-// primitives, pointers, time.Time, and tt.Option[T]-style wrappers (any struct
-// with a "Val" field).
+// optionTypeHint is satisfied by wrappers (e.g., tt.Option[T]) that expose
+// their inner type. Defining the interface here keeps tt independent of tags.
+type optionTypeHint interface {
+	OptionType() reflect.Type
+}
+
 func inferKind(t reflect.Type) SortKind {
 	if t == nil {
 		return SortKindUnknown
@@ -50,8 +53,9 @@ func inferKind(t reflect.Type) SortKind {
 		if t == reflect.TypeOf(time.Time{}) {
 			return SortKindDate
 		}
-		if vf, ok := t.FieldByName("Val"); ok {
-			return inferKind(vf.Type)
+		zero := reflect.New(t).Elem().Interface()
+		if h, ok := zero.(optionTypeHint); ok {
+			return inferKind(h.OptionType())
 		}
 	}
 	return SortKindUnknown

--- a/server/rest/feed_version_export.go
+++ b/server/rest/feed_version_export.go
@@ -48,9 +48,9 @@ type ExportTransforms struct {
 	UseBasicRouteTypes bool `json:"use_basic_route_types,omitempty"`
 	// Entity value overrides (filename.entity_id.field = value)
 	SetValues map[string]string `json:"set_values,omitempty"`
-	// Standardized sort order for CSV files ("asc", "desc", or "none"). If set, all CSV files will be sorted before zipping.
+	// Sort all CSV rows before zipping ("asc" or "desc"). Omit for no sort.
 	StandardizedSort string `json:"standardized_sort,omitempty"`
-	// Optional specific columns to sort by. If empty, defaults are used based on file type.
+	// Override the columns used for the sort; otherwise per-file defaults apply.
 	StandardizedSortColumns []string `json:"standardized_sort_columns,omitempty"`
 }
 
@@ -153,8 +153,8 @@ func (r FeedVersionExportOpenAPIRequest) RequestInfo() RequestInfo {
 														"standardized_sort": &oa.SchemaRef{
 															Value: &oa.Schema{
 																Type:        &oa.Types{"string"},
-																Description: "Sort all CSV files before zipping. Use 'asc' (ascending), 'desc' (descending), or 'none' (default). This is an optional feature and is off by default. By default, transitland-lib's streaming architecture generally preserves input order, but may reorder some associated records (e.g., parent stations before children) to maintain integrity.",
-																Enum:        []any{"asc", "desc", "none"},
+																Description: "Sort CSV rows before zipping. 'asc' or 'desc'; omit for no sort (default preserves copier order, modulo parent-before-child reordering). Empty cells in numeric/date columns rank as the greatest value (NULLS LAST in asc, NULLS FIRST in desc).",
+																Enum:        []any{"asc", "desc"},
 															},
 														},
 														"standardized_sort_columns": &oa.SchemaRef{
@@ -283,7 +283,7 @@ func feedVersionExportHandler(graphqlHandler http.Handler, w http.ResponseWriter
 	_ = cpResult
 
 	// Apply sorting if requested
-	if req.Transforms != nil && req.Transforms.StandardizedSort != "" && req.Transforms.StandardizedSort != adapters.SortNone {
+	if req.Transforms != nil && req.Transforms.StandardizedSort != "" {
 		csvWriter.SetStandardizedSortOptions(adapters.StandardizedSortOptions{
 			StandardizedSort:        req.Transforms.StandardizedSort,
 			StandardizedSortColumns: req.Transforms.StandardizedSortColumns,
@@ -383,9 +383,9 @@ func validateExportRequest(req *FeedVersionExportRequest) error {
 	// Validate standardized sort order if provided
 	if req.Transforms != nil && req.Transforms.StandardizedSort != "" {
 		switch req.Transforms.StandardizedSort {
-		case adapters.SortAsc, adapters.SortDesc, adapters.SortNone:
+		case adapters.SortAsc, adapters.SortDesc:
 		default:
-			return util.NewBadRequestError(fmt.Sprintf("invalid standardized_sort value: %s (must be 'asc', 'desc', or 'none')", req.Transforms.StandardizedSort), nil)
+			return util.NewBadRequestError(fmt.Sprintf("invalid standardized_sort value: %s (must be 'asc' or 'desc')", req.Transforms.StandardizedSort), nil)
 		}
 	}
 

--- a/server/rest/feed_version_export.go
+++ b/server/rest/feed_version_export.go
@@ -285,8 +285,8 @@ func feedVersionExportHandler(graphqlHandler http.Handler, w http.ResponseWriter
 	// Apply sorting if requested
 	if req.Transforms != nil && req.Transforms.StandardizedSort != "" {
 		csvWriter.SetStandardizedSortOptions(adapters.StandardizedSortOptions{
-			StandardizedSort:        req.Transforms.StandardizedSort,
-			StandardizedSortColumns: req.Transforms.StandardizedSortColumns,
+			ApplySort:   req.Transforms.StandardizedSort,
+			SortColumns: req.Transforms.StandardizedSortColumns,
 		})
 	}
 
@@ -380,12 +380,9 @@ func validateExportRequest(req *FeedVersionExportRequest) error {
 		return util.NewBadRequestError("only 'gtfs_zip' format is currently supported", nil)
 	}
 
-	// Validate standardized sort order if provided
-	if req.Transforms != nil && req.Transforms.StandardizedSort != "" {
-		switch req.Transforms.StandardizedSort {
-		case adapters.SortAsc, adapters.SortDesc:
-		default:
-			return util.NewBadRequestError(fmt.Sprintf("invalid standardized_sort value: %s (must be 'asc' or 'desc')", req.Transforms.StandardizedSort), nil)
+	if req.Transforms != nil {
+		if err := adapters.ValidateSortDirection(req.Transforms.StandardizedSort); err != nil {
+			return util.NewBadRequestError(fmt.Sprintf("standardized_sort: %s", err), nil)
 		}
 	}
 

--- a/server/rest/feed_version_export.go
+++ b/server/rest/feed_version_export.go
@@ -283,7 +283,7 @@ func feedVersionExportHandler(graphqlHandler http.Handler, w http.ResponseWriter
 	_ = cpResult
 
 	// Apply sorting if requested
-	if req.Transforms != nil && req.Transforms.StandardizedSort != "" && req.Transforms.StandardizedSort != "none" {
+	if req.Transforms != nil && req.Transforms.StandardizedSort != "" && req.Transforms.StandardizedSort != adapters.SortNone {
 		csvWriter.SetStandardizedSortOptions(adapters.StandardizedSortOptions{
 			StandardizedSort:        req.Transforms.StandardizedSort,
 			StandardizedSortColumns: req.Transforms.StandardizedSortColumns,
@@ -382,7 +382,9 @@ func validateExportRequest(req *FeedVersionExportRequest) error {
 
 	// Validate standardized sort order if provided
 	if req.Transforms != nil && req.Transforms.StandardizedSort != "" {
-		if req.Transforms.StandardizedSort != "asc" && req.Transforms.StandardizedSort != "desc" && req.Transforms.StandardizedSort != "none" {
+		switch req.Transforms.StandardizedSort {
+		case adapters.SortAsc, adapters.SortDesc, adapters.SortNone:
+		default:
 			return util.NewBadRequestError(fmt.Sprintf("invalid standardized_sort value: %s (must be 'asc', 'desc', or 'none')", req.Transforms.StandardizedSort), nil)
 		}
 	}

--- a/server/rest/feed_version_export_test.go
+++ b/server/rest/feed_version_export_test.go
@@ -425,7 +425,8 @@ func TestFeedVersionExportRequest(t *testing.T) {
 		rr := makeExportRequest(t, reqBody, asAdmin)
 
 		assert.Equal(t, 400, rr.Result().StatusCode, "should be bad request")
-		assert.Contains(t, rr.Body.String(), "invalid standardized_sort", "error message")
+		assert.Contains(t, rr.Body.String(), "standardized_sort", "error message")
+		assert.Contains(t, rr.Body.String(), "invalid sort direction", "error message")
 	})
 
 	t.Run("bad request - feed version not imported", func(t *testing.T) {

--- a/server/rest/feed_version_export_test.go
+++ b/server/rest/feed_version_export_test.go
@@ -170,28 +170,23 @@ func TestFeedVersionExportRequest(t *testing.T) {
 	})
 
 	t.Run("export without standardized sort", func(t *testing.T) {
+		// Caltrain's natural route order has TaSj before Gi (non-alphabetical),
+		// so this assertion fails if we ever silently sort by default.
 		reqBody := FeedVersionExportRequest{
 			FeedVersionKeys: []string{caltrainFv},
-			// Transforms: nil, should default to no sort
 		}
 		rr := makeExportRequest(t, reqBody, asAdmin)
-
 		assert.Equal(t, 200, rr.Result().StatusCode, "status code")
-		// Verify stops are NOT sorted
 		if err := makeTempReader(t, rr.Body.Bytes(), func(t *testing.T, reader *tlcsv.Reader) {
-			var stopIds []string
-			for ent := range reader.Stops() {
-				stopIds = append(stopIds, ent.StopID.Val)
+			var ids []string
+			for ent := range reader.Routes() {
+				ids = append(ids, ent.RouteID.Val)
 			}
-			// Check that stops are NOT necessarily sorted ascending
-			isSorted := true
-			for i := 1; i < len(stopIds); i++ {
-				if stopIds[i-1] > stopIds[i] {
-					isSorted = false
-					break
-				}
-			}
-			assert.False(t, isSorted, "stops should not be automatically sorted")
+			assert.Equal(t,
+				[]string{"Bu-130", "Li-130", "Lo-130", "TaSj-130", "Gi-130", "Sp-130"},
+				ids,
+				"routes should be in copier (natural input) order, not sorted",
+			)
 		}); err != nil {
 			t.Fatalf("test failed: %v", err)
 		}

--- a/tlcsv/adapter.go
+++ b/tlcsv/adapter.go
@@ -500,6 +500,18 @@ func (adapter *DirAdapter) resolveSortColumns(filename string) []*tags.FieldInfo
 	return out
 }
 
+// StandardizedSortCSVFiles sorts every registered .txt file in place.
+//
+// TODO: this loads each file fully into memory (csv.ReadAll + in-memory
+// sort.SliceStable + truncate-and-rewrite). For large feeds, files like
+// stop_times.txt and shapes.txt can be tens of millions of rows and will
+// drive RSS up accordingly. The feature is opt-in, so the cost is only
+// paid when callers ask for it. A streaming external-merge replacement is
+// possible (write sorted runs to temp files, then k-way merge), but the
+// same memory pressure is reachable through other endpoints, so a
+// caller-bounded fix here can be defeated by an attacker who simply hits
+// a different code path. Revisit alongside any general resource-limit
+// work, not as a one-off.
 func (adapter *DirAdapter) StandardizedSortCSVFiles() error {
 	sortOrder := adapter.sortOptions.StandardizedSort
 	if sortOrder == "" {

--- a/tlcsv/adapter.go
+++ b/tlcsv/adapter.go
@@ -2,7 +2,6 @@ package tlcsv
 
 import (
 	"archive/zip"
-	"cmp"
 	"context"
 	"crypto/sha1"
 	"encoding/csv"
@@ -14,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/interline-io/log"
@@ -386,9 +384,8 @@ func (adapter *ZipAdapter) findInternalPrefix() (string, error) {
 
 /////////////////////
 
-// sortColumnRegistrar lets a Writer hand captured sort metadata to whichever
-// adapter is sitting under it. Both DirAdapter and ZipWriterAdapter
-// (via embedding) implement it.
+// sortColumnRegistrar receives sort metadata from a Writer at file-write
+// time. ZipWriterAdapter inherits the implementation via embedded DirAdapter.
 type sortColumnRegistrar interface {
 	registerSortColumns(filename string, cols []*tags.FieldInfo)
 }
@@ -412,8 +409,6 @@ func NewDirAdapter(path string) *DirAdapter {
 	}
 }
 
-// registerSortColumns records the sort metadata an entity's tags imply,
-// captured by the Writer when a file's header is first generated.
 func (adapter *DirAdapter) registerSortColumns(filename string, cols []*tags.FieldInfo) {
 	adapter.sortColumnsByFile[filename] = cols
 }
@@ -486,17 +481,14 @@ func (adapter *DirAdapter) SetStandardizedSortOptions(opts adapters.Standardized
 	adapter.sortOptions = opts
 }
 
-// resolveSortColumns picks the sort columns for a file. A user-supplied
-// override (StandardizedSortColumns) wins; otherwise the columns captured
-// from the entity at file-write time are used. Returns nil if neither
-// applies — a signal to the sort step to skip the file.
+// resolveSortColumns returns the user-supplied override if set, otherwise
+// the captured per-file defaults; nil signals "skip this file".
 func (adapter *DirAdapter) resolveSortColumns(filename string) []*tags.FieldInfo {
 	captured := adapter.sortColumnsByFile[filename]
 	if len(adapter.sortOptions.StandardizedSortColumns) == 0 {
 		return captured
 	}
-	// Look up captured kinds so user-supplied names still get type-aware
-	// sorting when the file is one we know about.
+	// User-supplied column names still get type-aware sorting if we recognize them.
 	kindByName := map[string]tags.SortKind{}
 	for _, c := range captured {
 		kindByName[c.Name] = c.Kind
@@ -506,95 +498,6 @@ func (adapter *DirAdapter) resolveSortColumns(filename string) []*tags.FieldInfo
 		out = append(out, &tags.FieldInfo{Name: name, Kind: kindByName[name], SortOrder: i + 1})
 	}
 	return out
-}
-
-// compareCells returns -1, 0, or +1 comparing two raw CSV cell strings
-// under the given kind. For numeric/date kinds, empty or unparseable
-// values always sort after valid values regardless of direction.
-func compareCells(a, b string, kind tags.SortKind) int {
-	switch kind {
-	case tags.SortKindInt:
-		return compareNumeric(a, b, func(s string) (int64, error) {
-			return strconv.ParseInt(strings.TrimSpace(s), 10, 64)
-		})
-	case tags.SortKindFloat:
-		return compareNumeric(a, b, func(s string) (float64, error) {
-			return strconv.ParseFloat(strings.TrimSpace(s), 64)
-		})
-	case tags.SortKindDate:
-		// GTFS dates are YYYYMMDD which sorts correctly as a string;
-		// missing values go last.
-		return compareEmptyLast(a, b)
-	default:
-		return strings.Compare(a, b)
-	}
-}
-
-func compareNumeric[T cmp.Ordered](a, b string, parse func(string) (T, error)) int {
-	av, aerr := parse(a)
-	bv, berr := parse(b)
-	switch {
-	case aerr != nil && berr != nil:
-		return 0
-	case aerr != nil:
-		return 1
-	case berr != nil:
-		return -1
-	}
-	return cmp.Compare(av, bv)
-}
-
-func compareEmptyLast(a, b string) int {
-	switch {
-	case a == "" && b == "":
-		return 0
-	case a == "":
-		return 1
-	case b == "":
-		return -1
-	}
-	return strings.Compare(a, b)
-}
-
-type sortKey struct {
-	idx  int
-	kind tags.SortKind
-}
-
-func resolveHeaderKeys(header []string, cols []*tags.FieldInfo) []sortKey {
-	var keys []sortKey
-	for _, fi := range cols {
-		for i, h := range header {
-			if h == fi.Name {
-				keys = append(keys, sortKey{idx: i, kind: fi.Kind})
-				break
-			}
-		}
-	}
-	return keys
-}
-
-func sortRows(rows [][]string, keys []sortKey, descending bool) {
-	sort.SliceStable(rows, func(i, j int) bool {
-		for _, k := range keys {
-			a, b := "", ""
-			if k.idx < len(rows[i]) {
-				a = rows[i][k.idx]
-			}
-			if k.idx < len(rows[j]) {
-				b = rows[j][k.idx]
-			}
-			c := compareCells(a, b, k.kind)
-			if c == 0 {
-				continue
-			}
-			if descending {
-				return c > 0
-			}
-			return c < 0
-		}
-		return false
-	})
 }
 
 func (adapter *DirAdapter) StandardizedSortCSVFiles() error {

--- a/tlcsv/adapter.go
+++ b/tlcsv/adapter.go
@@ -13,14 +13,14 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/interline-io/log"
 	"github.com/interline-io/transitland-lib/adapters"
 	"github.com/interline-io/transitland-lib/causes"
-	"github.com/interline-io/transitland-lib/gtfs"
+	"github.com/interline-io/transitland-lib/internal/tags"
 	"github.com/interline-io/transitland-lib/request"
-	"github.com/interline-io/transitland-lib/tt"
 	"github.com/twpayne/go-geom/encoding/geojson"
 )
 
@@ -385,21 +385,47 @@ func (adapter *ZipAdapter) findInternalPrefix() (string, error) {
 
 /////////////////////
 
+// sortColumn describes a single sort key captured from an entity's struct
+// tags at the time its file header was generated.
+type sortColumn struct {
+	Name  string
+	Kind  tags.SortKind
+	Order int
+}
+
+// sortColumnRegistrar is implemented by writer adapters that can remember
+// per-file sort metadata captured at header-generation time. The Writer
+// hands the captured columns to the adapter so the sort step can use them.
+type sortColumnRegistrar interface {
+	registerSortColumns(filename string, cols []sortColumn)
+}
+
 // DirAdapter supports plain directories of CSV files.
 type DirAdapter struct {
-	path            string
-	files           map[string]*os.File
-	geojsonFeatures map[string][]*geojson.Feature
-	sortOptions     adapters.StandardizedSortOptions
+	path              string
+	files             map[string]*os.File
+	geojsonFeatures   map[string][]*geojson.Feature
+	sortOptions       adapters.StandardizedSortOptions
+	sortColumnsByFile map[string][]sortColumn
 }
 
 // NewDirAdapter returns an initialized DirAdapter.
 func NewDirAdapter(path string) *DirAdapter {
 	return &DirAdapter{
-		path:            strings.TrimPrefix(path, "file://"),
-		files:           map[string]*os.File{},
-		geojsonFeatures: map[string][]*geojson.Feature{},
+		path:              strings.TrimPrefix(path, "file://"),
+		files:             map[string]*os.File{},
+		geojsonFeatures:   map[string][]*geojson.Feature{},
+		sortColumnsByFile: map[string][]sortColumn{},
 	}
+}
+
+// registerSortColumns is called by the Writer when a file's header is first
+// generated. The captured columns drive the per-file default sort.
+func (adapter *DirAdapter) registerSortColumns(filename string, cols []sortColumn) {
+	if adapter.sortColumnsByFile == nil {
+		adapter.sortColumnsByFile = map[string][]sortColumn{}
+	}
+	adapter.sortColumnsByFile[filename] = cols
 }
 
 // String
@@ -470,94 +496,88 @@ func (adapter *DirAdapter) SetStandardizedSortOptions(opts adapters.Standardized
 	adapter.sortOptions = opts
 }
 
-func (adapter *DirAdapter) getDefaultSortColumns(filename string) []string {
-	var ent tt.Entity
-	switch filename {
-	case "agency.txt":
-		ent = &gtfs.Agency{}
-	case "stops.txt":
-		ent = &gtfs.Stop{}
-	case "routes.txt":
-		ent = &gtfs.Route{}
-	case "trips.txt":
-		ent = &gtfs.Trip{}
-	case "stop_times.txt":
-		ent = &gtfs.StopTime{}
-	case "shapes.txt":
-		ent = &gtfs.Shape{}
-	case "calendar.txt":
-		ent = &gtfs.Calendar{}
-	case "calendar_dates.txt":
-		ent = &gtfs.CalendarDate{}
-	case "fare_attributes.txt":
-		ent = &gtfs.FareAttribute{}
-	case "fare_rules.txt":
-		ent = &gtfs.FareRule{}
-	case "fare_media.txt":
-		ent = &gtfs.FareMedia{}
-	case "fare_products.txt":
-		ent = &gtfs.FareProduct{}
-	case "fare_leg_rules.txt":
-		ent = &gtfs.FareLegRule{}
-	case "fare_transfer_rules.txt":
-		ent = &gtfs.FareTransferRule{}
-	case "feed_info.txt":
-		ent = &gtfs.FeedInfo{}
-	case "frequencies.txt":
-		ent = &gtfs.Frequency{}
-	case "transfers.txt":
-		ent = &gtfs.Transfer{}
-	case "levels.txt":
-		ent = &gtfs.Level{}
-	case "pathways.txt":
-		ent = &gtfs.Pathway{}
-	case "areas.txt":
-		ent = &gtfs.Area{}
-	case "attributions.txt":
-		ent = &gtfs.Attribution{}
-	case "locations.geojson":
-		ent = &gtfs.Location{}
-	case "location_groups.txt":
-		ent = &gtfs.LocationGroup{}
-	case "location_group_stops.txt":
-		ent = &gtfs.LocationGroupStop{}
-	case "networks.txt":
-		ent = &gtfs.Network{}
-	case "route_networks.txt":
-		ent = &gtfs.RouteNetwork{}
-	case "stop_areas.txt":
-		ent = &gtfs.StopArea{}
-	case "timeframes.txt":
-		ent = &gtfs.Timeframe{}
-	case "translations.txt":
-		ent = &gtfs.Translation{}
-	case "booking_rules.txt":
-		ent = &gtfs.BookingRule{}
-	}
-
-	if ent == nil {
-		return nil
-	}
-
-	fmap := MapperCache.GetStructTagMap(ent)
-	type sortCol struct {
-		name  string
-		order int
-	}
-	var cols []sortCol
-	for name, info := range fmap {
-		if info.SortOrder > 0 {
-			cols = append(cols, sortCol{name, info.SortOrder})
+// resolveSortColumns picks the sort columns to use for a given file. If the
+// caller supplied StandardizedSortColumns, those are used (with kinds looked
+// up from captured info when available, otherwise treated as strings). When
+// no override is given, the sort columns captured at file-write time drive
+// the default. Returns nil if there is nothing to sort by.
+func (adapter *DirAdapter) resolveSortColumns(filename string) []sortColumn {
+	captured := adapter.sortColumnsByFile[filename]
+	if len(adapter.sortOptions.StandardizedSortColumns) > 0 {
+		// Build a name → kind lookup from captured info so user-supplied
+		// columns still get type-aware sorting when possible.
+		kindByName := map[string]tags.SortKind{}
+		for _, c := range captured {
+			kindByName[c.Name] = c.Kind
 		}
+		out := make([]sortColumn, 0, len(adapter.sortOptions.StandardizedSortColumns))
+		for i, name := range adapter.sortOptions.StandardizedSortColumns {
+			out = append(out, sortColumn{Name: name, Kind: kindByName[name], Order: i + 1})
+		}
+		return out
 	}
-	sort.Slice(cols, func(i, j int) bool {
-		return cols[i].order < cols[j].order
-	})
-	var result []string
-	for _, c := range cols {
-		result = append(result, c.name)
+	return captured
+}
+
+// compareCells returns -1, 0, or +1 comparing two raw CSV cell strings under
+// the given kind. For numeric/date kinds, empty or unparseable values always
+// sort after valid values regardless of direction.
+func compareCells(a, b string, kind tags.SortKind) int {
+	switch kind {
+	case tags.SortKindInt:
+		ai, aerr := strconv.ParseInt(strings.TrimSpace(a), 10, 64)
+		bi, berr := strconv.ParseInt(strings.TrimSpace(b), 10, 64)
+		if aerr != nil && berr != nil {
+			return 0
+		}
+		if aerr != nil {
+			return 1
+		}
+		if berr != nil {
+			return -1
+		}
+		switch {
+		case ai < bi:
+			return -1
+		case ai > bi:
+			return 1
+		}
+		return 0
+	case tags.SortKindFloat:
+		af, aerr := strconv.ParseFloat(strings.TrimSpace(a), 64)
+		bf, berr := strconv.ParseFloat(strings.TrimSpace(b), 64)
+		if aerr != nil && berr != nil {
+			return 0
+		}
+		if aerr != nil {
+			return 1
+		}
+		if berr != nil {
+			return -1
+		}
+		switch {
+		case af < bf:
+			return -1
+		case af > bf:
+			return 1
+		}
+		return 0
+	case tags.SortKindDate:
+		// GTFS dates are YYYYMMDD which sorts correctly as a string. Treat
+		// empty/missing as last.
+		if a == "" && b == "" {
+			return 0
+		}
+		if a == "" {
+			return 1
+		}
+		if b == "" {
+			return -1
+		}
+		return strings.Compare(a, b)
+	default:
+		return strings.Compare(a, b)
 	}
-	return result
 }
 
 func (adapter *DirAdapter) StandardizedSortCSVFiles() error {
@@ -565,97 +585,94 @@ func (adapter *DirAdapter) StandardizedSortCSVFiles() error {
 	if sortOrder == "" {
 		return nil
 	}
+	descending := sortOrder == "desc"
 
 	// Collect .txt filenames and close only those files
 	var filenamesToSort []string
 	for filename, f := range adapter.files {
-		if strings.HasSuffix(filename, ".txt") {
-			filenamesToSort = append(filenamesToSort, filename)
-			// Close .txt files so we can read and rewrite them
-			if err := f.Close(); err != nil {
-				return fmt.Errorf("failed to close file %s: %w", filename, err)
-			}
-			delete(adapter.files, filename)
+		if !strings.HasSuffix(filename, ".txt") {
+			continue
 		}
+		// Skip files we have no captured sort metadata for and no
+		// caller-supplied override — sort is best-effort and only runs
+		// on files written through the typed entity path.
+		if len(adapter.resolveSortColumns(filename)) == 0 {
+			continue
+		}
+		filenamesToSort = append(filenamesToSort, filename)
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("failed to close file %s: %w", filename, err)
+		}
+		delete(adapter.files, filename)
 	}
 
-	// Sort each CSV file that was written
 	for _, filename := range filenamesToSort {
 		fullPath := filepath.Join(adapter.path, filename)
 
-		// Read all rows
 		file, err := os.Open(fullPath)
 		if err != nil {
 			return fmt.Errorf("failed to open file %s: %w", filename, err)
 		}
-
 		reader := csv.NewReader(file)
 		allRows, err := reader.ReadAll()
 		file.Close()
 		if err != nil {
 			return fmt.Errorf("failed to read file %s: %w", filename, err)
 		}
-
 		if len(allRows) == 0 {
 			continue
 		}
 
-		// Separate header from data rows
 		header := allRows[0]
 		dataRows := allRows[1:]
 
-		// Determine columns to sort by
-		sortColumns := adapter.sortOptions.StandardizedSortColumns
-		if len(sortColumns) == 0 {
-			sortColumns = adapter.getDefaultSortColumns(filename)
+		// Resolve sort columns against the actual on-disk header. Columns
+		// not present in the header are dropped.
+		type indexedSort struct {
+			idx  int
+			kind tags.SortKind
 		}
-
-		// Sort data rows
-		if len(sortColumns) > 0 {
-			// Sort by specific columns
-			colIndices := make([]int, 0, len(sortColumns))
-			for _, colName := range sortColumns {
-				index := -1
-				for i, h := range header {
-					if h == colName {
-						index = i
-						break
-					}
-				}
-				if index != -1 {
-					colIndices = append(colIndices, index)
+		var keys []indexedSort
+		for _, sc := range adapter.resolveSortColumns(filename) {
+			idx := -1
+			for i, h := range header {
+				if h == sc.Name {
+					idx = i
+					break
 				}
 			}
-
-			if sortOrder == "desc" {
-				sort.Slice(dataRows, func(i, j int) bool {
-					for _, idx := range colIndices {
-						if dataRows[i][idx] == dataRows[j][idx] {
-							continue
-						}
-						return dataRows[i][idx] > dataRows[j][idx]
-					}
-					return false
-				})
-			} else {
-				sort.Slice(dataRows, func(i, j int) bool {
-					for _, idx := range colIndices {
-						if dataRows[i][idx] == dataRows[j][idx] {
-							continue
-						}
-						return dataRows[i][idx] < dataRows[j][idx]
-					}
-					return false
-				})
+			if idx != -1 {
+				keys = append(keys, indexedSort{idx: idx, kind: sc.Kind})
 			}
 		}
 
-		// Write sorted rows back to file
+		if len(keys) > 0 {
+			sort.SliceStable(dataRows, func(i, j int) bool {
+				for _, k := range keys {
+					ai, bj := "", ""
+					if k.idx < len(dataRows[i]) {
+						ai = dataRows[i][k.idx]
+					}
+					if k.idx < len(dataRows[j]) {
+						bj = dataRows[j][k.idx]
+					}
+					cmp := compareCells(ai, bj, k.kind)
+					if cmp == 0 {
+						continue
+					}
+					if descending {
+						return cmp > 0
+					}
+					return cmp < 0
+				}
+				return false
+			})
+		}
+
 		file, err = os.Create(fullPath)
 		if err != nil {
 			return fmt.Errorf("failed to create file %s: %w", filename, err)
 		}
-
 		writer := csv.NewWriter(file)
 		if err := writer.Write(header); err != nil {
 			file.Close()
@@ -672,7 +689,6 @@ func (adapter *DirAdapter) StandardizedSortCSVFiles() error {
 		}
 		file.Close()
 
-		// Re-open the sorted file and add it back to the files map
 		reopenedFile, err := os.Open(fullPath)
 		if err != nil {
 			return fmt.Errorf("failed to re-open sorted file %s: %w", filename, err)

--- a/tlcsv/adapter.go
+++ b/tlcsv/adapter.go
@@ -2,6 +2,7 @@ package tlcsv
 
 import (
 	"archive/zip"
+	"cmp"
 	"context"
 	"crypto/sha1"
 	"encoding/csv"
@@ -385,19 +386,11 @@ func (adapter *ZipAdapter) findInternalPrefix() (string, error) {
 
 /////////////////////
 
-// sortColumn describes a single sort key captured from an entity's struct
-// tags at the time its file header was generated.
-type sortColumn struct {
-	Name  string
-	Kind  tags.SortKind
-	Order int
-}
-
-// sortColumnRegistrar is implemented by writer adapters that can remember
-// per-file sort metadata captured at header-generation time. The Writer
-// hands the captured columns to the adapter so the sort step can use them.
+// sortColumnRegistrar lets a Writer hand captured sort metadata to whichever
+// adapter is sitting under it. Both DirAdapter and ZipWriterAdapter
+// (via embedding) implement it.
 type sortColumnRegistrar interface {
-	registerSortColumns(filename string, cols []sortColumn)
+	registerSortColumns(filename string, cols []*tags.FieldInfo)
 }
 
 // DirAdapter supports plain directories of CSV files.
@@ -406,7 +399,7 @@ type DirAdapter struct {
 	files             map[string]*os.File
 	geojsonFeatures   map[string][]*geojson.Feature
 	sortOptions       adapters.StandardizedSortOptions
-	sortColumnsByFile map[string][]sortColumn
+	sortColumnsByFile map[string][]*tags.FieldInfo
 }
 
 // NewDirAdapter returns an initialized DirAdapter.
@@ -415,16 +408,13 @@ func NewDirAdapter(path string) *DirAdapter {
 		path:              strings.TrimPrefix(path, "file://"),
 		files:             map[string]*os.File{},
 		geojsonFeatures:   map[string][]*geojson.Feature{},
-		sortColumnsByFile: map[string][]sortColumn{},
+		sortColumnsByFile: map[string][]*tags.FieldInfo{},
 	}
 }
 
-// registerSortColumns is called by the Writer when a file's header is first
-// generated. The captured columns drive the per-file default sort.
-func (adapter *DirAdapter) registerSortColumns(filename string, cols []sortColumn) {
-	if adapter.sortColumnsByFile == nil {
-		adapter.sortColumnsByFile = map[string][]sortColumn{}
-	}
+// registerSortColumns records the sort metadata an entity's tags imply,
+// captured by the Writer when a file's header is first generated.
+func (adapter *DirAdapter) registerSortColumns(filename string, cols []*tags.FieldInfo) {
 	adapter.sortColumnsByFile[filename] = cols
 }
 
@@ -496,88 +486,115 @@ func (adapter *DirAdapter) SetStandardizedSortOptions(opts adapters.Standardized
 	adapter.sortOptions = opts
 }
 
-// resolveSortColumns picks the sort columns to use for a given file. If the
-// caller supplied StandardizedSortColumns, those are used (with kinds looked
-// up from captured info when available, otherwise treated as strings). When
-// no override is given, the sort columns captured at file-write time drive
-// the default. Returns nil if there is nothing to sort by.
-func (adapter *DirAdapter) resolveSortColumns(filename string) []sortColumn {
+// resolveSortColumns picks the sort columns for a file. A user-supplied
+// override (StandardizedSortColumns) wins; otherwise the columns captured
+// from the entity at file-write time are used. Returns nil if neither
+// applies — a signal to the sort step to skip the file.
+func (adapter *DirAdapter) resolveSortColumns(filename string) []*tags.FieldInfo {
 	captured := adapter.sortColumnsByFile[filename]
-	if len(adapter.sortOptions.StandardizedSortColumns) > 0 {
-		// Build a name → kind lookup from captured info so user-supplied
-		// columns still get type-aware sorting when possible.
-		kindByName := map[string]tags.SortKind{}
-		for _, c := range captured {
-			kindByName[c.Name] = c.Kind
-		}
-		out := make([]sortColumn, 0, len(adapter.sortOptions.StandardizedSortColumns))
-		for i, name := range adapter.sortOptions.StandardizedSortColumns {
-			out = append(out, sortColumn{Name: name, Kind: kindByName[name], Order: i + 1})
-		}
-		return out
+	if len(adapter.sortOptions.StandardizedSortColumns) == 0 {
+		return captured
 	}
-	return captured
+	// Look up captured kinds so user-supplied names still get type-aware
+	// sorting when the file is one we know about.
+	kindByName := map[string]tags.SortKind{}
+	for _, c := range captured {
+		kindByName[c.Name] = c.Kind
+	}
+	out := make([]*tags.FieldInfo, 0, len(adapter.sortOptions.StandardizedSortColumns))
+	for i, name := range adapter.sortOptions.StandardizedSortColumns {
+		out = append(out, &tags.FieldInfo{Name: name, Kind: kindByName[name], SortOrder: i + 1})
+	}
+	return out
 }
 
-// compareCells returns -1, 0, or +1 comparing two raw CSV cell strings under
-// the given kind. For numeric/date kinds, empty or unparseable values always
-// sort after valid values regardless of direction.
+// compareCells returns -1, 0, or +1 comparing two raw CSV cell strings
+// under the given kind. For numeric/date kinds, empty or unparseable
+// values always sort after valid values regardless of direction.
 func compareCells(a, b string, kind tags.SortKind) int {
 	switch kind {
 	case tags.SortKindInt:
-		ai, aerr := strconv.ParseInt(strings.TrimSpace(a), 10, 64)
-		bi, berr := strconv.ParseInt(strings.TrimSpace(b), 10, 64)
-		if aerr != nil && berr != nil {
-			return 0
-		}
-		if aerr != nil {
-			return 1
-		}
-		if berr != nil {
-			return -1
-		}
-		switch {
-		case ai < bi:
-			return -1
-		case ai > bi:
-			return 1
-		}
-		return 0
+		return compareNumeric(a, b, func(s string) (int64, error) {
+			return strconv.ParseInt(strings.TrimSpace(s), 10, 64)
+		})
 	case tags.SortKindFloat:
-		af, aerr := strconv.ParseFloat(strings.TrimSpace(a), 64)
-		bf, berr := strconv.ParseFloat(strings.TrimSpace(b), 64)
-		if aerr != nil && berr != nil {
-			return 0
-		}
-		if aerr != nil {
-			return 1
-		}
-		if berr != nil {
-			return -1
-		}
-		switch {
-		case af < bf:
-			return -1
-		case af > bf:
-			return 1
-		}
-		return 0
+		return compareNumeric(a, b, func(s string) (float64, error) {
+			return strconv.ParseFloat(strings.TrimSpace(s), 64)
+		})
 	case tags.SortKindDate:
-		// GTFS dates are YYYYMMDD which sorts correctly as a string. Treat
-		// empty/missing as last.
-		if a == "" && b == "" {
-			return 0
-		}
-		if a == "" {
-			return 1
-		}
-		if b == "" {
-			return -1
-		}
-		return strings.Compare(a, b)
+		// GTFS dates are YYYYMMDD which sorts correctly as a string;
+		// missing values go last.
+		return compareEmptyLast(a, b)
 	default:
 		return strings.Compare(a, b)
 	}
+}
+
+func compareNumeric[T cmp.Ordered](a, b string, parse func(string) (T, error)) int {
+	av, aerr := parse(a)
+	bv, berr := parse(b)
+	switch {
+	case aerr != nil && berr != nil:
+		return 0
+	case aerr != nil:
+		return 1
+	case berr != nil:
+		return -1
+	}
+	return cmp.Compare(av, bv)
+}
+
+func compareEmptyLast(a, b string) int {
+	switch {
+	case a == "" && b == "":
+		return 0
+	case a == "":
+		return 1
+	case b == "":
+		return -1
+	}
+	return strings.Compare(a, b)
+}
+
+type sortKey struct {
+	idx  int
+	kind tags.SortKind
+}
+
+func resolveHeaderKeys(header []string, cols []*tags.FieldInfo) []sortKey {
+	var keys []sortKey
+	for _, fi := range cols {
+		for i, h := range header {
+			if h == fi.Name {
+				keys = append(keys, sortKey{idx: i, kind: fi.Kind})
+				break
+			}
+		}
+	}
+	return keys
+}
+
+func sortRows(rows [][]string, keys []sortKey, descending bool) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		for _, k := range keys {
+			a, b := "", ""
+			if k.idx < len(rows[i]) {
+				a = rows[i][k.idx]
+			}
+			if k.idx < len(rows[j]) {
+				b = rows[j][k.idx]
+			}
+			c := compareCells(a, b, k.kind)
+			if c == 0 {
+				continue
+			}
+			if descending {
+				return c > 0
+			}
+			return c < 0
+		}
+		return false
+	})
 }
 
 func (adapter *DirAdapter) StandardizedSortCSVFiles() error {
@@ -585,115 +602,58 @@ func (adapter *DirAdapter) StandardizedSortCSVFiles() error {
 	if sortOrder == "" {
 		return nil
 	}
-	descending := sortOrder == "desc"
+	descending := sortOrder == adapters.SortDesc
 
-	// Collect .txt filenames and close only those files
-	var filenamesToSort []string
-	for filename, f := range adapter.files {
+	type plan struct {
+		name string
+		cols []*tags.FieldInfo
+	}
+	var plans []plan
+	for filename := range adapter.files {
 		if !strings.HasSuffix(filename, ".txt") {
 			continue
 		}
-		// Skip files we have no captured sort metadata for and no
-		// caller-supplied override — sort is best-effort and only runs
-		// on files written through the typed entity path.
-		if len(adapter.resolveSortColumns(filename)) == 0 {
+		cols := adapter.resolveSortColumns(filename)
+		if len(cols) == 0 {
 			continue
 		}
-		filenamesToSort = append(filenamesToSort, filename)
-		if err := f.Close(); err != nil {
-			return fmt.Errorf("failed to close file %s: %w", filename, err)
-		}
-		delete(adapter.files, filename)
+		plans = append(plans, plan{name: filename, cols: cols})
 	}
 
-	for _, filename := range filenamesToSort {
-		fullPath := filepath.Join(adapter.path, filename)
-
-		file, err := os.Open(fullPath)
-		if err != nil {
-			return fmt.Errorf("failed to open file %s: %w", filename, err)
+	for _, p := range plans {
+		f := adapter.files[p.name]
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			return fmt.Errorf("failed to seek %s: %w", p.name, err)
 		}
-		reader := csv.NewReader(file)
-		allRows, err := reader.ReadAll()
-		file.Close()
+		allRows, err := csv.NewReader(f).ReadAll()
 		if err != nil {
-			return fmt.Errorf("failed to read file %s: %w", filename, err)
+			return fmt.Errorf("failed to read file %s: %w", p.name, err)
 		}
 		if len(allRows) == 0 {
 			continue
 		}
-
-		header := allRows[0]
-		dataRows := allRows[1:]
-
-		// Resolve sort columns against the actual on-disk header. Columns
-		// not present in the header are dropped.
-		type indexedSort struct {
-			idx  int
-			kind tags.SortKind
-		}
-		var keys []indexedSort
-		for _, sc := range adapter.resolveSortColumns(filename) {
-			idx := -1
-			for i, h := range header {
-				if h == sc.Name {
-					idx = i
-					break
-				}
-			}
-			if idx != -1 {
-				keys = append(keys, indexedSort{idx: idx, kind: sc.Kind})
-			}
+		header, dataRows := allRows[0], allRows[1:]
+		if keys := resolveHeaderKeys(header, p.cols); len(keys) > 0 {
+			sortRows(dataRows, keys, descending)
 		}
 
-		if len(keys) > 0 {
-			sort.SliceStable(dataRows, func(i, j int) bool {
-				for _, k := range keys {
-					ai, bj := "", ""
-					if k.idx < len(dataRows[i]) {
-						ai = dataRows[i][k.idx]
-					}
-					if k.idx < len(dataRows[j]) {
-						bj = dataRows[j][k.idx]
-					}
-					cmp := compareCells(ai, bj, k.kind)
-					if cmp == 0 {
-						continue
-					}
-					if descending {
-						return cmp > 0
-					}
-					return cmp < 0
-				}
-				return false
-			})
+		if err := f.Truncate(0); err != nil {
+			return fmt.Errorf("failed to truncate %s: %w", p.name, err)
 		}
-
-		file, err = os.Create(fullPath)
-		if err != nil {
-			return fmt.Errorf("failed to create file %s: %w", filename, err)
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			return fmt.Errorf("failed to seek %s: %w", p.name, err)
 		}
-		writer := csv.NewWriter(file)
-		if err := writer.Write(header); err != nil {
-			file.Close()
-			return fmt.Errorf("failed to write header to %s: %w", filename, err)
+		w := csv.NewWriter(f)
+		if err := w.Write(header); err != nil {
+			return fmt.Errorf("failed to write header to %s: %w", p.name, err)
 		}
-		if err := writer.WriteAll(dataRows); err != nil {
-			file.Close()
-			return fmt.Errorf("failed to write rows to %s: %w", filename, err)
+		if err := w.WriteAll(dataRows); err != nil {
+			return fmt.Errorf("failed to write rows to %s: %w", p.name, err)
 		}
-		writer.Flush()
-		if err := writer.Error(); err != nil {
-			file.Close()
-			return fmt.Errorf("failed to flush writer for %s: %w", filename, err)
+		w.Flush()
+		if err := w.Error(); err != nil {
+			return fmt.Errorf("failed to flush writer for %s: %w", p.name, err)
 		}
-		file.Close()
-
-		reopenedFile, err := os.Open(fullPath)
-		if err != nil {
-			return fmt.Errorf("failed to re-open sorted file %s: %w", filename, err)
-		}
-		adapter.files[filename] = reopenedFile
 	}
 
 	return nil

--- a/tlcsv/adapter.go
+++ b/tlcsv/adapter.go
@@ -485,7 +485,7 @@ func (adapter *DirAdapter) SetStandardizedSortOptions(opts adapters.Standardized
 // the captured per-file defaults; nil signals "skip this file".
 func (adapter *DirAdapter) resolveSortColumns(filename string) []*tags.FieldInfo {
 	captured := adapter.sortColumnsByFile[filename]
-	if len(adapter.sortOptions.StandardizedSortColumns) == 0 {
+	if len(adapter.sortOptions.SortColumns) == 0 {
 		return captured
 	}
 	// User-supplied column names still get type-aware sorting if we recognize them.
@@ -493,8 +493,8 @@ func (adapter *DirAdapter) resolveSortColumns(filename string) []*tags.FieldInfo
 	for _, c := range captured {
 		kindByName[c.Name] = c.Kind
 	}
-	out := make([]*tags.FieldInfo, 0, len(adapter.sortOptions.StandardizedSortColumns))
-	for i, name := range adapter.sortOptions.StandardizedSortColumns {
+	out := make([]*tags.FieldInfo, 0, len(adapter.sortOptions.SortColumns))
+	for i, name := range adapter.sortOptions.SortColumns {
 		out = append(out, &tags.FieldInfo{Name: name, Kind: kindByName[name], SortOrder: i + 1})
 	}
 	return out
@@ -513,7 +513,7 @@ func (adapter *DirAdapter) resolveSortColumns(filename string) []*tags.FieldInfo
 // a different code path. Revisit alongside any general resource-limit
 // work, not as a one-off.
 func (adapter *DirAdapter) StandardizedSortCSVFiles() error {
-	sortOrder := adapter.sortOptions.StandardizedSort
+	sortOrder := adapter.sortOptions.ApplySort
 	if sortOrder == "" {
 		return nil
 	}
@@ -577,7 +577,7 @@ func (adapter *DirAdapter) StandardizedSortCSVFiles() error {
 // Close the adapter. Flushes any buffered GeoJSON files before closing.
 func (adapter *DirAdapter) Close() error {
 	// Sort files if requested
-	if adapter.sortOptions.StandardizedSort != "" {
+	if adapter.sortOptions.ApplySort != "" {
 		if err := adapter.StandardizedSortCSVFiles(); err != nil {
 			return err
 		}
@@ -737,7 +737,7 @@ func NewZipWriterAdapter(path string) *ZipWriterAdapter {
 // Close creates a zip archive of all the written files at the specified destination.
 func (adapter *ZipWriterAdapter) Close() error {
 	// Sort files if requested
-	if adapter.sortOptions.StandardizedSort != "" {
+	if adapter.sortOptions.ApplySort != "" {
 		if err := adapter.DirAdapter.StandardizedSortCSVFiles(); err != nil {
 			return err
 		}

--- a/tlcsv/sort.go
+++ b/tlcsv/sort.go
@@ -1,0 +1,99 @@
+package tlcsv
+
+import (
+	"cmp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/interline-io/transitland-lib/internal/tags"
+)
+
+// compareCells compares two raw CSV cells under the given kind. Empty or
+// unparseable values rank as the greatest value (NULLS LAST in asc,
+// NULLS FIRST in desc — the SQL default).
+func compareCells(a, b string, kind tags.SortKind) int {
+	switch kind {
+	case tags.SortKindInt:
+		return compareNumeric(a, b, func(s string) (int64, error) {
+			return strconv.ParseInt(strings.TrimSpace(s), 10, 64)
+		})
+	case tags.SortKindFloat:
+		return compareNumeric(a, b, func(s string) (float64, error) {
+			return strconv.ParseFloat(strings.TrimSpace(s), 64)
+		})
+	case tags.SortKindDate:
+		// GTFS dates are YYYYMMDD; lexicographic compare is correct.
+		return compareEmptyAsGreatest(a, b)
+	default:
+		return strings.Compare(a, b)
+	}
+}
+
+func compareNumeric[T cmp.Ordered](a, b string, parse func(string) (T, error)) int {
+	av, aerr := parse(a)
+	bv, berr := parse(b)
+	switch {
+	case aerr != nil && berr != nil:
+		return 0
+	case aerr != nil:
+		return 1
+	case berr != nil:
+		return -1
+	}
+	return cmp.Compare(av, bv)
+}
+
+// compareEmptyAsGreatest treats empty strings as +∞: last in asc, first in desc.
+func compareEmptyAsGreatest(a, b string) int {
+	switch {
+	case a == "" && b == "":
+		return 0
+	case a == "":
+		return 1
+	case b == "":
+		return -1
+	}
+	return strings.Compare(a, b)
+}
+
+type sortKey struct {
+	idx  int
+	kind tags.SortKind
+}
+
+func resolveHeaderKeys(header []string, cols []*tags.FieldInfo) []sortKey {
+	var keys []sortKey
+	for _, fi := range cols {
+		for i, h := range header {
+			if h == fi.Name {
+				keys = append(keys, sortKey{idx: i, kind: fi.Kind})
+				break
+			}
+		}
+	}
+	return keys
+}
+
+func sortRows(rows [][]string, keys []sortKey, descending bool) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		for _, k := range keys {
+			a, b := "", ""
+			if k.idx < len(rows[i]) {
+				a = rows[i][k.idx]
+			}
+			if k.idx < len(rows[j]) {
+				b = rows[j][k.idx]
+			}
+			c := compareCells(a, b, k.kind)
+			if c == 0 {
+				continue
+			}
+			if descending {
+				return c > 0
+			}
+			return c < 0
+		}
+		return false
+	})
+}

--- a/tlcsv/sort_test.go
+++ b/tlcsv/sort_test.go
@@ -1,0 +1,129 @@
+package tlcsv
+
+import (
+	"encoding/csv"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/interline-io/transitland-lib/adapters"
+)
+
+func TestSortCSVFiles(t *testing.T) {
+	tmpdir, err := os.MkdirTemp("", "sort_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	adapter := NewDirAdapter(tmpdir)
+
+	// Test stops.txt default sort
+	stopsData := [][]string{
+		{"stop_id", "stop_name"},
+		{"S2", "Stop 2"},
+		{"S1", "Stop 1"},
+		{"S3", "Stop 3"},
+	}
+	if err := adapter.WriteRows("stops.txt", stopsData); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test stop_times.txt default sort (complex key)
+	stopTimesData := [][]string{
+		{"trip_id", "stop_sequence", "stop_id"},
+		{"T1", "2", "S2"},
+		{"T1", "1", "S1"},
+		{"T2", "1", "S1"},
+		{"T2", "2", "S2"},
+	}
+	if err := adapter.WriteRows("stop_times.txt", stopTimesData); err != nil {
+		t.Fatal(err)
+	}
+
+	// Apply sort
+	adapter.SetStandardizedSortOptions(adapters.StandardizedSortOptions{StandardizedSort: "asc"})
+	if err := adapter.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify stops.txt
+	verifyFile(t, filepath.Join(tmpdir, "stops.txt"), [][]string{
+		{"stop_id", "stop_name"},
+		{"S1", "Stop 1"},
+		{"S2", "Stop 2"},
+		{"S3", "Stop 3"},
+	})
+
+	// Verify stop_times.txt
+	verifyFile(t, filepath.Join(tmpdir, "stop_times.txt"), [][]string{
+		{"trip_id", "stop_sequence", "stop_id"},
+		{"T1", "1", "S1"},
+		{"T1", "2", "S2"},
+		{"T2", "1", "S1"},
+		{"T2", "2", "S2"},
+	})
+}
+
+func TestCustomColumnSort(t *testing.T) {
+	tmpdir, err := os.MkdirTemp("", "custom_sort_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	adapter := NewDirAdapter(tmpdir)
+
+	// Data with a column we want to sort by
+	data := [][]string{
+		{"id", "val", "custom"},
+		{"1", "A", "3"},
+		{"2", "B", "1"},
+		{"3", "C", "2"},
+	}
+	if err := adapter.WriteRows("custom.txt", data); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter.SetStandardizedSortOptions(adapters.StandardizedSortOptions{
+		StandardizedSort:        "asc",
+		StandardizedSortColumns: []string{"custom"},
+	})
+	if err := adapter.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	verifyFile(t, filepath.Join(tmpdir, "custom.txt"), [][]string{
+		{"id", "val", "custom"},
+		{"2", "B", "1"},
+		{"3", "C", "2"},
+		{"1", "A", "3"},
+	})
+}
+
+func verifyFile(t *testing.T, path string, expected [][]string) {
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	reader := csv.NewReader(f)
+	actual, err := reader.ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(actual) != len(expected) {
+		t.Errorf("expected %d rows, got %d for %s", len(expected), len(actual), path)
+		return
+	}
+
+	for i := range expected {
+		for j := range expected[i] {
+			if actual[i][j] != expected[i][j] {
+				t.Errorf("row %d col %d: expected %s, got %s for %s", i, j, expected[i][j], actual[i][j], path)
+			}
+		}
+	}
+}

--- a/tlcsv/sort_test.go
+++ b/tlcsv/sort_test.go
@@ -7,8 +7,13 @@ import (
 	"testing"
 
 	"github.com/interline-io/transitland-lib/adapters"
+	"github.com/interline-io/transitland-lib/gtfs"
+	"github.com/interline-io/transitland-lib/tt"
 )
 
+// TestSortCSVFiles drives the default-sort path through the typed Writer so
+// that sort metadata is captured at header-generation time, exercising the
+// real end-to-end flow.
 func TestSortCSVFiles(t *testing.T) {
 	tmpdir, err := os.MkdirTemp("", "sort_test")
 	if err != nil {
@@ -16,55 +21,120 @@ func TestSortCSVFiles(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 
-	adapter := NewDirAdapter(tmpdir)
-
-	// Test stops.txt default sort
-	stopsData := [][]string{
-		{"stop_id", "stop_name"},
-		{"S2", "Stop 2"},
-		{"S1", "Stop 1"},
-		{"S3", "Stop 3"},
+	w, err := NewWriter(tmpdir)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if err := adapter.WriteRows("stops.txt", stopsData); err != nil {
+	for _, s := range []string{"S2", "S1", "S3"} {
+		if _, err := w.AddEntity(&gtfs.Stop{StopID: tt.NewString(s)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Multi-digit sequences exercise numeric sort: "10" must sort after "2".
+	stopTimes := []struct {
+		trip string
+		seq  int
+	}{
+		{"T1", 2}, {"T1", 10}, {"T1", 1}, {"T2", 1}, {"T2", 2},
+	}
+	for _, st := range stopTimes {
+		ent := &gtfs.StopTime{TripID: tt.NewString(st.trip), StopSequence: tt.NewInt(st.seq)}
+		if _, err := w.AddEntity(ent); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	w.SetStandardizedSortOptions(adapters.StandardizedSortOptions{StandardizedSort: "asc"})
+	if err := w.Close(); err != nil {
 		t.Fatal(err)
 	}
 
-	// Test stop_times.txt default sort (complex key)
-	stopTimesData := [][]string{
-		{"trip_id", "stop_sequence", "stop_id"},
-		{"T1", "2", "S2"},
-		{"T1", "1", "S1"},
-		{"T2", "1", "S1"},
-		{"T2", "2", "S2"},
-	}
-	if err := adapter.WriteRows("stop_times.txt", stopTimesData); err != nil {
-		t.Fatal(err)
-	}
-
-	// Apply sort
-	adapter.SetStandardizedSortOptions(adapters.StandardizedSortOptions{StandardizedSort: "asc"})
-	if err := adapter.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Verify stops.txt
-	verifyFile(t, filepath.Join(tmpdir, "stops.txt"), [][]string{
-		{"stop_id", "stop_name"},
-		{"S1", "Stop 1"},
-		{"S2", "Stop 2"},
-		{"S3", "Stop 3"},
-	})
-
-	// Verify stop_times.txt
-	verifyFile(t, filepath.Join(tmpdir, "stop_times.txt"), [][]string{
-		{"trip_id", "stop_sequence", "stop_id"},
-		{"T1", "1", "S1"},
-		{"T1", "2", "S2"},
-		{"T2", "1", "S1"},
-		{"T2", "2", "S2"},
-	})
+	verifyColumn(t, filepath.Join(tmpdir, "stops.txt"), "stop_id", []string{"S1", "S2", "S3"})
+	// stop_times sorts by (trip_id asc, stop_sequence asc) with stop_sequence
+	// compared as int — so 10 sorts after 2 within trip T1.
+	verifyColumns(t, filepath.Join(tmpdir, "stop_times.txt"),
+		[]string{"trip_id", "stop_sequence"},
+		[][]string{
+			{"T1", "1"},
+			{"T1", "2"},
+			{"T1", "10"},
+			{"T2", "1"},
+			{"T2", "2"},
+		})
 }
 
+func TestSortCSVFilesDescending(t *testing.T) {
+	tmpdir, err := os.MkdirTemp("", "sort_desc_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	w, err := NewWriter(tmpdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range []string{"S2", "S1", "S3"} {
+		if _, err := w.AddEntity(&gtfs.Stop{StopID: tt.NewString(s)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	w.SetStandardizedSortOptions(adapters.StandardizedSortOptions{StandardizedSort: "desc"})
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	verifyColumn(t, filepath.Join(tmpdir, "stops.txt"), "stop_id", []string{"S3", "S2", "S1"})
+}
+
+// TestSortCSVFilesEmptyNumericLast verifies that for numeric sort columns,
+// empty/unparseable cells sort after valid values regardless of direction.
+func TestSortCSVFilesEmptyNumericLast(t *testing.T) {
+	tmpdir, err := os.MkdirTemp("", "sort_empty_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	w, err := NewWriter(tmpdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Two stop_times have a missing stop_sequence (zero value with !Valid
+	// renders as empty in CSV), one has a value.
+	stopTimes := []*gtfs.StopTime{
+		{TripID: tt.NewString("T1"), StopSequence: tt.NewInt(5)},
+		{TripID: tt.NewString("T1")}, // empty stop_sequence
+		{TripID: tt.NewString("T1"), StopSequence: tt.NewInt(2)},
+		{TripID: tt.NewString("T1")}, // empty stop_sequence
+	}
+	for _, st := range stopTimes {
+		if _, err := w.AddEntity(st); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	w.SetStandardizedSortOptions(adapters.StandardizedSortOptions{StandardizedSort: "asc"})
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Expect: 2, 5, then the two empties.
+	got := readColumn(t, filepath.Join(tmpdir, "stop_times.txt"), "stop_sequence")
+	want := []string{"2", "5", "", ""}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d rows, got %d (%v)", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("row %d: expected %q, got %q (full: %v)", i, want[i], got[i], got)
+		}
+	}
+}
+
+// TestCustomColumnSort exercises the user-supplied StandardizedSortColumns
+// override path, which works on any file regardless of whether the writer
+// captured metadata for it.
 func TestCustomColumnSort(t *testing.T) {
 	tmpdir, err := os.MkdirTemp("", "custom_sort_test")
 	if err != nil {
@@ -74,7 +144,6 @@ func TestCustomColumnSort(t *testing.T) {
 
 	adapter := NewDirAdapter(tmpdir)
 
-	// Data with a column we want to sort by
 	data := [][]string{
 		{"id", "val", "custom"},
 		{"1", "A", "3"},
@@ -101,7 +170,37 @@ func TestCustomColumnSort(t *testing.T) {
 	})
 }
 
+// TestSortCSVFilesSkipsUnknownFiles confirms that a file written via raw
+// WriteRows (without going through the typed Writer) is left untouched by
+// the sort step when no user override is supplied.
+func TestSortCSVFilesSkipsUnknownFiles(t *testing.T) {
+	tmpdir, err := os.MkdirTemp("", "sort_skip_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpdir)
+
+	adapter := NewDirAdapter(tmpdir)
+	original := [][]string{
+		{"id", "val"},
+		{"3", "C"},
+		{"1", "A"},
+		{"2", "B"},
+	}
+	if err := adapter.WriteRows("unknown.txt", original); err != nil {
+		t.Fatal(err)
+	}
+	adapter.SetStandardizedSortOptions(adapters.StandardizedSortOptions{StandardizedSort: "asc"})
+	if err := adapter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	verifyFile(t, filepath.Join(tmpdir, "unknown.txt"), original)
+}
+
+// helpers ---
+
 func verifyFile(t *testing.T, path string, expected [][]string) {
+	t.Helper()
 	f, err := os.Open(path)
 	if err != nil {
 		t.Fatal(err)
@@ -118,11 +217,96 @@ func verifyFile(t *testing.T, path string, expected [][]string) {
 		t.Errorf("expected %d rows, got %d for %s", len(expected), len(actual), path)
 		return
 	}
-
 	for i := range expected {
 		for j := range expected[i] {
 			if actual[i][j] != expected[i][j] {
 				t.Errorf("row %d col %d: expected %s, got %s for %s", i, j, expected[i][j], actual[i][j], path)
+			}
+		}
+	}
+}
+
+func readAll(t *testing.T, path string) [][]string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	rows, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rows
+}
+
+func readColumn(t *testing.T, path, name string) []string {
+	t.Helper()
+	rows := readAll(t, path)
+	if len(rows) == 0 {
+		return nil
+	}
+	idx := -1
+	for i, h := range rows[0] {
+		if h == name {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		t.Fatalf("column %q not found in %s (header: %v)", name, path, rows[0])
+	}
+	out := make([]string, 0, len(rows)-1)
+	for _, r := range rows[1:] {
+		if idx < len(r) {
+			out = append(out, r[idx])
+		} else {
+			out = append(out, "")
+		}
+	}
+	return out
+}
+
+func verifyColumn(t *testing.T, path, name string, want []string) {
+	t.Helper()
+	got := readColumn(t, path, name)
+	if len(got) != len(want) {
+		t.Fatalf("%s: expected %d rows in column %q, got %d (%v)", path, len(want), name, len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("%s column %q row %d: expected %q, got %q (full: %v)", path, name, i, want[i], got[i], got)
+		}
+	}
+}
+
+func verifyColumns(t *testing.T, path string, names []string, want [][]string) {
+	t.Helper()
+	rows := readAll(t, path)
+	if len(rows) == 0 {
+		t.Fatalf("%s: no rows", path)
+	}
+	header := rows[0]
+	idxs := make([]int, len(names))
+	for k, n := range names {
+		idxs[k] = -1
+		for i, h := range header {
+			if h == n {
+				idxs[k] = i
+				break
+			}
+		}
+		if idxs[k] == -1 {
+			t.Fatalf("column %q not found in %s", n, path)
+		}
+	}
+	if len(rows)-1 != len(want) {
+		t.Fatalf("%s: expected %d data rows, got %d", path, len(want), len(rows)-1)
+	}
+	for i := range want {
+		for k, idx := range idxs {
+			if rows[i+1][idx] != want[i][k] {
+				t.Errorf("%s row %d col %s: expected %q, got %q", path, i, names[k], want[i][k], rows[i+1][idx])
 			}
 		}
 	}

--- a/tlcsv/sort_test.go
+++ b/tlcsv/sort_test.go
@@ -36,7 +36,7 @@ func TestSortCSVFiles(t *testing.T) {
 		}
 	}
 
-	w.SetStandardizedSortOptions(adapters.StandardizedSortOptions{StandardizedSort: adapters.SortAsc})
+	w.SetStandardizedSortOptions(adapters.StandardizedSortOptions{ApplySort: adapters.SortAsc})
 	if err := w.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +66,7 @@ func TestSortCSVFilesDescending(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	w.SetStandardizedSortOptions(adapters.StandardizedSortOptions{StandardizedSort: adapters.SortDesc})
+	w.SetStandardizedSortOptions(adapters.StandardizedSortOptions{ApplySort: adapters.SortDesc})
 	if err := w.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestSortCSVFilesEmptyNumericSqlConvention(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		w.SetStandardizedSortOptions(adapters.StandardizedSortOptions{StandardizedSort: direction})
+		w.SetStandardizedSortOptions(adapters.StandardizedSortOptions{ApplySort: direction})
 		if err := w.Close(); err != nil {
 			t.Fatal(err)
 		}
@@ -125,8 +125,8 @@ func TestCustomColumnSort(t *testing.T) {
 		t.Fatal(err)
 	}
 	adapter.SetStandardizedSortOptions(adapters.StandardizedSortOptions{
-		StandardizedSort:        adapters.SortAsc,
-		StandardizedSortColumns: []string{"custom"},
+		ApplySort:   adapters.SortAsc,
+		SortColumns: []string{"custom"},
 	})
 	if err := adapter.Close(); err != nil {
 		t.Fatal(err)
@@ -152,7 +152,7 @@ func TestSortCSVFilesSkipsUnknownFiles(t *testing.T) {
 	if err := adapter.WriteRows("unknown.txt", original); err != nil {
 		t.Fatal(err)
 	}
-	adapter.SetStandardizedSortOptions(adapters.StandardizedSortOptions{StandardizedSort: adapters.SortAsc})
+	adapter.SetStandardizedSortOptions(adapters.StandardizedSortOptions{ApplySort: adapters.SortAsc})
 	if err := adapter.Close(); err != nil {
 		t.Fatal(err)
 	}

--- a/tlcsv/sort_test.go
+++ b/tlcsv/sort_test.go
@@ -11,16 +11,8 @@ import (
 	"github.com/interline-io/transitland-lib/tt"
 )
 
-// TestSortCSVFiles drives the default-sort path through the typed Writer so
-// that sort metadata is captured at header-generation time, exercising the
-// real end-to-end flow.
 func TestSortCSVFiles(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "sort_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
-
+	tmpdir := t.TempDir()
 	w, err := NewWriter(tmpdir)
 	if err != nil {
 		t.Fatal(err)
@@ -44,14 +36,14 @@ func TestSortCSVFiles(t *testing.T) {
 		}
 	}
 
-	w.SetStandardizedSortOptions(adapters.StandardizedSortOptions{StandardizedSort: "asc"})
+	w.SetStandardizedSortOptions(adapters.StandardizedSortOptions{StandardizedSort: adapters.SortAsc})
 	if err := w.Close(); err != nil {
 		t.Fatal(err)
 	}
 
-	verifyColumn(t, filepath.Join(tmpdir, "stops.txt"), "stop_id", []string{"S1", "S2", "S3"})
-	// stop_times sorts by (trip_id asc, stop_sequence asc) with stop_sequence
-	// compared as int — so 10 sorts after 2 within trip T1.
+	verifyColumns(t, filepath.Join(tmpdir, "stops.txt"),
+		[]string{"stop_id"},
+		[][]string{{"S1"}, {"S2"}, {"S3"}})
 	verifyColumns(t, filepath.Join(tmpdir, "stop_times.txt"),
 		[]string{"trip_id", "stop_sequence"},
 		[][]string{
@@ -64,12 +56,7 @@ func TestSortCSVFiles(t *testing.T) {
 }
 
 func TestSortCSVFilesDescending(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "sort_desc_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
-
+	tmpdir := t.TempDir()
 	w, err := NewWriter(tmpdir)
 	if err != nil {
 		t.Fatal(err)
@@ -79,29 +66,23 @@ func TestSortCSVFilesDescending(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	w.SetStandardizedSortOptions(adapters.StandardizedSortOptions{StandardizedSort: "desc"})
+	w.SetStandardizedSortOptions(adapters.StandardizedSortOptions{StandardizedSort: adapters.SortDesc})
 	if err := w.Close(); err != nil {
 		t.Fatal(err)
 	}
-
-	verifyColumn(t, filepath.Join(tmpdir, "stops.txt"), "stop_id", []string{"S3", "S2", "S1"})
+	verifyColumns(t, filepath.Join(tmpdir, "stops.txt"),
+		[]string{"stop_id"},
+		[][]string{{"S3"}, {"S2"}, {"S1"}})
 }
 
-// TestSortCSVFilesEmptyNumericLast verifies that for numeric sort columns,
-// empty/unparseable cells sort after valid values regardless of direction.
+// Empty/unparseable cells must sort after valid values when the column kind
+// is numeric, regardless of sort direction.
 func TestSortCSVFilesEmptyNumericLast(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "sort_empty_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
-
+	tmpdir := t.TempDir()
 	w, err := NewWriter(tmpdir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Two stop_times have a missing stop_sequence (zero value with !Valid
-	// renders as empty in CSV), one has a value.
 	stopTimes := []*gtfs.StopTime{
 		{TripID: tt.NewString("T1"), StopSequence: tt.NewInt(5)},
 		{TripID: tt.NewString("T1")}, // empty stop_sequence
@@ -114,36 +95,21 @@ func TestSortCSVFilesEmptyNumericLast(t *testing.T) {
 		}
 	}
 
-	w.SetStandardizedSortOptions(adapters.StandardizedSortOptions{StandardizedSort: "asc"})
+	w.SetStandardizedSortOptions(adapters.StandardizedSortOptions{StandardizedSort: adapters.SortAsc})
 	if err := w.Close(); err != nil {
 		t.Fatal(err)
 	}
 
-	// Expect: 2, 5, then the two empties.
-	got := readColumn(t, filepath.Join(tmpdir, "stop_times.txt"), "stop_sequence")
-	want := []string{"2", "5", "", ""}
-	if len(got) != len(want) {
-		t.Fatalf("expected %d rows, got %d (%v)", len(want), len(got), got)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("row %d: expected %q, got %q (full: %v)", i, want[i], got[i], got)
-		}
-	}
+	verifyColumns(t, filepath.Join(tmpdir, "stop_times.txt"),
+		[]string{"stop_sequence"},
+		[][]string{{"2"}, {"5"}, {""}, {""}})
 }
 
-// TestCustomColumnSort exercises the user-supplied StandardizedSortColumns
-// override path, which works on any file regardless of whether the writer
-// captured metadata for it.
+// User-supplied StandardizedSortColumns work on any file even without
+// captured entity metadata.
 func TestCustomColumnSort(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "custom_sort_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
-
+	tmpdir := t.TempDir()
 	adapter := NewDirAdapter(tmpdir)
-
 	data := [][]string{
 		{"id", "val", "custom"},
 		{"1", "A", "3"},
@@ -153,16 +119,14 @@ func TestCustomColumnSort(t *testing.T) {
 	if err := adapter.WriteRows("custom.txt", data); err != nil {
 		t.Fatal(err)
 	}
-
 	adapter.SetStandardizedSortOptions(adapters.StandardizedSortOptions{
-		StandardizedSort:        "asc",
+		StandardizedSort:        adapters.SortAsc,
 		StandardizedSortColumns: []string{"custom"},
 	})
 	if err := adapter.Close(); err != nil {
 		t.Fatal(err)
 	}
-
-	verifyFile(t, filepath.Join(tmpdir, "custom.txt"), [][]string{
+	verifyAllRows(t, filepath.Join(tmpdir, "custom.txt"), [][]string{
 		{"id", "val", "custom"},
 		{"2", "B", "1"},
 		{"3", "C", "2"},
@@ -170,16 +134,10 @@ func TestCustomColumnSort(t *testing.T) {
 	})
 }
 
-// TestSortCSVFilesSkipsUnknownFiles confirms that a file written via raw
-// WriteRows (without going through the typed Writer) is left untouched by
-// the sort step when no user override is supplied.
+// Files written outside the typed Writer path are left alone when no user
+// override is supplied.
 func TestSortCSVFilesSkipsUnknownFiles(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "sort_skip_test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
-
+	tmpdir := t.TempDir()
 	adapter := NewDirAdapter(tmpdir)
 	original := [][]string{
 		{"id", "val"},
@@ -190,41 +148,14 @@ func TestSortCSVFilesSkipsUnknownFiles(t *testing.T) {
 	if err := adapter.WriteRows("unknown.txt", original); err != nil {
 		t.Fatal(err)
 	}
-	adapter.SetStandardizedSortOptions(adapters.StandardizedSortOptions{StandardizedSort: "asc"})
+	adapter.SetStandardizedSortOptions(adapters.StandardizedSortOptions{StandardizedSort: adapters.SortAsc})
 	if err := adapter.Close(); err != nil {
 		t.Fatal(err)
 	}
-	verifyFile(t, filepath.Join(tmpdir, "unknown.txt"), original)
+	verifyAllRows(t, filepath.Join(tmpdir, "unknown.txt"), original)
 }
 
-// helpers ---
-
-func verifyFile(t *testing.T, path string, expected [][]string) {
-	t.Helper()
-	f, err := os.Open(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer f.Close()
-
-	reader := csv.NewReader(f)
-	actual, err := reader.ReadAll()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(actual) != len(expected) {
-		t.Errorf("expected %d rows, got %d for %s", len(expected), len(actual), path)
-		return
-	}
-	for i := range expected {
-		for j := range expected[i] {
-			if actual[i][j] != expected[i][j] {
-				t.Errorf("row %d col %d: expected %s, got %s for %s", i, j, expected[i][j], actual[i][j], path)
-			}
-		}
-	}
-}
+// helpers
 
 func readAll(t *testing.T, path string) [][]string {
 	t.Helper()
@@ -240,46 +171,27 @@ func readAll(t *testing.T, path string) [][]string {
 	return rows
 }
 
-func readColumn(t *testing.T, path, name string) []string {
+func verifyAllRows(t *testing.T, path string, want [][]string) {
 	t.Helper()
-	rows := readAll(t, path)
-	if len(rows) == 0 {
-		return nil
-	}
-	idx := -1
-	for i, h := range rows[0] {
-		if h == name {
-			idx = i
-			break
-		}
-	}
-	if idx == -1 {
-		t.Fatalf("column %q not found in %s (header: %v)", name, path, rows[0])
-	}
-	out := make([]string, 0, len(rows)-1)
-	for _, r := range rows[1:] {
-		if idx < len(r) {
-			out = append(out, r[idx])
-		} else {
-			out = append(out, "")
-		}
-	}
-	return out
-}
-
-func verifyColumn(t *testing.T, path, name string, want []string) {
-	t.Helper()
-	got := readColumn(t, path, name)
+	got := readAll(t, path)
 	if len(got) != len(want) {
-		t.Fatalf("%s: expected %d rows in column %q, got %d (%v)", path, len(want), name, len(got), got)
+		t.Fatalf("%s: expected %d rows, got %d", path, len(want), len(got))
 	}
 	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("%s column %q row %d: expected %q, got %q (full: %v)", path, name, i, want[i], got[i], got)
+		if len(got[i]) != len(want[i]) {
+			t.Errorf("%s row %d: expected %d cols, got %d", path, i, len(want[i]), len(got[i]))
+			continue
+		}
+		for j := range want[i] {
+			if got[i][j] != want[i][j] {
+				t.Errorf("%s row %d col %d: expected %q, got %q", path, i, j, want[i][j], got[i][j])
+			}
 		}
 	}
 }
 
+// verifyColumns checks the values of a subset of columns, identified by
+// header name, against expected values for each data row.
 func verifyColumns(t *testing.T, path string, names []string, want [][]string) {
 	t.Helper()
 	rows := readAll(t, path)
@@ -305,8 +217,12 @@ func verifyColumns(t *testing.T, path string, names []string, want [][]string) {
 	}
 	for i := range want {
 		for k, idx := range idxs {
-			if rows[i+1][idx] != want[i][k] {
-				t.Errorf("%s row %d col %s: expected %q, got %q", path, i, names[k], want[i][k], rows[i+1][idx])
+			cell := ""
+			if idx < len(rows[i+1]) {
+				cell = rows[i+1][idx]
+			}
+			if cell != want[i][k] {
+				t.Errorf("%s row %d col %s: expected %q, got %q", path, i, names[k], want[i][k], cell)
 			}
 		}
 	}

--- a/tlcsv/sort_test.go
+++ b/tlcsv/sort_test.go
@@ -75,38 +75,43 @@ func TestSortCSVFilesDescending(t *testing.T) {
 		[][]string{{"S3"}, {"S2"}, {"S1"}})
 }
 
-// Empty/unparseable cells must sort after valid values when the column kind
-// is numeric, regardless of sort direction.
-func TestSortCSVFilesEmptyNumericLast(t *testing.T) {
-	tmpdir := t.TempDir()
-	w, err := NewWriter(tmpdir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	stopTimes := []*gtfs.StopTime{
-		{TripID: tt.NewString("T1"), StopSequence: tt.NewInt(5)},
-		{TripID: tt.NewString("T1")}, // empty stop_sequence
-		{TripID: tt.NewString("T1"), StopSequence: tt.NewInt(2)},
-		{TripID: tt.NewString("T1")}, // empty stop_sequence
-	}
-	for _, st := range stopTimes {
-		if _, err := w.AddEntity(st); err != nil {
-			t.Fatal(err)
+// Empty cells in numeric columns rank as +∞: NULLS LAST in asc, NULLS FIRST in desc.
+func TestSortCSVFilesEmptyNumericSqlConvention(t *testing.T) {
+	stopTimes := func() []*gtfs.StopTime {
+		return []*gtfs.StopTime{
+			{TripID: tt.NewString("T1"), StopSequence: tt.NewInt(5)},
+			{TripID: tt.NewString("T1")}, // empty stop_sequence
+			{TripID: tt.NewString("T1"), StopSequence: tt.NewInt(2)},
+			{TripID: tt.NewString("T1")}, // empty stop_sequence
 		}
 	}
-
-	w.SetStandardizedSortOptions(adapters.StandardizedSortOptions{StandardizedSort: adapters.SortAsc})
-	if err := w.Close(); err != nil {
-		t.Fatal(err)
+	run := func(t *testing.T, direction string, want [][]string) {
+		dir := t.TempDir()
+		w, err := NewWriter(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, st := range stopTimes() {
+			if _, err := w.AddEntity(st); err != nil {
+				t.Fatal(err)
+			}
+		}
+		w.SetStandardizedSortOptions(adapters.StandardizedSortOptions{StandardizedSort: direction})
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		verifyColumns(t, filepath.Join(dir, "stop_times.txt"), []string{"stop_sequence"}, want)
 	}
 
-	verifyColumns(t, filepath.Join(tmpdir, "stop_times.txt"),
-		[]string{"stop_sequence"},
-		[][]string{{"2"}, {"5"}, {""}, {""}})
+	t.Run("asc puts empties last", func(t *testing.T) {
+		run(t, adapters.SortAsc, [][]string{{"2"}, {"5"}, {""}, {""}})
+	})
+	t.Run("desc puts empties first", func(t *testing.T) {
+		run(t, adapters.SortDesc, [][]string{{""}, {""}, {"5"}, {"2"}})
+	})
 }
 
-// User-supplied StandardizedSortColumns work on any file even without
-// captured entity metadata.
+// User-supplied columns work on files without captured entity metadata.
 func TestCustomColumnSort(t *testing.T) {
 	tmpdir := t.TempDir()
 	adapter := NewDirAdapter(tmpdir)
@@ -134,8 +139,7 @@ func TestCustomColumnSort(t *testing.T) {
 	})
 }
 
-// Files written outside the typed Writer path are left alone when no user
-// override is supplied.
+// Files written outside the typed Writer path are left alone without an override.
 func TestSortCSVFilesSkipsUnknownFiles(t *testing.T) {
 	tmpdir := t.TempDir()
 	adapter := NewDirAdapter(tmpdir)
@@ -190,8 +194,7 @@ func verifyAllRows(t *testing.T, path string, want [][]string) {
 	}
 }
 
-// verifyColumns checks the values of a subset of columns, identified by
-// header name, against expected values for each data row.
+// verifyColumns checks values for a subset of columns by header name.
 func verifyColumns(t *testing.T, path string, names []string, want [][]string) {
 	t.Helper()
 	rows := readAll(t, path)

--- a/tlcsv/writer.go
+++ b/tlcsv/writer.go
@@ -218,6 +218,12 @@ func (writer *Writer) addBatchGeoJSON(ents []tt.Entity, filename string) ([]stri
 	return eids, nil
 }
 
+func (writer *Writer) SetStandardizedSortOptions(opts adapters.StandardizedSortOptions) {
+	if s, ok := writer.WriterAdapter.(adapters.WriterWithStandardizedSort); ok {
+		s.SetStandardizedSortOptions(opts)
+	}
+}
+
 type canFlatten interface {
 	Flatten() []tt.Entity
 }

--- a/tlcsv/writer.go
+++ b/tlcsv/writer.go
@@ -224,10 +224,7 @@ func (writer *Writer) addBatchGeoJSON(ents []tt.Entity, filename string) ([]stri
 }
 
 func (writer *Writer) SetStandardizedSortOptions(opts adapters.StandardizedSortOptions) {
-	type setter interface {
-		SetStandardizedSortOptions(adapters.StandardizedSortOptions)
-	}
-	if s, ok := writer.WriterAdapter.(setter); ok {
+	if s, ok := writer.WriterAdapter.(adapters.SortableWriter); ok {
 		s.SetStandardizedSortOptions(opts)
 	}
 }

--- a/tlcsv/writer.go
+++ b/tlcsv/writer.go
@@ -2,6 +2,7 @@ package tlcsv
 
 import (
 	"errors"
+	"sort"
 	"strings"
 
 	"github.com/interline-io/transitland-lib/adapters"
@@ -147,6 +148,23 @@ func (writer *Writer) addBatch(ents []tt.Entity) ([]string, error) {
 		h2 := append([]string{}, header...)
 		h2 = append(h2, extraHeader...)
 		writer.WriterAdapter.WriteRows(efn, [][]string{h2})
+		// Capture sort columns + their underlying type kind from the
+		// entity's struct tags. Used by the adapter's sort step (if
+		// enabled) to drive type-aware comparisons. Files written
+		// without a registered entity simply won't be sorted.
+		if reg, ok3 := writer.WriterAdapter.(sortColumnRegistrar); ok3 {
+			fmap := MapperCache.GetStructTagMap(ent)
+			var cols []sortColumn
+			for name, info := range fmap {
+				if info.SortOrder > 0 {
+					cols = append(cols, sortColumn{Name: name, Kind: info.Kind, Order: info.SortOrder})
+				}
+			}
+			sort.Slice(cols, func(i, j int) bool { return cols[i].Order < cols[j].Order })
+			if len(cols) > 0 {
+				reg.registerSortColumns(efn, cols)
+			}
+		}
 	}
 	rows := [][]string{}
 	for _, ent := range ents {
@@ -219,7 +237,10 @@ func (writer *Writer) addBatchGeoJSON(ents []tt.Entity, filename string) ([]stri
 }
 
 func (writer *Writer) SetStandardizedSortOptions(opts adapters.StandardizedSortOptions) {
-	if s, ok := writer.WriterAdapter.(adapters.WriterWithStandardizedSort); ok {
+	type setter interface {
+		SetStandardizedSortOptions(adapters.StandardizedSortOptions)
+	}
+	if s, ok := writer.WriterAdapter.(setter); ok {
 		s.SetStandardizedSortOptions(opts)
 	}
 }

--- a/tlcsv/writer.go
+++ b/tlcsv/writer.go
@@ -2,7 +2,6 @@ package tlcsv
 
 import (
 	"errors"
-	"sort"
 	"strings"
 
 	"github.com/interline-io/transitland-lib/adapters"
@@ -148,20 +147,8 @@ func (writer *Writer) addBatch(ents []tt.Entity) ([]string, error) {
 		h2 := append([]string{}, header...)
 		h2 = append(h2, extraHeader...)
 		writer.WriterAdapter.WriteRows(efn, [][]string{h2})
-		// Capture sort columns + their underlying type kind from the
-		// entity's struct tags. Used by the adapter's sort step (if
-		// enabled) to drive type-aware comparisons. Files written
-		// without a registered entity simply won't be sorted.
 		if reg, ok3 := writer.WriterAdapter.(sortColumnRegistrar); ok3 {
-			fmap := MapperCache.GetStructTagMap(ent)
-			var cols []sortColumn
-			for name, info := range fmap {
-				if info.SortOrder > 0 {
-					cols = append(cols, sortColumn{Name: name, Kind: info.Kind, Order: info.SortOrder})
-				}
-			}
-			sort.Slice(cols, func(i, j int) bool { return cols[i].Order < cols[j].Order })
-			if len(cols) > 0 {
+			if cols := MapperCache.GetSortColumns(ent); len(cols) > 0 {
 				reg.registerSortColumns(efn, cols)
 			}
 		}

--- a/tlcsv/writer.go
+++ b/tlcsv/writer.go
@@ -147,7 +147,7 @@ func (writer *Writer) addBatch(ents []tt.Entity) ([]string, error) {
 		h2 := append([]string{}, header...)
 		h2 = append(h2, extraHeader...)
 		writer.WriterAdapter.WriteRows(efn, [][]string{h2})
-		if reg, ok3 := writer.WriterAdapter.(sortColumnRegistrar); ok3 {
+		if reg, okSortReg := writer.WriterAdapter.(sortColumnRegistrar); okSortReg {
 			if cols := MapperCache.GetSortColumns(ent); len(cols) > 0 {
 				reg.registerSortColumns(efn, cols)
 			}

--- a/tt/option.go
+++ b/tt/option.go
@@ -3,6 +3,7 @@ package tt
 import (
 	"database/sql/driver"
 	"encoding/json"
+	"reflect"
 )
 
 type Option[T any] struct {
@@ -12,6 +13,13 @@ type Option[T any] struct {
 
 func NewOption[T any](v T) Option[T] {
 	return Option[T]{Val: v, Valid: true}
+}
+
+// OptionType returns the reflect.Type of the wrapped value (T), exposing
+// the inner type to reflection-based callers without leaking struct layout.
+func (Option[T]) OptionType() reflect.Type {
+	var zero T
+	return reflect.TypeOf(zero)
 }
 
 func (r Option[T]) IsValid() bool {


### PR DESCRIPTION
## Summary

Adds an opt-in standardized sort to the export endpoint and the `copy` CLI. When enabled, every CSV file in the output zip is sorted by its declared primary keys before being archived. Default behavior is unchanged — output preserves copier order modulo associations like parent-before-child stops.

## Usage

**CLI**
```
transitland copy --standardized-sort=asc input.zip output.zip
transitland copy --standardized-sort=desc --standardized-sort-columns=route_id,trip_id input.zip output.zip
```

**REST** (`POST /feed_versions/export`)
```json
{
  "feed_version_keys": ["..."],
  "transforms": {
    "standardized_sort": "asc",
    "standardized_sort_columns": ["route_id", "trip_id"]
  }
}
```

`standardized_sort` accepts `"asc"` or `"desc"`; omit for no sort. `standardized_sort_columns` overrides the per-file defaults.

## How sort columns are declared

GTFS entities tag their primary-key fields with `standardized_sort:"N"`, where N is the priority (1 = highest):

```go
type StopTime struct {
    TripID       tt.String `csv:",required" target:"trips.txt" standardized_sort:"1"`
    StopID       tt.Key    `target:"stops.txt"`
    StopSequence tt.Int    `csv:",required" standardized_sort:"2"`
    ...
}
```

Sort is type-aware: `stop_sequence=10` sorts after `stop_sequence=2` (numeric), not before (lex). Empty cells in numeric/date columns rank as the greatest value (NULLS LAST in asc, NULLS FIRST in desc — SQL convention). Type inference walks through `tt.Option[T]` via the new `OptionType()` method.

## Caveats

- **Memory:** sorting reads each file fully into memory, sorts in place, then truncates and rewrites. Documented with a TODO at `tlcsv/adapter.go`. For multi-million-row stop_times.txt this can use significant RSS. Acceptable for an opt-in feature; revisit alongside any general resource-limit work.
- **Order of associations is still respected** by the copier itself — the sort runs at writer-close time on already-written files.

## Also in this PR

- Fixes a swallowed-error bug in `ZipWriterAdapter.Close` where a failed `os.Create` returned `nil` instead of the error.

## Test plan

- [x] `go test ./tlcsv/...` — covers ascending, descending, multi-digit numeric sort, NULLS handling, custom columns, and untagged-file passthrough.
- [x] `go test ./server/rest/...` — covers REST integration in both directions, the explicit unsorted-default assertion (Caltrain's natural non-alphabetical route order), and bad-input rejection.
- [x] `go test ./internal/tags/... ./gtfs/... ./adapters/...` — green.
- [ ] Manual CLI sanity check with a real feed.