### PR TITLE
Start design for vehicle positions subscriptions api

### DIFF
--- a/cmd/rt-test-server/main.go
+++ b/cmd/rt-test-server/main.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	ilog "github.com/interline-io/log"
+	"github.com/interline-io/transitland-lib/rt/pb"
+	"github.com/interline-io/transitland-lib/server/dbutil"
+	"github.com/interline-io/transitland-lib/server/finders/dbfinder"
+	"github.com/interline-io/transitland-lib/server/finders/rtfinder"
+	"github.com/interline-io/transitland-lib/server/model"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	_ "github.com/interline-io/transitland-lib/tldb/postgres"
+)
+
+// Oakland center
+const (
+	centerLat = 37.8044
+	centerLon = -122.2712
+	radiusDeg = 0.02 // ~2km
+)
+
+func main() {
+	port := flag.String("port", "8888", "HTTP port for test RT server")
+	dbURL := flag.String("dburl", "", "Database URL (default: $TL_DATABASE_URL)")
+	redisURL := flag.String("redisurl", "", "Redis URL (default: $TL_REDIS_URL)")
+	fetchInterval := flag.Int("fetch-interval", 10, "Fetch RT feeds every N seconds")
+	flag.Parse()
+
+	if *dbURL == "" {
+		*dbURL = os.Getenv("TL_DATABASE_URL")
+	}
+	if *redisURL == "" {
+		*redisURL = os.Getenv("TL_REDIS_URL")
+	}
+
+	ctx := context.Background()
+
+	// Start RT fetch loop if DB and Redis are configured
+	if *dbURL != "" && *redisURL != "" {
+		db, err := dbutil.OpenDB(*dbURL)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error opening database: %s\n", err)
+			os.Exit(1)
+		}
+		redisClient, err := dbutil.OpenRedis(*redisURL)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error opening redis: %s\n", err)
+			os.Exit(1)
+		}
+		finder := dbfinder.NewFinder(db)
+		cache := rtfinder.NewRedisCache(redisClient)
+		interval := time.Duration(*fetchInterval) * time.Second
+		go rtFetchLoop(ctx, finder, cache, interval)
+	} else {
+		fmt.Println("Note: --dburl and --redisurl not set, fetch loop disabled")
+	}
+
+	// Serve test RT data
+	http.HandleFunc("/vehicle_positions.pb", handleVehiclePositions)
+	fmt.Printf("RT test server listening on :%s\n", *port)
+	fmt.Println("  GET /vehicle_positions.pb")
+	fmt.Println("  Optional query param: ?time=<unix_timestamp>")
+	fmt.Println("  Set Accept: application/json for JSON output")
+	if err := http.ListenAndServe(":"+*port, nil); err != nil {
+		fmt.Printf("error: %s\n", err)
+	}
+}
+
+// RT fetch loop — queries DB for RT feeds and pushes data to Redis
+
+func rtFetchLoop(ctx context.Context, finder *dbfinder.Finder, cache *rtfinder.RedisCache, interval time.Duration) {
+	ilog.For(ctx).Info().Msgf("RT fetch: starting background fetcher every %s", interval)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	rtFetchAll(ctx, finder, cache)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			rtFetchAll(ctx, finder, cache)
+		}
+	}
+}
+
+func rtFetchAll(ctx context.Context, finder *dbfinder.Finder, cache *rtfinder.RedisCache) {
+	spec := model.FeedSpecTypesGtfsRt
+	feeds, err := finder.FindFeeds(ctx, nil, nil, nil, &model.FeedFilter{Spec: []model.FeedSpecTypes{spec}})
+	if err != nil {
+		ilog.For(ctx).Error().Err(err).Msg("RT fetch: error finding feeds")
+		return
+	}
+	type rtFeed struct {
+		feedID  string
+		url     string
+		urlType string
+	}
+	var toFetch []rtFeed
+	for _, feed := range feeds {
+		if u := feed.URLs.RealtimeVehiclePositions; u != "" {
+			toFetch = append(toFetch, rtFeed{feed.FeedID, u, "realtime_vehicle_positions"})
+		}
+		if u := feed.URLs.RealtimeTripUpdates; u != "" {
+			toFetch = append(toFetch, rtFeed{feed.FeedID, u, "realtime_trip_updates"})
+		}
+		if u := feed.URLs.RealtimeAlerts; u != "" {
+			toFetch = append(toFetch, rtFeed{feed.FeedID, u, "realtime_alerts"})
+		}
+	}
+	ilog.For(ctx).Info().Int("feeds", len(feeds)).Int("urls", len(toFetch)).Msg("RT fetch: fetching")
+	for _, f := range toFetch {
+		if err := rtFetchOne(ctx, cache, f.feedID, f.url, f.urlType); err != nil {
+			ilog.For(ctx).Error().Err(err).Str("feed", f.feedID).Str("url_type", f.urlType).Msg("RT fetch: error")
+		}
+	}
+}
+
+func rtFetchOne(ctx context.Context, cache *rtfinder.RedisCache, feedID string, url string, urlType string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	key := fmt.Sprintf("rtdata:%s:%s", feedID, urlType)
+	ilog.For(ctx).Info().Str("feed", feedID).Str("url_type", urlType).Int("bytes", len(data)).Msg("RT fetch: ok")
+	return cache.AddData(ctx, key, data)
+}
+
+// Test RT data server
+
+func buildMessage(now time.Time) *pb.FeedMessage {
+	// Position within the hour: 0.0 to 1.0
+	secondsIntoHour := float64(now.Minute()*60 + now.Second())
+	fraction := secondsIntoHour / 3600.0
+	angle := fraction * 2 * math.Pi
+
+	lat := float32(centerLat + radiusDeg*math.Sin(angle))
+	lon := float32(centerLon + radiusDeg*math.Cos(angle))
+	bearing := float32(math.Mod(math.Mod(90-angle*180/math.Pi, 360)+360, 360))
+	speed := float32(2 * math.Pi * radiusDeg * 111000 / 3600) // approx m/s
+
+	ts := uint64(now.Unix())
+	headerTs := uint64(now.Unix())
+	version := "2.0"
+	incrementality := pb.FeedHeader_FULL_DATASET
+
+	vehicleID := "test-vehicle-1"
+	tripID := "test-trip-1"
+	routeID := "test-route-1"
+	label := "Oakland Circle Bus"
+	entityID := "vehicle-1"
+	status := pb.VehiclePosition_IN_TRANSIT_TO
+
+	return &pb.FeedMessage{
+		Header: &pb.FeedHeader{
+			GtfsRealtimeVersion: &version,
+			Incrementality:      &incrementality,
+			Timestamp:           &headerTs,
+		},
+		Entity: []*pb.FeedEntity{
+			{
+				Id: &entityID,
+				Vehicle: &pb.VehiclePosition{
+					Vehicle: &pb.VehicleDescriptor{
+						Id:    &vehicleID,
+						Label: &label,
+					},
+					Trip: &pb.TripDescriptor{
+						TripId:  &tripID,
+						RouteId: &routeID,
+					},
+					Position: &pb.Position{
+						Latitude:  &lat,
+						Longitude: &lon,
+						Bearing:   &bearing,
+						Speed:     &speed,
+					},
+					Timestamp:     &ts,
+					CurrentStatus: &status,
+				},
+			},
+		},
+	}
+}
+
+func wantsJSON(r *http.Request) bool {
+	accept := r.Header.Get("Accept")
+	return strings.Contains(accept, "application/json") || strings.Contains(accept, "text/json")
+}
+
+func handleVehiclePositions(w http.ResponseWriter, r *http.Request) {
+	now := time.Now().UTC()
+	if tStr := r.URL.Query().Get("time"); tStr != "" {
+		if unix, err := strconv.ParseInt(tStr, 10, 64); err == nil {
+			now = time.Unix(unix, 0).UTC()
+		}
+	}
+
+	msg := buildMessage(now)
+	pos := msg.Entity[0].Vehicle.Position
+
+	if wantsJSON(r) {
+		data, err := protojson.Marshal(msg)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data)
+	} else {
+		data, err := proto.Marshal(msg)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.Write(data)
+	}
+
+	fmt.Printf("[%s] Served vehicle at (%.4f, %.4f) bearing=%.1f\n", now.Format("15:04:05"), pos.GetLatitude(), pos.GetLongitude(), pos.GetBearing())
+}
+

--- a/cmds/server_cmd.go
+++ b/cmds/server_cmd.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"os"
+	"strings"
 	"time"
 	_ "time/tzdata"
 
@@ -244,8 +245,17 @@ func (cmd *ServerCommand) Run(ctx context.Context) error {
 	timeOut := time.Duration(cmd.Timeout) * time.Second
 	addr := fmt.Sprintf("%s:%s", "0.0.0.0", cmd.Port)
 	log.For(ctx).Info().Msgf("Listening on: %s", addr)
+	// Bypass timeout handler for WebSocket upgrade requests
+	timeoutHandler := http.TimeoutHandler(root, timeOut, "timeout")
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+			root.ServeHTTP(w, r)
+		} else {
+			timeoutHandler.ServeHTTP(w, r)
+		}
+	})
 	srv := &http.Server{
-		Handler:      http.TimeoutHandler(root, timeOut, "timeout"),
+		Handler:      handler,
 		Addr:         addr,
 		WriteTimeout: 2 * timeOut,
 		ReadTimeout:  2 * timeOut,

--- a/cmds/server_cmd.go
+++ b/cmds/server_cmd.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"os"
-	"strings"
 	"time"
 	_ "time/tzdata"
 
@@ -241,35 +240,12 @@ func (cmd *ServerCommand) Run(ctx context.Context) error {
 	// GraphQL Playground
 	root.Handle("/", playground.Handler("GraphQL playground", "/query"))
 
-	// WebSocket router — same config/auth middleware but no response writer wrapping
-	wsRoot := chi.NewRouter()
-	wsRoot.Use(cors.Handler(cors.Options{
-		AllowedOrigins:   []string{"https://*", "http://*"},
-		AllowedMethods:   []string{"GET", "POST", "DELETE", "OPTIONS"},
-		AllowedHeaders:   []string{"content-type", "apikey", "authorization"},
-		AllowCredentials: true,
-	}))
-	wsRoot.Use(model.AddConfig(cfg))
-	wsRoot.Use(usercheck.AdminDefaultMiddleware("admin"))
-	wsRoot.Use(log.RequestIDMiddleware)
-	wsRoot.Use(model.AddPerms(cfg.Checker))
-	wsRoot.Mount("/query", graphqlServer)
-
 	// Start server
 	timeOut := time.Duration(cmd.Timeout) * time.Second
 	addr := fmt.Sprintf("%s:%s", "0.0.0.0", cmd.Port)
 	log.For(ctx).Info().Msgf("Listening on: %s", addr)
-	// Bypass timeout handler and response-writer-wrapping middleware for WebSocket upgrades
-	timeoutHandler := http.TimeoutHandler(root, timeOut, "timeout")
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
-			wsRoot.ServeHTTP(w, r)
-		} else {
-			timeoutHandler.ServeHTTP(w, r)
-		}
-	})
 	srv := &http.Server{
-		Handler:      handler,
+		Handler:      wsAwareTimeout(root, timeOut),
 		Addr:         addr,
 		WriteTimeout: 2 * timeOut,
 		ReadTimeout:  2 * timeOut,
@@ -285,4 +261,20 @@ type globalAdminChecker struct {
 
 func (c *globalAdminChecker) CheckGlobalAdmin(ctx context.Context) (bool, error) {
 	return true, nil
+}
+
+// wsAwareTimeout wraps the handler with http.TimeoutHandler for normal HTTP requests,
+// but bypasses the timeout for WebSocket upgrades. WebSocket connections are long-lived
+// and would be killed by the timeout handler. The timeout handler also wraps the
+// ResponseWriter in a way that doesn't support Hijack(), which is required for the
+// WebSocket upgrade handshake.
+func wsAwareTimeout(h http.Handler, dt time.Duration) http.Handler {
+	timeoutHandler := http.TimeoutHandler(h, dt, "timeout")
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Upgrade") != "" {
+			h.ServeHTTP(w, r)
+		} else {
+			timeoutHandler.ServeHTTP(w, r)
+		}
+	})
 }

--- a/cmds/server_cmd.go
+++ b/cmds/server_cmd.go
@@ -241,15 +241,29 @@ func (cmd *ServerCommand) Run(ctx context.Context) error {
 	// GraphQL Playground
 	root.Handle("/", playground.Handler("GraphQL playground", "/query"))
 
+	// WebSocket router — same config/auth middleware but no response writer wrapping
+	wsRoot := chi.NewRouter()
+	wsRoot.Use(cors.Handler(cors.Options{
+		AllowedOrigins:   []string{"https://*", "http://*"},
+		AllowedMethods:   []string{"GET", "POST", "DELETE", "OPTIONS"},
+		AllowedHeaders:   []string{"content-type", "apikey", "authorization"},
+		AllowCredentials: true,
+	}))
+	wsRoot.Use(model.AddConfig(cfg))
+	wsRoot.Use(usercheck.AdminDefaultMiddleware("admin"))
+	wsRoot.Use(log.RequestIDMiddleware)
+	wsRoot.Use(model.AddPerms(cfg.Checker))
+	wsRoot.Mount("/query", graphqlServer)
+
 	// Start server
 	timeOut := time.Duration(cmd.Timeout) * time.Second
 	addr := fmt.Sprintf("%s:%s", "0.0.0.0", cmd.Port)
 	log.For(ctx).Info().Msgf("Listening on: %s", addr)
-	// Bypass timeout handler for WebSocket upgrade requests
+	// Bypass timeout handler and response-writer-wrapping middleware for WebSocket upgrades
 	timeoutHandler := http.TimeoutHandler(root, timeOut, "timeout")
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
-			root.ServeHTTP(w, r)
+			wsRoot.ServeHTTP(w, r)
 		} else {
 			timeoutHandler.ServeHTTP(w, r)
 		}

--- a/doc/design-vehicle-position-subscriptions.md
+++ b/doc/design-vehicle-position-subscriptions.md
@@ -1,0 +1,128 @@
+# Vehicle Position Subscriptions
+
+Design document for real-time vehicle position streaming via GraphQL subscriptions.
+
+Branch: `vp-2`
+
+## Goal
+
+Allow clients to subscribe to live GTFS-RT vehicle position updates over WebSocket, with filtering by geography and feed. Positions are pushed as full snapshots on each RT update cycle.
+
+## Architecture
+
+```
+RT Feed Sources
+    |
+    v
+Cache (Local or Redis)
+    |  pub/sub notification on update
+    v
+Subscription Resolver
+    |  collect + filter positions from all cached feeds
+    v
+WebSocket (graphql-ws protocol)
+    |
+    v
+Client
+```
+
+Key design choice: the subscription resolver reads only from the RT cache, not the database. This keeps the hot path fast and avoids DB load per push, but limits filtering to data available in the GTFS-RT messages themselves.
+
+## GraphQL Schema
+
+```graphql
+type Subscription {
+  vehicle_positions(where: VehiclePositionFilter): [VehiclePosition!]!
+}
+
+input VehiclePositionFilter {
+  bbox: BoundingBox
+  feed_onestop_ids: [String!]
+  limit: Int
+}
+```
+
+Extended `VehiclePosition` type fields: `trip`, `feed_onestop_id`, `bearing`, `speed`, `stop_id` (as String, no DB lookup).
+
+## Work Items
+
+### Infrastructure
+
+- [x] WebSocket transport in gqlgen server (gorilla/websocket, keepalive pings)
+- [x] `wsAwareTimeout` middleware bypasses `http.TimeoutHandler` for WebSocket upgrades (single router, no middleware duplication)
+- [x] Hijack() support on responseWriterWrapper for meters middleware
+- [x] GraphiQL v3 upgrade with native subscription support
+
+### Cache Pub/Sub
+
+- [x] `Subscribe()` and `GetSourceKeys()` on Cache interface
+- [x] LocalCache in-memory subscriber notification
+- [x] RedisCache PSUBSCRIBE-based notification
+- [x] Clean up unused `subscribers` map and `notifySubscribers` on RedisCache (dead code removed)
+- [ ] Consider debounce/coalesce: multiple RT feed updates within a short window should produce one push, not N
+
+### Vehicle Position Parsing
+
+- [x] Parse `ent.Vehicle` in `Source.processMessage` (was a TODO)
+- [x] `GetVehiclePositions()` on Source, Finder, and RTFinder interface
+- [x] `GetCachedFeedIDs()` to discover feeds with VP data from cache keys
+- [ ] **Thread safety (near-term):** Add `sync.RWMutex` to `Source` struct. `processMessage` is called from background goroutines (LocalCache.AddData, Redis listener) while `GetVehiclePositions`, `GetTrip`, and `GetTimestamp` are called concurrently from request/subscription goroutines. The fields (`entityByTrip`, `alerts`, `vehiclePositions`) are replaced non-atomically — readers can see inconsistent state across fields. This is a pre-existing race for trip updates and alerts; adding vehicle positions extends the surface. Fix: write lock in `processMessage`, read lock in all getters.
+
+### Subscription Resolver
+
+- [x] `subscriptionResolver.VehiclePositions` — subscribe, initial snapshot, ongoing pushes
+- [x] `convertVehiclePosition` — full protobuf-to-model mapping (position, bearing, speed, vehicle, trip, stop info, timestamp)
+- [x] `matchesFilter` — bbox filtering
+- [x] `feed_onestop_ids` filtering (at feed level before collecting)
+
+### Filters — Remaining
+
+- [x] `agency_ids`: Removed from schema — requires DB lookup which conflicts with cache-only design. May revisit.
+- [x] `route_ids`: Removed from schema — depends on optional RT field, keeping surface simple. May revisit.
+- [x] `stop_id`: Changed from `Stop` (object, DB lookup) to `String` (raw GTFS-RT value) to keep subscription path DB-free.
+- [x] `limit` on VehiclePositionFilter — defaults to 1000 (RESOLVER_MAXLIMIT), capped at 1000
+
+### Performance
+
+- [ ] Scope notifications: currently any cache update (trip updates, alerts, etc.) triggers a full vehicle position collection for all subscribers. Filter to only `realtime_vehicle_positions` topics before collecting.
+- [ ] Debounce: coalesce rapid updates within a window (e.g., 500ms-1s) before pushing
+- [ ] RedisCache `GetSourceKeys` does a SCAN on every notification per subscriber. Cache key list in memory with short TTL, or maintain incrementally.
+
+### Observability / Security
+
+- [x] WebSocket requests now go through the same middleware stack as HTTP (single router)
+- [x] WebSocket upgrader `CheckOrigin` allows all origins — acceptable because all connections require explicit API key/auth header (no cookie/session auth)
+- [ ] Add subscription connection count metrics / logging for monitoring
+
+### Testing
+
+- [x] Integration tests via gqlgen WebSocket test client (`subscription_resolver_test.go`):
+  - Full field mapping (feed_onestop_id, bearing, speed, position, vehicle, trip)
+  - Feed filter (two feeds, filter to one)
+  - Bbox filter (matching and non-matching)
+  - Live update (empty initial snapshot, push data, verify update arrives)
+- [ ] Unit tests for `convertVehiclePosition` (pure function, easy to test)
+- [ ] Unit tests for `GetCachedFeedIDs` key parsing
+- [ ] Verify existing RT resolver tests still pass with Cache interface changes
+
+### Dev Tooling
+
+- [x] `cmd/rt-test-server` — synthetic VP generator + optional real RT feed fetcher
+- [x] `testdata/dmfr/rt-test.dmfr.json` fixture
+
+## Design Decisions
+
+- **Cache-only, no DB in hot path.** The subscription resolver reads exclusively from the RT cache. This avoids DB load per push and keeps latency low. It constrains what filtering and field resolution is possible — filters that require static GTFS data (agency_ids, route_ids) and fields that resolve to DB objects (stop_id as Stop) were removed or simplified to match.
+- **`stop_id` is a raw String, not a resolved Stop object.** The rest of the GraphQL API resolves stop_id to a Stop entity via DB lookup. The subscription intentionally returns the raw GTFS-RT string to avoid DB dependencies. A resolved `stop` field could be added later as an opt-in.
+- **`agency_ids` and `route_ids` removed from filter.** Both require joining against static GTFS data. Keeping the filter surface to what the cache can deliver (bbox, feed_onestop_ids, limit).
+- **Single router with `wsAwareTimeout`.** Standard Go pattern — `http.TimeoutHandler` is incompatible with WebSocket (no Hijack support, kills long-lived connections). A single middleware skips the timeout for Upgrade requests. All other middleware (auth, CORS, meters, logging, permissions) is shared.
+- **`CheckOrigin` allows all origins.** Safe because auth is API-key-based (explicit header), not cookie/session-based. No ambient browser credentials to exploit via CSRF.
+- **Full snapshot per push, not deltas.** Simpler for consumers (replace the whole list, no client-side state management). Trade-off is bandwidth for large fleets.
+- **Default limit of 1000 per push.** Uses existing `RESOLVER_MAXLIMIT`. Prevents unbounded responses from unfiltered subscriptions.
+- **gorilla/websocket.** Archived/unmaintained, but it's gqlgen's transitive dependency. No alternative without switching gqlgen's transport.
+
+## Open Questions
+
+1. **Snapshot vs. delta**: Currently sends full snapshot of all matching positions on every update. Should this eventually support deltas (added/changed/removed)?
+2. **Rate limiting**: Should there be a max subscription count per client or global?
+3. **gorilla/websocket**: Archived/unmaintained, but it's a transitive dependency via gqlgen's `transport.Websocket`. No action needed unless gqlgen migrates (likely to `coder/websocket`).

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.18.3
 	github.com/golang/geo v0.0.0-20210211234256-740aa86cb551
 	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.0
 	github.com/graph-gophers/dataloader/v7 v7.1.0
 	github.com/hypirion/go-filecache v0.0.0-20160810125507-e3e6ef6981f0
 	github.com/iancoleman/orderedmap v0.2.0
@@ -86,7 +87,6 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
-	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect

--- a/internal/generated/gqlout/generated.go
+++ b/internal/generated/gqlout/generated.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -72,6 +73,7 @@ type ResolverRoot interface {
 	Stop() StopResolver
 	StopExternalReference() StopExternalReferenceResolver
 	StopTime() StopTimeResolver
+	Subscription() SubscriptionResolver
 	Trip() TripResolver
 	ValidationReport() ValidationReportResolver
 	ValidationReportErrorGroup() ValidationReportErrorGroupResolver
@@ -1168,6 +1170,10 @@ type ComplexityRoot struct {
 		Uncertainty    func(childComplexity int) int
 	}
 
+	Subscription struct {
+		VehiclePositions func(childComplexity int, where *model.VehiclePositionFilter) int
+	}
+
 	Trip struct {
 		Alerts               func(childComplexity int, active *bool, limit *int) int
 		BikesAllowed         func(childComplexity int) int
@@ -1249,12 +1255,16 @@ type ComplexityRoot struct {
 	}
 
 	VehiclePosition struct {
+		Bearing             func(childComplexity int) int
 		CongestionLevel     func(childComplexity int) int
 		CurrentStatus       func(childComplexity int) int
 		CurrentStopSequence func(childComplexity int) int
+		FeedOnestopID       func(childComplexity int) int
 		Position            func(childComplexity int) int
+		Speed               func(childComplexity int) int
 		StopID              func(childComplexity int) int
 		Timestamp           func(childComplexity int) int
+		Trip                func(childComplexity int) int
 		Vehicle             func(childComplexity int) int
 	}
 
@@ -1520,6 +1530,9 @@ type StopTimeResolver interface {
 	Departure(ctx context.Context, obj *model.StopTime) (*model.StopTimeEvent, error)
 
 	ScheduleRelationship(ctx context.Context, obj *model.StopTime) (*model.ScheduleRelationship, error)
+}
+type SubscriptionResolver interface {
+	VehiclePositions(ctx context.Context, where *model.VehiclePositionFilter) (<-chan []*model.VehiclePosition, error)
 }
 type TripResolver interface {
 	Calendar(ctx context.Context, obj *model.Trip) (*model.Calendar, error)
@@ -7532,6 +7545,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.StopTimeEvent.Uncertainty(childComplexity), true
 
+	case "Subscription.vehicle_positions":
+		if e.complexity.Subscription.VehiclePositions == nil {
+			break
+		}
+
+		args, err := ec.field_Subscription_vehicle_positions_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Subscription.VehiclePositions(childComplexity, args["where"].(*model.VehiclePositionFilter)), true
+
 	case "Trip.alerts":
 		if e.complexity.Trip.Alerts == nil {
 			break
@@ -8026,6 +8051,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.ValidationReportErrorGroup.GroupKey(childComplexity), true
 
+	case "VehiclePosition.bearing":
+		if e.complexity.VehiclePosition.Bearing == nil {
+			break
+		}
+
+		return e.complexity.VehiclePosition.Bearing(childComplexity), true
+
 	case "VehiclePosition.congestion_level":
 		if e.complexity.VehiclePosition.CongestionLevel == nil {
 			break
@@ -8047,12 +8079,26 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.VehiclePosition.CurrentStopSequence(childComplexity), true
 
+	case "VehiclePosition.feed_onestop_id":
+		if e.complexity.VehiclePosition.FeedOnestopID == nil {
+			break
+		}
+
+		return e.complexity.VehiclePosition.FeedOnestopID(childComplexity), true
+
 	case "VehiclePosition.position":
 		if e.complexity.VehiclePosition.Position == nil {
 			break
 		}
 
 		return e.complexity.VehiclePosition.Position(childComplexity), true
+
+	case "VehiclePosition.speed":
+		if e.complexity.VehiclePosition.Speed == nil {
+			break
+		}
+
+		return e.complexity.VehiclePosition.Speed(childComplexity), true
 
 	case "VehiclePosition.stop_id":
 		if e.complexity.VehiclePosition.StopID == nil {
@@ -8067,6 +8113,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.VehiclePosition.Timestamp(childComplexity), true
+
+	case "VehiclePosition.trip":
+		if e.complexity.VehiclePosition.Trip == nil {
+			break
+		}
+
+		return e.complexity.VehiclePosition.Trip(childComplexity), true
 
 	case "VehiclePosition.vehicle":
 		if e.complexity.VehiclePosition.Vehicle == nil {
@@ -8273,6 +8326,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputTripFilter,
 		ec.unmarshalInputTripStopTimeFilter,
 		ec.unmarshalInputValidationReportFilter,
+		ec.unmarshalInputVehiclePositionFilter,
 		ec.unmarshalInputWaypointInput,
 	)
 	first := true
@@ -8317,6 +8371,23 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 			ctx = graphql.WithUnmarshalerMap(ctx, inputUnmarshalMap)
 			data := ec._Mutation(ctx, opCtx.Operation.SelectionSet)
 			var buf bytes.Buffer
+			data.MarshalGQL(&buf)
+
+			return &graphql.Response{
+				Data: buf.Bytes(),
+			}
+		}
+	case ast.Subscription:
+		next := ec._Subscription(ctx, opCtx.Operation.SelectionSet)
+
+		var buf bytes.Buffer
+		return func(ctx context.Context) *graphql.Response {
+			buf.Reset()
+			data := next(ctx)
+
+			if data == nil {
+				return nil
+			}
 			data.MarshalGQL(&buf)
 
 			return &graphql.Response{
@@ -8915,6 +8986,24 @@ type Mutation {
   pathway_update(set: PathwaySetInput!): Pathway!
   "Delete a pathway"
   pathway_delete(id: Int!): EntityDeleteResult!
+}
+
+# Root subscription
+type Subscription {
+  "Subscribe to vehicle position updates. Returns snapshots of matching vehicles on each RT update cycle."
+  vehicle_positions(where: VehiclePositionFilter): [VehiclePosition!]!
+}
+
+"""Filter for vehicle position subscriptions"""
+input VehiclePositionFilter {
+  "Bounding box to filter vehicle positions by geographic area"
+  bbox: BoundingBox
+  "Filter by feed OnestopIDs"
+  feed_onestop_ids: [String!]
+  "Filter by agency IDs"
+  agency_ids: [String!]
+  "Filter by route IDs"
+  route_ids: [String!]
 }
 
 """Result of entity delete operation"""
@@ -10289,8 +10378,16 @@ type StopTimeEvent {
 type VehiclePosition {
   "GTFS-RT VehiclePosition vehicle. See https://gtfs.org/realtime/reference/#message-vehicledescriptor"
   vehicle: RTVehicleDescriptor
+  "GTFS-RT VehiclePosition trip. See https://gtfs.org/realtime/reference/#message-tripdescriptor"
+  trip: RTTripDescriptor
+  "Feed that provided this vehicle position"
+  feed_onestop_id: String
   "GTFS-RT VehiclePosition current vehicle position"
   position: Point
+  "GTFS-RT VehiclePosition bearing in degrees"
+  bearing: Float
+  "GTFS-RT VehiclePosition speed in meters per second"
+  speed: Float
   "GTFS-RT VehiclePosition current stop sequence in trip"
   current_stop_sequence: Int
   "GTFS-RT VehiclePosition current stop in trip"
@@ -12596,6 +12693,17 @@ func (ec *executionContext) field_Stop_stop_times_args(ctx context.Context, rawA
 		return nil, err
 	}
 	args["where"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Subscription_vehicle_positions_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "where", ec.unmarshalOVehiclePositionFilter2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐVehiclePositionFilter)
+	if err != nil {
+		return nil, err
+	}
+	args["where"] = arg0
 	return args, nil
 }
 
@@ -53077,6 +53185,99 @@ func (ec *executionContext) fieldContext_StopTimeEvent_uncertainty(_ context.Con
 	return fc, nil
 }
 
+func (ec *executionContext) _Subscription_vehicle_positions(ctx context.Context, field graphql.CollectedField) (ret func(ctx context.Context) graphql.Marshaler) {
+	fc, err := ec.fieldContext_Subscription_vehicle_positions(ctx, field)
+	if err != nil {
+		return nil
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = nil
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Subscription().VehiclePositions(rctx, fc.Args["where"].(*model.VehiclePositionFilter))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return nil
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return nil
+	}
+	return func(ctx context.Context) graphql.Marshaler {
+		select {
+		case res, ok := <-resTmp.(<-chan []*model.VehiclePosition):
+			if !ok {
+				return nil
+			}
+			return graphql.WriterFunc(func(w io.Writer) {
+				w.Write([]byte{'{'})
+				graphql.MarshalString(field.Alias).MarshalGQL(w)
+				w.Write([]byte{':'})
+				ec.marshalNVehiclePosition2ᚕᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐVehiclePositionᚄ(ctx, field.Selections, res).MarshalGQL(w)
+				w.Write([]byte{'}'})
+			})
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (ec *executionContext) fieldContext_Subscription_vehicle_positions(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Subscription",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "vehicle":
+				return ec.fieldContext_VehiclePosition_vehicle(ctx, field)
+			case "trip":
+				return ec.fieldContext_VehiclePosition_trip(ctx, field)
+			case "feed_onestop_id":
+				return ec.fieldContext_VehiclePosition_feed_onestop_id(ctx, field)
+			case "position":
+				return ec.fieldContext_VehiclePosition_position(ctx, field)
+			case "bearing":
+				return ec.fieldContext_VehiclePosition_bearing(ctx, field)
+			case "speed":
+				return ec.fieldContext_VehiclePosition_speed(ctx, field)
+			case "current_stop_sequence":
+				return ec.fieldContext_VehiclePosition_current_stop_sequence(ctx, field)
+			case "stop_id":
+				return ec.fieldContext_VehiclePosition_stop_id(ctx, field)
+			case "current_status":
+				return ec.fieldContext_VehiclePosition_current_status(ctx, field)
+			case "timestamp":
+				return ec.fieldContext_VehiclePosition_timestamp(ctx, field)
+			case "congestion_level":
+				return ec.fieldContext_VehiclePosition_congestion_level(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type VehiclePosition", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Subscription_vehicle_positions_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Trip_id(ctx context.Context, field graphql.CollectedField, obj *model.Trip) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Trip_id(ctx, field)
 	if err != nil {
@@ -56531,6 +56732,102 @@ func (ec *executionContext) fieldContext_VehiclePosition_vehicle(_ context.Conte
 	return fc, nil
 }
 
+func (ec *executionContext) _VehiclePosition_trip(ctx context.Context, field graphql.CollectedField, obj *model.VehiclePosition) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_VehiclePosition_trip(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Trip, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.RTTripDescriptor)
+	fc.Result = res
+	return ec.marshalORTTripDescriptor2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐRTTripDescriptor(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_VehiclePosition_trip(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "VehiclePosition",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "trip_id":
+				return ec.fieldContext_RTTripDescriptor_trip_id(ctx, field)
+			case "route_id":
+				return ec.fieldContext_RTTripDescriptor_route_id(ctx, field)
+			case "direction_id":
+				return ec.fieldContext_RTTripDescriptor_direction_id(ctx, field)
+			case "start_time":
+				return ec.fieldContext_RTTripDescriptor_start_time(ctx, field)
+			case "start_date":
+				return ec.fieldContext_RTTripDescriptor_start_date(ctx, field)
+			case "schedule_relationship":
+				return ec.fieldContext_RTTripDescriptor_schedule_relationship(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type RTTripDescriptor", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _VehiclePosition_feed_onestop_id(ctx context.Context, field graphql.CollectedField, obj *model.VehiclePosition) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_VehiclePosition_feed_onestop_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FeedOnestopID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_VehiclePosition_feed_onestop_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "VehiclePosition",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _VehiclePosition_position(ctx context.Context, field graphql.CollectedField, obj *model.VehiclePosition) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_VehiclePosition_position(ctx, field)
 	if err != nil {
@@ -56567,6 +56864,88 @@ func (ec *executionContext) fieldContext_VehiclePosition_position(_ context.Cont
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Point does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _VehiclePosition_bearing(ctx context.Context, field graphql.CollectedField, obj *model.VehiclePosition) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_VehiclePosition_bearing(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Bearing, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*float64)
+	fc.Result = res
+	return ec.marshalOFloat2ᚖfloat64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_VehiclePosition_bearing(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "VehiclePosition",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _VehiclePosition_speed(ctx context.Context, field graphql.CollectedField, obj *model.VehiclePosition) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_VehiclePosition_speed(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Speed, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*float64)
+	fc.Result = res
+	return ec.marshalOFloat2ᚖfloat64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_VehiclePosition_speed(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "VehiclePosition",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
 		},
 	}
 	return fc, nil
@@ -62516,6 +62895,54 @@ func (ec *executionContext) unmarshalInputValidationReportFilter(ctx context.Con
 				return it, err
 			}
 			it.IncludesStatic = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputVehiclePositionFilter(ctx context.Context, obj any) (model.VehiclePositionFilter, error) {
+	var it model.VehiclePositionFilter
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"bbox", "feed_onestop_ids", "agency_ids", "route_ids"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "bbox":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("bbox"))
+			data, err := ec.unmarshalOBoundingBox2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐBoundingBox(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Bbox = data
+		case "feed_onestop_ids":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("feed_onestop_ids"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.FeedOnestopIds = data
+		case "agency_ids":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("agency_ids"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AgencyIds = data
+		case "route_ids":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("route_ids"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.RouteIds = data
 		}
 	}
 
@@ -72663,6 +73090,26 @@ func (ec *executionContext) _StopTimeEvent(ctx context.Context, sel ast.Selectio
 	return out
 }
 
+var subscriptionImplementors = []string{"Subscription"}
+
+func (ec *executionContext) _Subscription(ctx context.Context, sel ast.SelectionSet) func(ctx context.Context) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, subscriptionImplementors)
+	ctx = graphql.WithFieldContext(ctx, &graphql.FieldContext{
+		Object: "Subscription",
+	})
+	if len(fields) != 1 {
+		ec.Errorf(ctx, "must subscribe to exactly one stream")
+		return nil
+	}
+
+	switch fields[0].Name {
+	case "vehicle_positions":
+		return ec._Subscription_vehicle_positions(ctx, fields[0])
+	default:
+		panic("unknown field " + strconv.Quote(fields[0].Name))
+	}
+}
+
 var tripImplementors = []string{"Trip"}
 
 func (ec *executionContext) _Trip(ctx context.Context, sel ast.SelectionSet, obj *model.Trip) graphql.Marshaler {
@@ -73555,8 +74002,16 @@ func (ec *executionContext) _VehiclePosition(ctx context.Context, sel ast.Select
 			out.Values[i] = graphql.MarshalString("VehiclePosition")
 		case "vehicle":
 			out.Values[i] = ec._VehiclePosition_vehicle(ctx, field, obj)
+		case "trip":
+			out.Values[i] = ec._VehiclePosition_trip(ctx, field, obj)
+		case "feed_onestop_id":
+			out.Values[i] = ec._VehiclePosition_feed_onestop_id(ctx, field, obj)
 		case "position":
 			out.Values[i] = ec._VehiclePosition_position(ctx, field, obj)
+		case "bearing":
+			out.Values[i] = ec._VehiclePosition_bearing(ctx, field, obj)
+		case "speed":
+			out.Values[i] = ec._VehiclePosition_speed(ctx, field, obj)
 		case "current_stop_sequence":
 			out.Values[i] = ec._VehiclePosition_current_stop_sequence(ctx, field, obj)
 		case "stop_id":
@@ -76570,6 +77025,60 @@ func (ec *executionContext) marshalNValidationReportErrorGroup2ᚖgithubᚗcom�
 	return ec._ValidationReportErrorGroup(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNVehiclePosition2ᚕᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐVehiclePositionᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.VehiclePosition) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNVehiclePosition2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐVehiclePosition(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNVehiclePosition2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐVehiclePosition(ctx context.Context, sel ast.SelectionSet, v *model.VehiclePosition) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._VehiclePosition(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNWaypoint2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐWaypoint(ctx context.Context, sel ast.SelectionSet, v *model.Waypoint) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -79210,6 +79719,13 @@ func (ec *executionContext) marshalORTTranslation2ᚕᚖgithubᚗcomᚋinterline
 	return ret
 }
 
+func (ec *executionContext) marshalORTTripDescriptor2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐRTTripDescriptor(ctx context.Context, sel ast.SelectionSet, v *model.RTTripDescriptor) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._RTTripDescriptor(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalORTVehicleDescriptor2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐRTVehicleDescriptor(ctx context.Context, sel ast.SelectionSet, v *model.RTVehicleDescriptor) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -80129,6 +80645,14 @@ func (ec *executionContext) unmarshalOValidationReportFilter2ᚖgithubᚗcomᚋi
 		return nil, nil
 	}
 	res, err := ec.unmarshalInputValidationReportFilter(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOVehiclePositionFilter2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐVehiclePositionFilter(ctx context.Context, v any) (*model.VehiclePositionFilter, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputVehiclePositionFilter(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/internal/generated/gqlout/generated.go
+++ b/internal/generated/gqlout/generated.go
@@ -9000,10 +9000,6 @@ input VehiclePositionFilter {
   bbox: BoundingBox
   "Filter by feed OnestopIDs"
   feed_onestop_ids: [String!]
-  "Filter by agency IDs"
-  agency_ids: [String!]
-  "Filter by route IDs"
-  route_ids: [String!]
 }
 
 """Result of entity delete operation"""
@@ -62832,7 +62828,7 @@ func (ec *executionContext) unmarshalInputVehiclePositionFilter(ctx context.Cont
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"bbox", "feed_onestop_ids", "agency_ids", "route_ids"}
+	fieldsInOrder := [...]string{"bbox", "feed_onestop_ids"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -62853,20 +62849,6 @@ func (ec *executionContext) unmarshalInputVehiclePositionFilter(ctx context.Cont
 				return it, err
 			}
 			it.FeedOnestopIds = data
-		case "agency_ids":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("agency_ids"))
-			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.AgencyIds = data
-		case "route_ids":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("route_ids"))
-			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.RouteIds = data
 		}
 	}
 

--- a/internal/generated/gqlout/generated.go
+++ b/internal/generated/gqlout/generated.go
@@ -10390,8 +10390,8 @@ type VehiclePosition {
   speed: Float
   "GTFS-RT VehiclePosition current stop sequence in trip"
   current_stop_sequence: Int
-  "GTFS-RT VehiclePosition current stop in trip"
-  stop_id: Stop
+  "GTFS-RT VehiclePosition current stop ID"
+  stop_id: String
   "GTFS-RT VehiclePosition current status string"
   current_status: String
   "GTFS-RT VehiclePosition timestamp"
@@ -57015,9 +57015,9 @@ func (ec *executionContext) _VehiclePosition_stop_id(ctx context.Context, field 
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*model.Stop)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalOStop2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐStop(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_VehiclePosition_stop_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -57027,83 +57027,7 @@ func (ec *executionContext) fieldContext_VehiclePosition_stop_id(_ context.Conte
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Stop_id(ctx, field)
-			case "onestop_id":
-				return ec.fieldContext_Stop_onestop_id(ctx, field)
-			case "location_type":
-				return ec.fieldContext_Stop_location_type(ctx, field)
-			case "stop_code":
-				return ec.fieldContext_Stop_stop_code(ctx, field)
-			case "stop_desc":
-				return ec.fieldContext_Stop_stop_desc(ctx, field)
-			case "stop_id":
-				return ec.fieldContext_Stop_stop_id(ctx, field)
-			case "stop_name":
-				return ec.fieldContext_Stop_stop_name(ctx, field)
-			case "stop_timezone":
-				return ec.fieldContext_Stop_stop_timezone(ctx, field)
-			case "stop_url":
-				return ec.fieldContext_Stop_stop_url(ctx, field)
-			case "wheelchair_boarding":
-				return ec.fieldContext_Stop_wheelchair_boarding(ctx, field)
-			case "zone_id":
-				return ec.fieldContext_Stop_zone_id(ctx, field)
-			case "platform_code":
-				return ec.fieldContext_Stop_platform_code(ctx, field)
-			case "tts_stop_name":
-				return ec.fieldContext_Stop_tts_stop_name(ctx, field)
-			case "geometry":
-				return ec.fieldContext_Stop_geometry(ctx, field)
-			case "feed_version_sha1":
-				return ec.fieldContext_Stop_feed_version_sha1(ctx, field)
-			case "feed_onestop_id":
-				return ec.fieldContext_Stop_feed_onestop_id(ctx, field)
-			case "feed_version":
-				return ec.fieldContext_Stop_feed_version(ctx, field)
-			case "location_groups":
-				return ec.fieldContext_Stop_location_groups(ctx, field)
-			case "level":
-				return ec.fieldContext_Stop_level(ctx, field)
-			case "parent":
-				return ec.fieldContext_Stop_parent(ctx, field)
-			case "external_reference":
-				return ec.fieldContext_Stop_external_reference(ctx, field)
-			case "observations":
-				return ec.fieldContext_Stop_observations(ctx, field)
-			case "children":
-				return ec.fieldContext_Stop_children(ctx, field)
-			case "route_stops":
-				return ec.fieldContext_Stop_route_stops(ctx, field)
-			case "child_levels":
-				return ec.fieldContext_Stop_child_levels(ctx, field)
-			case "pathways_from_stop":
-				return ec.fieldContext_Stop_pathways_from_stop(ctx, field)
-			case "pathways_to_stop":
-				return ec.fieldContext_Stop_pathways_to_stop(ctx, field)
-			case "stop_times":
-				return ec.fieldContext_Stop_stop_times(ctx, field)
-			case "departures":
-				return ec.fieldContext_Stop_departures(ctx, field)
-			case "arrivals":
-				return ec.fieldContext_Stop_arrivals(ctx, field)
-			case "search_rank":
-				return ec.fieldContext_Stop_search_rank(ctx, field)
-			case "place":
-				return ec.fieldContext_Stop_place(ctx, field)
-			case "census_geographies":
-				return ec.fieldContext_Stop_census_geographies(ctx, field)
-			case "directions":
-				return ec.fieldContext_Stop_directions(ctx, field)
-			case "nearby_stops":
-				return ec.fieldContext_Stop_nearby_stops(ctx, field)
-			case "alerts":
-				return ec.fieldContext_Stop_alerts(ctx, field)
-			case "within_features":
-				return ec.fieldContext_Stop_within_features(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Stop", field.Name)
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil

--- a/internal/generated/gqlout/generated.go
+++ b/internal/generated/gqlout/generated.go
@@ -9000,6 +9000,8 @@ input VehiclePositionFilter {
   bbox: BoundingBox
   "Filter by feed OnestopIDs"
   feed_onestop_ids: [String!]
+  "Maximum number of vehicle positions to return per update (default 1000)"
+  limit: Int
 }
 
 """Result of entity delete operation"""
@@ -62828,7 +62830,7 @@ func (ec *executionContext) unmarshalInputVehiclePositionFilter(ctx context.Cont
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"bbox", "feed_onestop_ids"}
+	fieldsInOrder := [...]string{"bbox", "feed_onestop_ids", "limit"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -62849,6 +62851,13 @@ func (ec *executionContext) unmarshalInputVehiclePositionFilter(ctx context.Cont
 				return it, err
 			}
 			it.FeedOnestopIds = data
+		case "limit":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("limit"))
+			data, err := ec.unmarshalOInt2ᚖint(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Limit = data
 		}
 	}
 

--- a/schema/graphql/schema.graphqls
+++ b/schema/graphql/schema.graphqls
@@ -147,10 +147,6 @@ input VehiclePositionFilter {
   bbox: BoundingBox
   "Filter by feed OnestopIDs"
   feed_onestop_ids: [String!]
-  "Filter by agency IDs"
-  agency_ids: [String!]
-  "Filter by route IDs"
-  route_ids: [String!]
 }
 
 """Result of entity delete operation"""

--- a/schema/graphql/schema.graphqls
+++ b/schema/graphql/schema.graphqls
@@ -147,6 +147,8 @@ input VehiclePositionFilter {
   bbox: BoundingBox
   "Filter by feed OnestopIDs"
   feed_onestop_ids: [String!]
+  "Maximum number of vehicle positions to return per update (default 1000)"
+  limit: Int
 }
 
 """Result of entity delete operation"""

--- a/schema/graphql/schema.graphqls
+++ b/schema/graphql/schema.graphqls
@@ -1537,8 +1537,8 @@ type VehiclePosition {
   speed: Float
   "GTFS-RT VehiclePosition current stop sequence in trip"
   current_stop_sequence: Int
-  "GTFS-RT VehiclePosition current stop in trip"
-  stop_id: Stop
+  "GTFS-RT VehiclePosition current stop ID"
+  stop_id: String
   "GTFS-RT VehiclePosition current status string"
   current_status: String
   "GTFS-RT VehiclePosition timestamp"

--- a/schema/graphql/schema.graphqls
+++ b/schema/graphql/schema.graphqls
@@ -135,6 +135,24 @@ type Mutation {
   pathway_delete(id: Int!): EntityDeleteResult!
 }
 
+# Root subscription
+type Subscription {
+  "Subscribe to vehicle position updates. Returns snapshots of matching vehicles on each RT update cycle."
+  vehicle_positions(where: VehiclePositionFilter): [VehiclePosition!]!
+}
+
+"""Filter for vehicle position subscriptions"""
+input VehiclePositionFilter {
+  "Bounding box to filter vehicle positions by geographic area"
+  bbox: BoundingBox
+  "Filter by feed OnestopIDs"
+  feed_onestop_ids: [String!]
+  "Filter by agency IDs"
+  agency_ids: [String!]
+  "Filter by route IDs"
+  route_ids: [String!]
+}
+
 """Result of entity delete operation"""
 type EntityDeleteResult {
   "ID of deleted entity"
@@ -1507,8 +1525,16 @@ type StopTimeEvent {
 type VehiclePosition {
   "GTFS-RT VehiclePosition vehicle. See https://gtfs.org/realtime/reference/#message-vehicledescriptor"
   vehicle: RTVehicleDescriptor
+  "GTFS-RT VehiclePosition trip. See https://gtfs.org/realtime/reference/#message-tripdescriptor"
+  trip: RTTripDescriptor
+  "Feed that provided this vehicle position"
+  feed_onestop_id: String
   "GTFS-RT VehiclePosition current vehicle position"
   position: Point
+  "GTFS-RT VehiclePosition bearing in degrees"
+  bearing: Float
+  "GTFS-RT VehiclePosition speed in meters per second"
+  speed: Float
   "GTFS-RT VehiclePosition current stop sequence in trip"
   current_stop_sequence: Int
   "GTFS-RT VehiclePosition current stop in trip"

--- a/server/finders/rtfinder/finder.go
+++ b/server/finders/rtfinder/finder.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/interline-io/log"
@@ -19,6 +20,8 @@ type Cache interface {
 	AddFeedMessage(context.Context, string, *pb.FeedMessage) error
 	AddData(context.Context, string, []byte) error
 	GetSource(context.Context, string) (*Source, bool)
+	// GetSourceKeys returns all cached source topic keys.
+	GetSourceKeys() []string
 	// Subscribe returns a channel that receives the topic name whenever that topic is updated.
 	// Call the returned cancel function to unsubscribe.
 	Subscribe() (chan string, func())
@@ -47,6 +50,25 @@ func (f *Finder) AddData(ctx context.Context, topic string, data []byte) error {
 
 func (f *Finder) Subscribe() (chan string, func()) {
 	return f.cache.Subscribe()
+}
+
+func (f *Finder) GetCachedFeedIDs() []string {
+	seen := map[string]bool{}
+	suffix := ":realtime_vehicle_positions"
+	prefix := "rtdata:"
+	for _, key := range f.cache.GetSourceKeys() {
+		if strings.HasPrefix(key, prefix) && strings.HasSuffix(key, suffix) {
+			feedID := strings.TrimSuffix(strings.TrimPrefix(key, prefix), suffix)
+			if feedID != "" {
+				seen[feedID] = true
+			}
+		}
+	}
+	var result []string
+	for k := range seen {
+		result = append(result, k)
+	}
+	return result
 }
 
 func (f *Finder) GetVehiclePositions(ctx context.Context, topic string) []*pb.VehiclePosition {

--- a/server/finders/rtfinder/finder.go
+++ b/server/finders/rtfinder/finder.go
@@ -19,6 +19,9 @@ type Cache interface {
 	AddFeedMessage(context.Context, string, *pb.FeedMessage) error
 	AddData(context.Context, string, []byte) error
 	GetSource(context.Context, string) (*Source, bool)
+	// Subscribe returns a channel that receives the topic name whenever that topic is updated.
+	// Call the returned cancel function to unsubscribe.
+	Subscribe() (chan string, func())
 	Close() error
 }
 
@@ -40,6 +43,18 @@ func NewFinder(cache Cache, db tldb.Ext) *Finder {
 
 func (f *Finder) AddData(ctx context.Context, topic string, data []byte) error {
 	return f.cache.AddData(ctx, topic, data)
+}
+
+func (f *Finder) Subscribe() (chan string, func()) {
+	return f.cache.Subscribe()
+}
+
+func (f *Finder) GetVehiclePositions(ctx context.Context, topic string) []*pb.VehiclePosition {
+	a, ok := f.cache.GetSource(ctx, getTopicKey(topic, "realtime_vehicle_positions"))
+	if !ok || a == nil {
+		return nil
+	}
+	return a.GetVehiclePositions()
 }
 
 func (f *Finder) GetGtfsTripID(ctx context.Context, id int) (string, bool) {

--- a/server/finders/rtfinder/local.go
+++ b/server/finders/rtfinder/local.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/interline-io/log"
 	"github.com/interline-io/transitland-lib/rt/pb"
 )
 
@@ -25,6 +26,7 @@ func (f *LocalCache) Subscribe() (chan string, func()) {
 	defer f.lock.Unlock()
 	ch := make(chan string, 100)
 	f.subscribers[ch] = struct{}{}
+	log.Info().Int("total_subscribers", len(f.subscribers)).Msg("cache: new subscriber added")
 	cancel := func() {
 		f.lock.Lock()
 		defer f.lock.Unlock()
@@ -35,12 +37,23 @@ func (f *LocalCache) Subscribe() (chan string, func()) {
 }
 
 func (f *LocalCache) notifySubscribers(topic string) {
+	log.Trace().Int("subscribers", len(f.subscribers)).Str("topic", topic).Msg("cache: notifying subscribers")
 	for ch := range f.subscribers {
 		select {
 		case ch <- topic:
 		default:
 		}
 	}
+}
+
+func (f *LocalCache) GetSourceKeys() []string {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	var keys []string
+	for k := range f.sources {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 func (f *LocalCache) GetSource(ctx context.Context, topic string) (*Source, bool) {
@@ -68,6 +81,7 @@ func (f *LocalCache) AddData(ctx context.Context, topic string, data []byte) err
 	if err := s.process(ctx, data); err != nil {
 		return err
 	}
+	log.Trace().Str("topic", topic).Int("bytes", len(data)).Msg("cache: added data")
 	f.notifySubscribers(topic)
 	return nil
 }

--- a/server/finders/rtfinder/local.go
+++ b/server/finders/rtfinder/local.go
@@ -8,13 +8,38 @@ import (
 )
 
 type LocalCache struct {
-	lock    sync.Mutex
-	sources map[string]*Source
+	lock        sync.Mutex
+	sources     map[string]*Source
+	subscribers map[chan string]struct{}
 }
 
 func NewLocalCache() *LocalCache {
 	return &LocalCache{
-		sources: map[string]*Source{},
+		sources:     map[string]*Source{},
+		subscribers: map[chan string]struct{}{},
+	}
+}
+
+func (f *LocalCache) Subscribe() (chan string, func()) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	ch := make(chan string, 100)
+	f.subscribers[ch] = struct{}{}
+	cancel := func() {
+		f.lock.Lock()
+		defer f.lock.Unlock()
+		delete(f.subscribers, ch)
+		close(ch)
+	}
+	return ch, cancel
+}
+
+func (f *LocalCache) notifySubscribers(topic string) {
+	for ch := range f.subscribers {
+		select {
+		case ch <- topic:
+		default:
+		}
 	}
 }
 
@@ -40,7 +65,11 @@ func (f *LocalCache) AddData(ctx context.Context, topic string, data []byte) err
 		s, _ = NewSource(topic)
 		f.sources[topic] = s
 	}
-	return s.process(ctx, data)
+	if err := s.process(ctx, data); err != nil {
+		return err
+	}
+	f.notifySubscribers(topic)
+	return nil
 }
 
 func (f *LocalCache) Close() error {

--- a/server/finders/rtfinder/redis.go
+++ b/server/finders/rtfinder/redis.go
@@ -3,6 +3,7 @@ package rtfinder
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -46,14 +47,34 @@ func NewRedisCache(client *redis.Client) *RedisCache {
 }
 
 func (f *RedisCache) Subscribe() (chan string, func()) {
-	f.lock.Lock()
-	defer f.lock.Unlock()
 	ch := make(chan string, 100)
-	f.subscribers[ch] = struct{}{}
+	subCtx, subCancel := context.WithCancel(f.ctx)
+	// Use Redis PSUBSCRIBE to watch for all RT data updates
+	psub := f.client.PSubscribe(subCtx, "rtfetch:sub:*")
+	go func() {
+		defer psub.Close()
+		pch := psub.Channel()
+		for {
+			select {
+			case <-subCtx.Done():
+				return
+			case msg, ok := <-pch:
+				if !ok {
+					return
+				}
+				// Extract topic from channel name (strip "rtfetch:sub:" prefix)
+				topic := strings.TrimPrefix(msg.Channel, "rtfetch:sub:")
+				// Also ensure a listener exists so GetSource/GetVehiclePositions works
+				f.ensureListener(subCtx, topic)
+				select {
+				case ch <- topic:
+				default:
+				}
+			}
+		}
+	}()
 	cancel := func() {
-		f.lock.Lock()
-		defer f.lock.Unlock()
-		delete(f.subscribers, ch)
+		subCancel()
 		close(ch)
 	}
 	return ch, cancel
@@ -69,6 +90,34 @@ func (f *RedisCache) notifySubscribers(topic string) {
 			// drop if subscriber is slow
 		}
 	}
+}
+
+func (f *RedisCache) GetSourceKeys() []string {
+	// Scan Redis for cached RT data keys
+	rctx, cc := context.WithTimeout(f.ctx, 2*time.Second)
+	defer cc()
+	prefix := "rtfetch:last:"
+	var keys []string
+	iter := f.client.Scan(rctx, 0, prefix+"*", 1000).Iterator()
+	for iter.Next(rctx) {
+		topic := strings.TrimPrefix(iter.Val(), prefix)
+		keys = append(keys, topic)
+	}
+	return keys
+}
+
+func (f *RedisCache) ensureListener(ctx context.Context, topic string) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	if _, ok := f.listeners[topic]; ok {
+		return
+	}
+	a, err := f.startListener(ctx, topic)
+	if err != nil {
+		log.For(ctx).Error().Err(err).Str("topic", topic).Msg("cache: error creating listener")
+		return
+	}
+	f.listeners[topic] = a
 }
 
 func (f *RedisCache) GetSource(ctx context.Context, topic string) (*Source, bool) {

--- a/server/finders/rtfinder/redis.go
+++ b/server/finders/rtfinder/redis.go
@@ -27,20 +27,48 @@ func newListener(s *Source, parent context.Context) *listener {
 }
 
 type RedisCache struct {
-	ctx       context.Context
-	lock      sync.Mutex
-	client    *redis.Client
-	listeners map[string]*listener
+	ctx         context.Context
+	lock        sync.Mutex
+	client      *redis.Client
+	listeners   map[string]*listener
+	subscribers map[chan string]struct{}
 }
 
 func NewRedisCache(client *redis.Client) *RedisCache {
 	ctx := context.Background()
 	f := RedisCache{
-		client:    client,
-		listeners: map[string]*listener{},
-		ctx:       ctx,
+		client:      client,
+		listeners:   map[string]*listener{},
+		subscribers: map[chan string]struct{}{},
+		ctx:         ctx,
 	}
 	return &f
+}
+
+func (f *RedisCache) Subscribe() (chan string, func()) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	ch := make(chan string, 100)
+	f.subscribers[ch] = struct{}{}
+	cancel := func() {
+		f.lock.Lock()
+		defer f.lock.Unlock()
+		delete(f.subscribers, ch)
+		close(ch)
+	}
+	return ch, cancel
+}
+
+func (f *RedisCache) notifySubscribers(topic string) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	for ch := range f.subscribers {
+		select {
+		case ch <- topic:
+		default:
+			// drop if subscriber is slow
+		}
+	}
 }
 
 func (f *RedisCache) GetSource(ctx context.Context, topic string) (*Source, bool) {
@@ -111,6 +139,7 @@ func (f *RedisCache) startListener(ctx context.Context, topic string) (*listener
 				log.For(ctx).Error().Err(err).Str("topic", topic).Int("bytes", len(rmsg.Payload)).Msg("cache: error processing update")
 			} else {
 				log.For(ctx).Trace().Str("topic", topic).Int("bytes", len(rmsg.Payload)).Msg("cache: processed update")
+				f.notifySubscribers(topic)
 			}
 		}
 	}(f.client, topic, ls)

--- a/server/finders/rtfinder/redis.go
+++ b/server/finders/rtfinder/redis.go
@@ -28,20 +28,18 @@ func newListener(s *Source, parent context.Context) *listener {
 }
 
 type RedisCache struct {
-	ctx         context.Context
-	lock        sync.Mutex
-	client      *redis.Client
-	listeners   map[string]*listener
-	subscribers map[chan string]struct{}
+	ctx       context.Context
+	lock      sync.Mutex
+	client    *redis.Client
+	listeners map[string]*listener
 }
 
 func NewRedisCache(client *redis.Client) *RedisCache {
 	ctx := context.Background()
 	f := RedisCache{
-		client:      client,
-		listeners:   map[string]*listener{},
-		subscribers: map[chan string]struct{}{},
-		ctx:         ctx,
+		client:    client,
+		listeners: map[string]*listener{},
+		ctx:       ctx,
 	}
 	return &f
 }
@@ -78,18 +76,6 @@ func (f *RedisCache) Subscribe() (chan string, func()) {
 		close(ch)
 	}
 	return ch, cancel
-}
-
-func (f *RedisCache) notifySubscribers(topic string) {
-	f.lock.Lock()
-	defer f.lock.Unlock()
-	for ch := range f.subscribers {
-		select {
-		case ch <- topic:
-		default:
-			// drop if subscriber is slow
-		}
-	}
 }
 
 func (f *RedisCache) GetSourceKeys() []string {
@@ -188,7 +174,6 @@ func (f *RedisCache) startListener(ctx context.Context, topic string) (*listener
 				log.For(ctx).Error().Err(err).Str("topic", topic).Int("bytes", len(rmsg.Payload)).Msg("cache: error processing update")
 			} else {
 				log.For(ctx).Trace().Str("topic", topic).Int("bytes", len(rmsg.Payload)).Msg("cache: processed update")
-				f.notifySubscribers(topic)
 			}
 		}
 	}(f.client, topic, ls)

--- a/server/finders/rtfinder/source.go
+++ b/server/finders/rtfinder/source.go
@@ -9,10 +9,11 @@ import (
 )
 
 type Source struct {
-	feed         string
-	msg          *pb.FeedMessage
-	entityByTrip map[string]*pb.TripUpdate
-	alerts       []*pb.Alert
+	feed             string
+	msg              *pb.FeedMessage
+	entityByTrip     map[string]*pb.TripUpdate
+	alerts           []*pb.Alert
+	vehiclePositions []*pb.VehiclePosition
 }
 
 func NewSource(feed string) (*Source, error) {
@@ -25,6 +26,10 @@ func NewSource(feed string) (*Source, error) {
 
 func (f *Source) GetTimestamp() uint64 {
 	return f.msg.GetHeader().GetTimestamp()
+}
+
+func (f *Source) GetVehiclePositions() []*pb.VehiclePosition {
+	return f.vehiclePositions
 }
 
 func (f *Source) GetTrip(tid string) (*pb.TripUpdate, bool) {
@@ -40,6 +45,7 @@ func (f *Source) processMessage(ctx context.Context, rtmsg *pb.FeedMessage) erro
 	defaultTimestamp := rtmsg.GetHeader().GetTimestamp()
 	a := map[string]*pb.TripUpdate{}
 	var alerts []*pb.Alert
+	var vehiclePositions []*pb.VehiclePosition
 	for _, ent := range rtmsg.Entity {
 		if v := ent.TripUpdate; v != nil {
 			// Set default timestamp
@@ -52,11 +58,14 @@ func (f *Source) processMessage(ctx context.Context, rtmsg *pb.FeedMessage) erro
 		if v := ent.Alert; v != nil {
 			alerts = append(alerts, v)
 		}
-		// todo: vehicle positions...
+		if v := ent.Vehicle; v != nil {
+			vehiclePositions = append(vehiclePositions, v)
+		}
 	}
-	log.For(ctx).Trace().Str("feed_id", f.feed).Int("trip_updates", len(a)).Int("alerts", len(alerts)).Msg("rtsource: processed data")
+	log.For(ctx).Trace().Str("feed_id", f.feed).Int("trip_updates", len(a)).Int("alerts", len(alerts)).Int("vehicle_positions", len(vehiclePositions)).Msg("rtsource: processed data")
 	f.entityByTrip = a
 	f.alerts = alerts
+	f.vehiclePositions = vehiclePositions
 	return nil
 }
 

--- a/server/gql/resolver.go
+++ b/server/gql/resolver.go
@@ -145,6 +145,9 @@ func (r *Resolver) Query() gqlout.QueryResolver { return &queryResolver{r} }
 // Mutation .
 func (r *Resolver) Mutation() gqlout.MutationResolver { return &mutationResolver{r} }
 
+// Subscription .
+func (r *Resolver) Subscription() gqlout.SubscriptionResolver { return &subscriptionResolver{r} }
+
 // Agency .
 func (r *Resolver) Agency() gqlout.AgencyResolver { return &agencyResolver{r} }
 

--- a/server/gql/server.go
+++ b/server/gql/server.go
@@ -2,9 +2,13 @@ package gql
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/extension"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/gorilla/websocket"
 	"github.com/interline-io/transitland-lib/internal/generated/gqlout"
 )
 
@@ -24,8 +28,21 @@ func WithExtensions(exts ...graphql.HandlerExtension) ServerOption {
 
 func NewServer(opts ...ServerOption) (http.Handler, error) {
 	c := gqlout.Config{Resolvers: &Resolver{}}
-	// Setup server
-	srv := handler.NewDefaultServer(gqlout.NewExecutableSchema(c))
+	// Setup server with explicit transports to include WebSocket support
+	srv := handler.New(gqlout.NewExecutableSchema(c))
+	srv.AddTransport(transport.Options{})
+	srv.AddTransport(transport.GET{})
+	srv.AddTransport(transport.POST{})
+	srv.AddTransport(transport.MultipartForm{})
+	srv.AddTransport(transport.Websocket{
+		KeepAlivePingInterval: 10 * time.Second,
+		Upgrader: websocket.Upgrader{
+			CheckOrigin: func(r *http.Request) bool {
+				return true
+			},
+		},
+	})
+	srv.Use(extension.Introspection{})
 	// Apply functional options
 	for _, opt := range opts {
 		if opt != nil {

--- a/server/gql/server.go
+++ b/server/gql/server.go
@@ -36,6 +36,7 @@ func NewServer(opts ...ServerOption) (http.Handler, error) {
 	srv.AddTransport(transport.MultipartForm{})
 	srv.AddTransport(transport.Websocket{
 		KeepAlivePingInterval: 10 * time.Second,
+		InitTimeout:           30 * time.Second,
 		Upgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool {
 				return true

--- a/server/gql/subscription_resolver.go
+++ b/server/gql/subscription_resolver.go
@@ -147,6 +147,9 @@ func convertVehiclePosition(vp *pb.VehiclePosition, feedOnestopID string) *model
 	}
 
 	// Stop info
+	if vp.StopId != nil {
+		mvp.StopID = vp.StopId
+	}
 	if vp.CurrentStopSequence != nil {
 		seq := int(vp.GetCurrentStopSequence())
 		mvp.CurrentStopSequence = &seq

--- a/server/gql/subscription_resolver.go
+++ b/server/gql/subscription_resolver.go
@@ -63,6 +63,18 @@ func (r *subscriptionResolver) collectVehiclePositions(ctx context.Context, cfg 
 	feedIDs := cfg.RTFinder.GetCachedFeedIDs()
 	log.For(ctx).Trace().Strs("feed_ids", feedIDs).Msg("subscription: collecting vehicle positions")
 
+	// Apply limit: use filter value if provided, otherwise default
+	limit := RESOLVER_MAXLIMIT
+	if where != nil && where.Limit != nil {
+		limit = *where.Limit
+	}
+	if limit > RESOLVER_MAXLIMIT {
+		limit = RESOLVER_MAXLIMIT
+	}
+	if limit < 0 {
+		limit = 0
+	}
+
 	var result []*model.VehiclePosition
 	for _, feedID := range feedIDs {
 		// Filter by feed_onestop_ids if specified
@@ -73,6 +85,9 @@ func (r *subscriptionResolver) collectVehiclePositions(ctx context.Context, cfg 
 		}
 		vps := cfg.RTFinder.GetVehiclePositions(ctx, feedID)
 		for _, vp := range vps {
+			if len(result) >= limit {
+				return result
+			}
 			mvp := convertVehiclePosition(vp, feedID)
 			if mvp == nil {
 				continue

--- a/server/gql/subscription_resolver.go
+++ b/server/gql/subscription_resolver.go
@@ -1,0 +1,198 @@
+package gql
+
+import (
+	"context"
+	"time"
+
+	"github.com/interline-io/log"
+	"github.com/interline-io/transitland-lib/rt/pb"
+	"github.com/interline-io/transitland-lib/server/model"
+	"github.com/interline-io/transitland-lib/tt"
+)
+
+type subscriptionResolver struct{ *Resolver }
+
+func (r *subscriptionResolver) VehiclePositions(ctx context.Context, where *model.VehiclePositionFilter) (<-chan []*model.VehiclePosition, error) {
+	cfg := model.ForContext(ctx)
+	ch := make(chan []*model.VehiclePosition, 1)
+
+	// Subscribe to cache update notifications
+	updateCh, cancelSub := cfg.RTFinder.Subscribe()
+
+	go func() {
+		defer close(ch)
+		defer cancelSub()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case _, ok := <-updateCh:
+				if !ok {
+					return
+				}
+				// Collect vehicle positions from all known RT feeds
+				positions := r.collectVehiclePositions(ctx, cfg, where)
+				select {
+				case ch <- positions:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+
+	return ch, nil
+}
+
+func (r *subscriptionResolver) collectVehiclePositions(ctx context.Context, cfg model.Config, where *model.VehiclePositionFilter) []*model.VehiclePosition {
+	// Get all feeds to check for vehicle positions
+	feeds, err := cfg.Finder.FindFeeds(ctx, nil, nil, nil, nil)
+	if err != nil {
+		log.For(ctx).Error().Err(err).Msg("subscription: error finding feeds")
+		return nil
+	}
+
+	var result []*model.VehiclePosition
+	for _, feed := range feeds {
+		feedID := feed.FeedID
+		// Filter by feed_onestop_ids if specified
+		if where != nil && len(where.FeedOnestopIds) > 0 {
+			if !containsString(where.FeedOnestopIds, feedID) {
+				continue
+			}
+		}
+		vps := cfg.RTFinder.GetVehiclePositions(ctx, feedID)
+		for _, vp := range vps {
+			mvp := convertVehiclePosition(vp, feedID)
+			if mvp == nil {
+				continue
+			}
+			if !matchesFilter(mvp, vp, where) {
+				continue
+			}
+			result = append(result, mvp)
+		}
+	}
+	return result
+}
+
+func convertVehiclePosition(vp *pb.VehiclePosition, feedOnestopID string) *model.VehiclePosition {
+	if vp == nil {
+		return nil
+	}
+	pos := vp.GetPosition()
+	if pos == nil {
+		return nil
+	}
+
+	mvp := &model.VehiclePosition{
+		FeedOnestopID: &feedOnestopID,
+	}
+
+	// Position
+	p := tt.NewPoint(float64(pos.GetLongitude()), float64(pos.GetLatitude()))
+	mvp.Position = &p
+
+	// Bearing and speed
+	if pos.Bearing != nil {
+		b := float64(pos.GetBearing())
+		mvp.Bearing = &b
+	}
+	if pos.Speed != nil {
+		s := float64(pos.GetSpeed())
+		mvp.Speed = &s
+	}
+
+	// Vehicle descriptor
+	if v := vp.GetVehicle(); v != nil {
+		mvp.Vehicle = &model.RTVehicleDescriptor{}
+		if v.Id != nil {
+			mvp.Vehicle.ID = v.Id
+		}
+		if v.Label != nil {
+			mvp.Vehicle.Label = v.Label
+		}
+		if v.LicensePlate != nil {
+			mvp.Vehicle.LicensePlate = v.LicensePlate
+		}
+	}
+
+	// Trip descriptor
+	if td := vp.GetTrip(); td != nil {
+		mvp.Trip = &model.RTTripDescriptor{}
+		if td.TripId != nil {
+			mvp.Trip.TripID = td.TripId
+		}
+		if td.RouteId != nil {
+			mvp.Trip.RouteID = td.RouteId
+		}
+		if td.DirectionId != nil {
+			d := int(*td.DirectionId)
+			mvp.Trip.DirectionID = &d
+		}
+		if td.ScheduleRelationship != nil {
+			sr := td.ScheduleRelationship.String()
+			mvp.Trip.ScheduleRelationship = &sr
+		}
+	}
+
+	// Stop info
+	if vp.CurrentStopSequence != nil {
+		seq := int(vp.GetCurrentStopSequence())
+		mvp.CurrentStopSequence = &seq
+	}
+	if vp.CurrentStatus != nil {
+		cs := vp.CurrentStatus.String()
+		mvp.CurrentStatus = &cs
+	}
+	if vp.CongestionLevel != nil {
+		cl := vp.CongestionLevel.String()
+		mvp.CongestionLevel = &cl
+	}
+
+	// Timestamp
+	if vp.Timestamp != nil {
+		t := time.Unix(int64(vp.GetTimestamp()), 0).In(time.UTC)
+		mvp.Timestamp = &t
+	}
+
+	return mvp
+}
+
+func matchesFilter(mvp *model.VehiclePosition, vp *pb.VehiclePosition, where *model.VehiclePositionFilter) bool {
+	if where == nil {
+		return true
+	}
+
+	// Bbox filter
+	if where.Bbox != nil && mvp.Position != nil {
+		lon := mvp.Position.X()
+		lat := mvp.Position.Y()
+		if lon < where.Bbox.MinLon || lon > where.Bbox.MaxLon ||
+			lat < where.Bbox.MinLat || lat > where.Bbox.MaxLat {
+			return false
+		}
+	}
+
+	// Route filter
+	if len(where.RouteIds) > 0 {
+		if vp.GetTrip() == nil || !containsString(where.RouteIds, vp.GetTrip().GetRouteId()) {
+			return false
+		}
+	}
+
+	// Agency filter — match via route_id is not possible without DB lookup,
+	// so for now agency_ids filters on the feed level only.
+	// A future enhancement could join against GTFS static data.
+
+	return true
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/server/gql/subscription_resolver.go
+++ b/server/gql/subscription_resolver.go
@@ -18,20 +18,34 @@ func (r *subscriptionResolver) VehiclePositions(ctx context.Context, where *mode
 
 	// Subscribe to cache update notifications
 	updateCh, cancelSub := cfg.RTFinder.Subscribe()
+	log.For(ctx).Info().Msg("subscription: client connected for vehicle_positions")
 
 	go func() {
 		defer close(ch)
 		defer cancelSub()
+		defer log.For(ctx).Info().Msg("subscription: client disconnected")
+
+		// Send initial snapshot from cache on connection
+		positions := r.collectVehiclePositions(ctx, cfg, where)
+		log.For(ctx).Info().Int("positions", len(positions)).Msg("subscription: sending initial snapshot")
+		select {
+		case ch <- positions:
+		case <-ctx.Done():
+			return
+		}
+
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case _, ok := <-updateCh:
+			case topic, ok := <-updateCh:
 				if !ok {
 					return
 				}
+				log.For(ctx).Trace().Str("topic", topic).Msg("subscription: cache update received")
 				// Collect vehicle positions from all known RT feeds
 				positions := r.collectVehiclePositions(ctx, cfg, where)
+				log.For(ctx).Trace().Int("positions", len(positions)).Msg("subscription: sending positions to client")
 				select {
 				case ch <- positions:
 				case <-ctx.Done():
@@ -45,16 +59,12 @@ func (r *subscriptionResolver) VehiclePositions(ctx context.Context, where *mode
 }
 
 func (r *subscriptionResolver) collectVehiclePositions(ctx context.Context, cfg model.Config, where *model.VehiclePositionFilter) []*model.VehiclePosition {
-	// Get all feeds to check for vehicle positions
-	feeds, err := cfg.Finder.FindFeeds(ctx, nil, nil, nil, nil)
-	if err != nil {
-		log.For(ctx).Error().Err(err).Msg("subscription: error finding feeds")
-		return nil
-	}
+	// Get feed IDs from cache (doesn't require database)
+	feedIDs := cfg.RTFinder.GetCachedFeedIDs()
+	log.For(ctx).Trace().Strs("feed_ids", feedIDs).Msg("subscription: collecting vehicle positions")
 
 	var result []*model.VehiclePosition
-	for _, feed := range feeds {
-		feedID := feed.FeedID
+	for _, feedID := range feedIDs {
 		// Filter by feed_onestop_ids if specified
 		if where != nil && len(where.FeedOnestopIds) > 0 {
 			if !containsString(where.FeedOnestopIds, feedID) {

--- a/server/gql/subscription_resolver.go
+++ b/server/gql/subscription_resolver.go
@@ -77,7 +77,7 @@ func (r *subscriptionResolver) collectVehiclePositions(ctx context.Context, cfg 
 			if mvp == nil {
 				continue
 			}
-			if !matchesFilter(mvp, vp, where) {
+			if !matchesFilter(mvp, where) {
 				continue
 			}
 			result = append(result, mvp)
@@ -172,7 +172,7 @@ func convertVehiclePosition(vp *pb.VehiclePosition, feedOnestopID string) *model
 	return mvp
 }
 
-func matchesFilter(mvp *model.VehiclePosition, vp *pb.VehiclePosition, where *model.VehiclePositionFilter) bool {
+func matchesFilter(mvp *model.VehiclePosition, where *model.VehiclePositionFilter) bool {
 	if where == nil {
 		return true
 	}
@@ -186,17 +186,6 @@ func matchesFilter(mvp *model.VehiclePosition, vp *pb.VehiclePosition, where *mo
 			return false
 		}
 	}
-
-	// Route filter
-	if len(where.RouteIds) > 0 {
-		if vp.GetTrip() == nil || !containsString(where.RouteIds, vp.GetTrip().GetRouteId()) {
-			return false
-		}
-	}
-
-	// Agency filter — match via route_id is not possible without DB lookup,
-	// so for now agency_ids filters on the feed level only.
-	// A future enhancement could join against GTFS static data.
 
 	return true
 }

--- a/server/gql/subscription_resolver_test.go
+++ b/server/gql/subscription_resolver_test.go
@@ -1,0 +1,230 @@
+package gql
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/99designs/gqlgen/client"
+	"github.com/interline-io/transitland-lib/internal/testconfig"
+	"github.com/interline-io/transitland-lib/rt/pb"
+	"github.com/interline-io/transitland-lib/server/auth/authn"
+	"github.com/interline-io/transitland-lib/server/auth/mw/usercheck"
+	"github.com/interline-io/transitland-lib/server/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func buildTestVehiclePositionData(t *testing.T) []byte {
+	t.Helper()
+	lat := float32(37.8044)
+	lon := float32(-122.2712)
+	bearing := float32(90.0)
+	speed := float32(10.0)
+	ts := uint64(time.Now().Unix())
+	version := "2.0"
+	incrementality := pb.FeedHeader_FULL_DATASET
+	vehicleID := "test-vehicle-1"
+	label := "Test Bus"
+	entityID := "entity-1"
+	tripID := "trip-1"
+	routeID := "route-1"
+	status := pb.VehiclePosition_IN_TRANSIT_TO
+
+	msg := &pb.FeedMessage{
+		Header: &pb.FeedHeader{
+			GtfsRealtimeVersion: &version,
+			Incrementality:      &incrementality,
+			Timestamp:           &ts,
+		},
+		Entity: []*pb.FeedEntity{
+			{
+				Id: &entityID,
+				Vehicle: &pb.VehiclePosition{
+					Vehicle: &pb.VehicleDescriptor{
+						Id:    &vehicleID,
+						Label: &label,
+					},
+					Trip: &pb.TripDescriptor{
+						TripId:  &tripID,
+						RouteId: &routeID,
+					},
+					Position: &pb.Position{
+						Latitude:  &lat,
+						Longitude: &lon,
+						Bearing:   &bearing,
+						Speed:     &speed,
+					},
+					Timestamp:     &ts,
+					CurrentStatus: &status,
+				},
+			},
+		},
+	}
+	data, err := proto.Marshal(msg)
+	require.NoError(t, err)
+	return data
+}
+
+// newSubscriptionTestClient creates a test client and returns the config so
+// tests can push RT data into the cache via cfg.RTFinder.AddData.
+func newSubscriptionTestClient(t *testing.T) (*client.Client, model.Config) {
+	t.Helper()
+	cfg := testconfig.Config(t, testconfig.Options{})
+	srv, _ := NewServer()
+	graphqlServer := model.AddConfigAndPerms(cfg, srv)
+	srvMiddleware := usercheck.NewUserDefaultMiddleware(func() authn.User {
+		return authn.NewCtxUser("testuser", "", "").WithRoles("testrole")
+	})
+	return client.New(srvMiddleware(graphqlServer)), cfg
+}
+
+func TestSubscriptionVehiclePositions(t *testing.T) {
+	c, cfg := newSubscriptionTestClient(t)
+	ctx := context.Background()
+
+	// Push VP data into cache before subscribing so the initial snapshot has data
+	vpData := buildTestVehiclePositionData(t)
+	err := cfg.RTFinder.AddData(ctx, "rtdata:test-feed:realtime_vehicle_positions", vpData)
+	require.NoError(t, err)
+
+	// Subscribe
+	sub := c.Websocket(`subscription { vehicle_positions { feed_onestop_id bearing speed position vehicle { id label } trip { trip_id route_id } } }`)
+	defer sub.Close()
+
+	// Read initial snapshot
+	var resp struct {
+		VehiclePositions []struct {
+			FeedOnestopID string   `json:"feed_onestop_id"`
+			Bearing       *float64 `json:"bearing"`
+			Speed         *float64 `json:"speed"`
+			Position      any      `json:"position"`
+			Vehicle       *struct {
+				ID    string `json:"id"`
+				Label string `json:"label"`
+			} `json:"vehicle"`
+			Trip *struct {
+				TripID  string `json:"trip_id"`
+				RouteID string `json:"route_id"`
+			} `json:"trip"`
+		} `json:"vehicle_positions"`
+	}
+	err = sub.Next(&resp)
+	require.NoError(t, err)
+	require.Len(t, resp.VehiclePositions, 1)
+
+	vp := resp.VehiclePositions[0]
+	assert.Equal(t, "test-feed", vp.FeedOnestopID)
+	assert.NotNil(t, vp.Bearing)
+	assert.InDelta(t, 90.0, *vp.Bearing, 0.1)
+	assert.NotNil(t, vp.Speed)
+	assert.InDelta(t, 10.0, *vp.Speed, 0.1)
+	assert.NotNil(t, vp.Position)
+	require.NotNil(t, vp.Vehicle)
+	assert.Equal(t, "test-vehicle-1", vp.Vehicle.ID)
+	assert.Equal(t, "Test Bus", vp.Vehicle.Label)
+	require.NotNil(t, vp.Trip)
+	assert.Equal(t, "trip-1", vp.Trip.TripID)
+	assert.Equal(t, "route-1", vp.Trip.RouteID)
+}
+
+func TestSubscriptionVehiclePositions_FilterFeed(t *testing.T) {
+	c, cfg := newSubscriptionTestClient(t)
+	ctx := context.Background()
+
+	// Push VP data for two feeds
+	vpData := buildTestVehiclePositionData(t)
+	err := cfg.RTFinder.AddData(ctx, "rtdata:feed-a:realtime_vehicle_positions", vpData)
+	require.NoError(t, err)
+	err = cfg.RTFinder.AddData(ctx, "rtdata:feed-b:realtime_vehicle_positions", vpData)
+	require.NoError(t, err)
+
+	// Subscribe with feed filter — only feed-a
+	sub := c.Websocket(`subscription { vehicle_positions(where: {feed_onestop_ids: ["feed-a"]}) { feed_onestop_id } }`)
+	defer sub.Close()
+
+	var resp struct {
+		VehiclePositions []struct {
+			FeedOnestopID string `json:"feed_onestop_id"`
+		} `json:"vehicle_positions"`
+	}
+	err = sub.Next(&resp)
+	require.NoError(t, err)
+	require.Len(t, resp.VehiclePositions, 1)
+	assert.Equal(t, "feed-a", resp.VehiclePositions[0].FeedOnestopID)
+}
+
+func TestSubscriptionVehiclePositions_FilterBbox(t *testing.T) {
+	c, cfg := newSubscriptionTestClient(t)
+	ctx := context.Background()
+
+	// Test data is at lat=37.8044, lon=-122.2712
+	vpData := buildTestVehiclePositionData(t)
+	err := cfg.RTFinder.AddData(ctx, "rtdata:test-feed:realtime_vehicle_positions", vpData)
+	require.NoError(t, err)
+
+	t.Run("matching bbox", func(t *testing.T) {
+		sub := c.Websocket(`subscription { vehicle_positions(where: {bbox: {min_lon: -123, min_lat: 37, max_lon: -122, max_lat: 38}}) { feed_onestop_id } }`)
+		defer sub.Close()
+
+		var resp struct {
+			VehiclePositions []struct {
+				FeedOnestopID string `json:"feed_onestop_id"`
+			} `json:"vehicle_positions"`
+		}
+		err := sub.Next(&resp)
+		require.NoError(t, err)
+		assert.Len(t, resp.VehiclePositions, 1)
+	})
+
+	t.Run("non-matching bbox", func(t *testing.T) {
+		sub := c.Websocket(`subscription { vehicle_positions(where: {bbox: {min_lon: 0, min_lat: 0, max_lon: 1, max_lat: 1}}) { feed_onestop_id } }`)
+		defer sub.Close()
+
+		var resp struct {
+			VehiclePositions []struct {
+				FeedOnestopID string `json:"feed_onestop_id"`
+			} `json:"vehicle_positions"`
+		}
+		err := sub.Next(&resp)
+		require.NoError(t, err)
+		assert.Len(t, resp.VehiclePositions, 0)
+	})
+}
+
+func TestSubscriptionVehiclePositions_LiveUpdate(t *testing.T) {
+	c, cfg := newSubscriptionTestClient(t)
+	ctx := context.Background()
+
+	// Subscribe first with no data — initial snapshot should be empty
+	sub := c.Websocket(`subscription { vehicle_positions { feed_onestop_id vehicle { id } } }`)
+	defer sub.Close()
+
+	var resp struct {
+		VehiclePositions []struct {
+			FeedOnestopID string `json:"feed_onestop_id"`
+			Vehicle       *struct {
+				ID string `json:"id"`
+			} `json:"vehicle"`
+		} `json:"vehicle_positions"`
+	}
+
+	// Initial snapshot: empty
+	err := sub.Next(&resp)
+	require.NoError(t, err)
+	assert.Len(t, resp.VehiclePositions, 0)
+
+	// Push data — should trigger a live update
+	vpData := buildTestVehiclePositionData(t)
+	err = cfg.RTFinder.AddData(ctx, "rtdata:test-feed:realtime_vehicle_positions", vpData)
+	require.NoError(t, err)
+
+	// Read the live update
+	err = sub.Next(&resp)
+	require.NoError(t, err)
+	require.Len(t, resp.VehiclePositions, 1)
+	assert.Equal(t, "test-feed", resp.VehiclePositions[0].FeedOnestopID)
+	require.NotNil(t, resp.VehiclePositions[0].Vehicle)
+	assert.Equal(t, "test-vehicle-1", resp.VehiclePositions[0].Vehicle.ID)
+}

--- a/server/meters/mw.go
+++ b/server/meters/mw.go
@@ -1,6 +1,9 @@
 package meters
 
 import (
+	"bufio"
+	"fmt"
+	"net"
 	"net/http"
 	"time"
 
@@ -81,4 +84,12 @@ func (w *responseWriterWrapper) Write(b []byte) (int, error) {
 	n, err := w.ResponseWriter.Write(b)
 	w.responseSize += int64(n)
 	return n, err
+}
+
+// Hijack implements http.Hijacker to support WebSocket upgrades.
+func (w *responseWriterWrapper) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := w.ResponseWriter.(http.Hijacker); ok {
+		return hj.Hijack()
+	}
+	return nil, nil, fmt.Errorf("underlying ResponseWriter does not implement http.Hijacker")
 }

--- a/server/model/finders.go
+++ b/server/model/finders.go
@@ -156,6 +156,10 @@ type RTFinder interface {
 	FindAlertsForAgency(context.Context, *Agency, *int, *bool) []*Alert
 	GetAddedTripsForStop(context.Context, *Stop) []*pb.TripUpdate
 	FindStopTimeUpdate(context.Context, *Trip, *StopTime) (*RTStopTimeUpdate, bool)
+	// Vehicle positions
+	GetVehiclePositions(context.Context, string) []*pb.VehiclePosition
+	// Subscribe returns a channel notified when any RT topic is updated
+	Subscribe() (chan string, func())
 	// lookup cache methods
 	StopTimezone(context.Context, int, string) (*time.Location, bool)
 	FeedVersionTimezone(context.Context, int) (*time.Location, bool)

--- a/server/model/finders.go
+++ b/server/model/finders.go
@@ -158,6 +158,8 @@ type RTFinder interface {
 	FindStopTimeUpdate(context.Context, *Trip, *StopTime) (*RTStopTimeUpdate, bool)
 	// Vehicle positions
 	GetVehiclePositions(context.Context, string) []*pb.VehiclePosition
+	// GetCachedFeedIDs returns feed IDs that have cached vehicle position data
+	GetCachedFeedIDs() []string
 	// Subscribe returns a channel notified when any RT topic is updated
 	Subscribe() (chan string, func())
 	// lookup cache methods

--- a/server/model/models_gen.go
+++ b/server/model/models_gen.go
@@ -1476,6 +1476,8 @@ type VehiclePositionFilter struct {
 	Bbox *BoundingBox `json:"bbox,omitempty"`
 	// Filter by feed OnestopIDs
 	FeedOnestopIds []string `json:"feed_onestop_ids,omitempty"`
+	// Maximum number of vehicle positions to return per update (default 1000)
+	Limit *int `json:"limit,omitempty"`
 }
 
 type Waypoint struct {

--- a/server/model/models_gen.go
+++ b/server/model/models_gen.go
@@ -1476,10 +1476,6 @@ type VehiclePositionFilter struct {
 	Bbox *BoundingBox `json:"bbox,omitempty"`
 	// Filter by feed OnestopIDs
 	FeedOnestopIds []string `json:"feed_onestop_ids,omitempty"`
-	// Filter by agency IDs
-	AgencyIds []string `json:"agency_ids,omitempty"`
-	// Filter by route IDs
-	RouteIds []string `json:"route_ids,omitempty"`
 }
 
 type Waypoint struct {

--- a/server/model/models_gen.go
+++ b/server/model/models_gen.go
@@ -1460,8 +1460,8 @@ type VehiclePosition struct {
 	Speed *float64 `json:"speed,omitempty"`
 	// GTFS-RT VehiclePosition current stop sequence in trip
 	CurrentStopSequence *int `json:"current_stop_sequence,omitempty"`
-	// GTFS-RT VehiclePosition current stop in trip
-	StopID *Stop `json:"stop_id,omitempty"`
+	// GTFS-RT VehiclePosition current stop ID
+	StopID *string `json:"stop_id,omitempty"`
 	// GTFS-RT VehiclePosition current status string
 	CurrentStatus *string `json:"current_status,omitempty"`
 	// GTFS-RT VehiclePosition timestamp

--- a/server/model/models_gen.go
+++ b/server/model/models_gen.go
@@ -1282,6 +1282,9 @@ type StopTimeFilter struct {
 	ExcludeLast *bool `json:"exclude_last,omitempty"`
 }
 
+type Subscription struct {
+}
+
 // Search options for trips
 type TripFilter struct {
 	// Search for trips scheduled on the specified GTFS calendar service date
@@ -1445,8 +1448,16 @@ type ValidationReportFilter struct {
 type VehiclePosition struct {
 	// GTFS-RT VehiclePosition vehicle. See https://gtfs.org/realtime/reference/#message-vehicledescriptor
 	Vehicle *RTVehicleDescriptor `json:"vehicle,omitempty"`
+	// GTFS-RT VehiclePosition trip. See https://gtfs.org/realtime/reference/#message-tripdescriptor
+	Trip *RTTripDescriptor `json:"trip,omitempty"`
+	// Feed that provided this vehicle position
+	FeedOnestopID *string `json:"feed_onestop_id,omitempty"`
 	// GTFS-RT VehiclePosition current vehicle position
 	Position *tt.Point `json:"position,omitempty"`
+	// GTFS-RT VehiclePosition bearing in degrees
+	Bearing *float64 `json:"bearing,omitempty"`
+	// GTFS-RT VehiclePosition speed in meters per second
+	Speed *float64 `json:"speed,omitempty"`
 	// GTFS-RT VehiclePosition current stop sequence in trip
 	CurrentStopSequence *int `json:"current_stop_sequence,omitempty"`
 	// GTFS-RT VehiclePosition current stop in trip
@@ -1457,6 +1468,18 @@ type VehiclePosition struct {
 	Timestamp *time.Time `json:"timestamp,omitempty"`
 	// GTFS-RT VehiclePosition congestion level estimate
 	CongestionLevel *string `json:"congestion_level,omitempty"`
+}
+
+// Filter for vehicle position subscriptions
+type VehiclePositionFilter struct {
+	// Bounding box to filter vehicle positions by geographic area
+	Bbox *BoundingBox `json:"bbox,omitempty"`
+	// Filter by feed OnestopIDs
+	FeedOnestopIds []string `json:"feed_onestop_ids,omitempty"`
+	// Filter by agency IDs
+	AgencyIds []string `json:"agency_ids,omitempty"`
+	// Filter by route IDs
+	RouteIds []string `json:"route_ids,omitempty"`
 }
 
 type Waypoint struct {

--- a/server/playground/playground.go
+++ b/server/playground/playground.go
@@ -26,62 +26,30 @@ const doc = `
         }
     </style>
 
-    <link rel="stylesheet"
-        href="https://cdn.jsdelivr.net/npm/graphiql-with-extensions@0.14.3/graphiqlWithExtensions.css"
-        integrity="{{.cssSRI}}"
-		crossorigin="anonymous" />
-    <script src="https://cdn.jsdelivr.net/npm/whatwg-fetch@2.0.3/fetch.min.js"
-		integrity="{{.fetchSRI}}"
-        crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react@16.8.6/umd/react.production.min.js"
-        integrity="{{.reactSRI}}"
-        crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/react-dom@16.8.6/umd/react-dom.production.min.js"
-        integrity="{{.reactDOMSRI}}"
-        crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/graphiql-with-extensions@0.14.3/graphiqlWithExtensions.min.js"
-        integrity="{{.jsSRI}}"
-        crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://unpkg.com/graphiql@3.0.9/graphiql.min.css" crossorigin="anonymous" />
 </head>
 
 <body>
     <div id="graphiql"></div>
+    <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/graphiql@3.0.9/graphiql.min.js" crossorigin="anonymous"></script>
     <script>
-        var query = "query{feeds{onestop_id}}";
-        class GraphiQLOpenExplorer extends GraphiQLWithExtensions.GraphiQLWithExtensions {
-            state = {
-                query: this.props.defaultQuery,
-                explorerIsOpen: true,
-            };
-        }
-		const url = location.protocol + '//' + location.host + '{{.endpoint}}';
-		const wsProto = location.protocol == 'https:' ? 'wss:' : 'ws:';
-		const subscriptionUrl = wsProto + '//' + location.host + '{{.endpoint}}';		
-        function graphQLFetcher(graphQLParams) {
-            var headers = {
-                Accept: 'application/json',
-                'Content-Type': 'application/json',
-            };
-            return fetch(url, {
-                method: 'post',
-                headers: headers,
-                body: JSON.stringify(graphQLParams),
-            })
-                .then(function (response) {
-                    return response.text();
-                })
-                .then(function (responseBody) {
-                    try {
-                        return JSON.parse(responseBody);
-                    } catch (error) {
-                        return responseBody;
-                    }
-                });
-        }
-        ReactDOM.render(React.createElement(GraphiQLOpenExplorer, {
-            defaultQuery: query,
-            fetcher: graphQLFetcher,
-        }), document.getElementById('graphiql'));
+        const url = location.protocol + '//' + location.host + '{{.endpoint}}';
+        const wsProto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+        const wsUrl = wsProto + '//' + location.host + '{{.endpoint}}';
+
+        const fetcher = GraphiQL.createGraphiQLFetcher({
+            url: url,
+            wsUrl: wsUrl,
+        });
+
+        ReactDOM.createRoot(document.getElementById('graphiql')).render(
+            React.createElement(GraphiQL, {
+                fetcher: fetcher,
+                defaultQuery: 'query { feeds { onestop_id } }',
+            }),
+        );
     </script>
 </body>
 </html>
@@ -94,13 +62,8 @@ func Handler(title string, endpoint string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "text/html")
 		err := page.Execute(w, map[string]string{
-			"title":       title,
-			"endpoint":    endpoint,
-			"cssSRI":      "sha384-GBqwox+q8UtVEyBLBKloN5QDlBDsQnuoSUfMeJH1ZtDiCrrk103D7Bg/WjIvl4ya",
-			"reactSRI":    "sha384-qn+ML/QkkJxqn4LLs1zjaKxlTg2Bl/6yU/xBTJAgxkmNGc6kMZyeskAG0a7eJBR1",
-			"reactDOMSRI": "sha384-85IMG5rvmoDsmMeWK/qUU4kwnYXVpC+o9hoHMLi4bpNR+gMEiPLrvkZCgsr7WWgV",
-			"fetchSRI":    "sha384-dcF7KoWRaRpjcNbVPUFgatYgAijf8DqW6NWuqLdfB5Sb4Cdbb8iHX7bHsl9YhpKa",
-			"jsSRI":       "sha384-TqI6gT2PjmSrnEOTvGHLad1U4Vm5VoyzMmcKK0C/PLCWTnwPyXhCJY6NYhC/tp19",
+			"title":    title,
+			"endpoint": endpoint,
 		})
 		if err != nil {
 			util.WriteJsonError(w, http.StatusText(http.StatusUnauthorized), http.StatusInternalServerError)

--- a/testdata/dmfr/rt-test.dmfr.json
+++ b/testdata/dmfr/rt-test.dmfr.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema.json",
+  "feeds": [
+    {
+      "id": "rt-test~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "http://localhost:8888/vehicle_positions.pb"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add GraphQL subscription support for real-time vehicle position streaming over WebSocket. Clients subscribe to `vehicle_positions` and receive live GTFS-RT vehicle position snapshots as they arrive, with optional filtering by bounding box and feed. The subscription path reads exclusively from the RT cache (no database), keeping the hot path fast.

See `doc/design-vehicle-position-subscriptions.md` for the full design document and remaining work items.

### GraphQL schema
- Add `Subscription` root type with `vehicle_positions(where: VehiclePositionFilter)` field
- `VehiclePositionFilter` supports `bbox`, `feed_onestop_ids`, and `limit` (default/max 1000)
- Extend `VehiclePosition` type with `trip`, `feed_onestop_id`, `bearing`, `speed` fields
- Change `stop_id` from `Stop` (DB-resolved object) to `String` (raw GTFS-RT value) to keep subscriptions DB-free

### WebSocket infrastructure
- Register WebSocket transport (gorilla/websocket) in gqlgen with 10s keepalive and 30s init timeout
- Add `wsAwareTimeout` middleware that bypasses `http.TimeoutHandler` for WebSocket upgrades while keeping the single router and full middleware stack (no middleware duplication)
- Add `Hijack()` on `responseWriterWrapper` in meters middleware to support WebSocket upgrades
- Upgrade GraphiQL playground from v0.14 to v3.0.9 with native subscription support

### RT cache pub/sub and vehicle position support
- Add `Subscribe()` and `GetSourceKeys()` to the `Cache` interface
- `LocalCache`: in-memory subscriber channels with non-blocking notification
- `RedisCache`: Redis PSUBSCRIBE on `rtfetch:sub:*` channels; removed unused in-memory subscriber dead code
- Parse vehicle position entities from GTFS-RT feed messages in `Source.processMessage`
- Add `GetVehiclePositions()` and `GetCachedFeedIDs()` to `RTFinder` interface and implementation

### Subscription resolver
- Subscribe to cache update notifications, send initial snapshot on connect, push updated snapshots on each RT update
- `convertVehiclePosition`: maps protobuf VehiclePosition to GraphQL model (position, bearing, speed, vehicle, trip, stop info, timestamp)
- Filtering by `feed_onestop_ids` (at feed level) and `bbox` (per position)
- Result capped at `limit` (default 1000) to prevent unbounded responses

### Testing
- Integration tests using gqlgen WebSocket test client: full field mapping, feed filter, bbox filter (match/no-match), live update flow (empty snapshot → push data → verify update)

### Dev tooling
- `cmd/rt-test-server`: standalone binary generating synthetic vehicle positions with optional real RT feed fetching
- `testdata/dmfr/rt-test.dmfr.json` fixture for local testing

## Test plan
- Run subscription integration tests: `go test -run TestSubscription -v ./server/gql/...`
- Start the server with RT feeds configured, open GraphiQL, execute `subscription { vehicle_positions { position bearing vehicle { id label } } }` and verify WebSocket streaming
- Verify filtering with `where: { bbox: {...}, feed_onestop_ids: [...] }` arguments
- Confirm non-WebSocket HTTP requests still go through the timeout handler normally
