### PR TITLE
Add users resolvers and additional tenant/group filters

### DIFF
--- a/internal/generated/gqlout/generated.go
+++ b/internal/generated/gqlout/generated.go
@@ -940,15 +940,15 @@ type ComplexityRoot struct {
 		Docks          func(childComplexity int, limit *int, where *model.GbfsDockRequest) int
 		FeedVersions   func(childComplexity int, limit *int, after *int, ids []int, where *model.FeedVersionFilter) int
 		Feeds          func(childComplexity int, limit *int, after *int, ids []int, where *model.FeedFilter) int
-		Groups         func(childComplexity int, limit *int, id *int) int
+		Groups         func(childComplexity int, limit *int, ids []int) int
 		Me             func(childComplexity int) int
 		Operators      func(childComplexity int, limit *int, after *int, ids []int, where *model.OperatorFilter) int
 		Places         func(childComplexity int, limit *int, after *int, level *model.PlaceAggregationLevel, where *model.PlaceFilter) int
 		Routes         func(childComplexity int, limit *int, after *int, ids []int, where *model.RouteFilter) int
 		Stops          func(childComplexity int, limit *int, after *int, ids []int, where *model.StopFilter) int
-		Tenants        func(childComplexity int, limit *int, id *int) int
+		Tenants        func(childComplexity int, limit *int, ids []int) int
 		Trips          func(childComplexity int, limit *int, after *int, ids []int, where *model.TripFilter) int
-		Users          func(childComplexity int, limit *int, id *string, q *string) int
+		Users          func(childComplexity int, limit *int, where *model.UserFilter) int
 	}
 
 	RTTimeRange struct {
@@ -1511,9 +1511,9 @@ type QueryResolver interface {
 	Docks(ctx context.Context, limit *int, where *model.GbfsDockRequest) ([]*model.GbfsStationInformation, error)
 	Me(ctx context.Context) (*model.Me, error)
 	CensusDatasets(ctx context.Context, limit *int, after *int, ids []int, where *model.CensusDatasetFilter) ([]*model.CensusDataset, error)
-	Tenants(ctx context.Context, limit *int, id *int) ([]*model.Tenant, error)
-	Groups(ctx context.Context, limit *int, id *int) ([]*model.Group, error)
-	Users(ctx context.Context, limit *int, id *string, q *string) ([]*model.User, error)
+	Tenants(ctx context.Context, limit *int, ids []int) ([]*model.Tenant, error)
+	Groups(ctx context.Context, limit *int, ids []int) ([]*model.Group, error)
+	Users(ctx context.Context, limit *int, where *model.UserFilter) ([]*model.User, error)
 }
 type RouteResolver interface {
 	Geometry(ctx context.Context, obj *model.Route) (*tt.Geometry, error)
@@ -6262,7 +6262,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Groups(childComplexity, args["limit"].(*int), args["id"].(*int)), true
+		return e.complexity.Query.Groups(childComplexity, args["limit"].(*int), args["ids"].([]int)), true
 
 	case "Query.me":
 		if e.complexity.Query.Me == nil {
@@ -6329,7 +6329,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Tenants(childComplexity, args["limit"].(*int), args["id"].(*int)), true
+		return e.complexity.Query.Tenants(childComplexity, args["limit"].(*int), args["ids"].([]int)), true
 
 	case "Query.trips":
 		if e.complexity.Query.Trips == nil {
@@ -6353,7 +6353,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Users(childComplexity, args["limit"].(*int), args["id"].(*string), args["q"].(*string)), true
+		return e.complexity.Query.Users(childComplexity, args["limit"].(*int), args["where"].(*model.UserFilter)), true
 
 	case "RTTimeRange.end":
 		if e.complexity.RTTimeRange.End == nil {
@@ -8643,6 +8643,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputTenantInput,
 		ec.unmarshalInputTripFilter,
 		ec.unmarshalInputTripStopTimeFilter,
+		ec.unmarshalInputUserFilter,
 		ec.unmarshalInputValidationReportFilter,
 		ec.unmarshalInputWaypointInput,
 	)
@@ -9254,13 +9255,21 @@ type User {
   email: String!
 }
 
+"""Search options for users"""
+input UserFilter {
+  "Search for a user by ID"
+  id: String
+  "Full text search"
+  q: String
+}
+
 extend type Query {
   "List tenants accessible to the current user"
-  tenants(limit: Int, id: Int): [Tenant!]!
+  tenants(limit: Int, ids: [Int!]): [Tenant!]!
   "List groups accessible to the current user"
-  groups(limit: Int, id: Int): [Group!]!
+  groups(limit: Int, ids: [Int!]): [Group!]!
   "Search for users"
-  users(limit: Int, id: String, q: String): [User!]!
+  users(limit: Int, where: UserFilter): [User!]!
 }
 
 extend type Mutation {
@@ -12752,11 +12761,11 @@ func (ec *executionContext) field_Query_groups_args(ctx context.Context, rawArgs
 		return nil, err
 	}
 	args["limit"] = arg0
-	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "id", ec.unmarshalOInt2ᚖint)
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "ids", ec.unmarshalOInt2ᚕintᚄ)
 	if err != nil {
 		return nil, err
 	}
-	args["id"] = arg1
+	args["ids"] = arg1
 	return args, nil
 }
 
@@ -12872,11 +12881,11 @@ func (ec *executionContext) field_Query_tenants_args(ctx context.Context, rawArg
 		return nil, err
 	}
 	args["limit"] = arg0
-	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "id", ec.unmarshalOInt2ᚖint)
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "ids", ec.unmarshalOInt2ᚕintᚄ)
 	if err != nil {
 		return nil, err
 	}
-	args["id"] = arg1
+	args["ids"] = arg1
 	return args, nil
 }
 
@@ -12914,16 +12923,11 @@ func (ec *executionContext) field_Query_users_args(ctx context.Context, rawArgs 
 		return nil, err
 	}
 	args["limit"] = arg0
-	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "id", ec.unmarshalOString2ᚖstring)
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "where", ec.unmarshalOUserFilter2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐUserFilter)
 	if err != nil {
 		return nil, err
 	}
-	args["id"] = arg1
-	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "q", ec.unmarshalOString2ᚖstring)
-	if err != nil {
-		return nil, err
-	}
-	args["q"] = arg2
+	args["where"] = arg1
 	return args, nil
 }
 
@@ -44644,7 +44648,7 @@ func (ec *executionContext) _Query_tenants(ctx context.Context, field graphql.Co
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Tenants(rctx, fc.Args["limit"].(*int), fc.Args["id"].(*int))
+		return ec.resolvers.Query().Tenants(rctx, fc.Args["limit"].(*int), fc.Args["ids"].([]int))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -44709,7 +44713,7 @@ func (ec *executionContext) _Query_groups(ctx context.Context, field graphql.Col
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Groups(rctx, fc.Args["limit"].(*int), fc.Args["id"].(*int))
+		return ec.resolvers.Query().Groups(rctx, fc.Args["limit"].(*int), fc.Args["ids"].([]int))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -44776,7 +44780,7 @@ func (ec *executionContext) _Query_users(ctx context.Context, field graphql.Coll
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Users(rctx, fc.Args["limit"].(*int), fc.Args["id"].(*string), fc.Args["q"].(*string))
+		return ec.resolvers.Query().Users(rctx, fc.Args["limit"].(*int), fc.Args["where"].(*model.UserFilter))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -65105,6 +65109,40 @@ func (ec *executionContext) unmarshalInputTripStopTimeFilter(ctx context.Context
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputUserFilter(ctx context.Context, obj any) (model.UserFilter, error) {
+	var it model.UserFilter
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"id", "q"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "id":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ID = data
+		case "q":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("q"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Q = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputValidationReportFilter(ctx context.Context, obj any) (model.ValidationReportFilter, error) {
 	var it model.ValidationReportFilter
 	asMap := map[string]any{}
@@ -83614,6 +83652,14 @@ func (ec *executionContext) marshalOUrl2ᚖgithubᚗcomᚋinterlineᚑioᚋtrans
 		return graphql.Null
 	}
 	return v
+}
+
+func (ec *executionContext) unmarshalOUserFilter2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐUserFilter(ctx context.Context, v any) (*model.UserFilter, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputUserFilter(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOValidationRealtimeResult2ᚕᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐValidationRealtimeResultᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.ValidationRealtimeResult) graphql.Marshaler {

--- a/internal/generated/gqlout/generated.go
+++ b/internal/generated/gqlout/generated.go
@@ -940,14 +940,15 @@ type ComplexityRoot struct {
 		Docks          func(childComplexity int, limit *int, where *model.GbfsDockRequest) int
 		FeedVersions   func(childComplexity int, limit *int, after *int, ids []int, where *model.FeedVersionFilter) int
 		Feeds          func(childComplexity int, limit *int, after *int, ids []int, where *model.FeedFilter) int
-		Groups         func(childComplexity int, limit *int) int
+		Groups         func(childComplexity int, limit *int, id *int) int
 		Me             func(childComplexity int) int
 		Operators      func(childComplexity int, limit *int, after *int, ids []int, where *model.OperatorFilter) int
 		Places         func(childComplexity int, limit *int, after *int, level *model.PlaceAggregationLevel, where *model.PlaceFilter) int
 		Routes         func(childComplexity int, limit *int, after *int, ids []int, where *model.RouteFilter) int
 		Stops          func(childComplexity int, limit *int, after *int, ids []int, where *model.StopFilter) int
-		Tenants        func(childComplexity int, limit *int) int
+		Tenants        func(childComplexity int, limit *int, id *int) int
 		Trips          func(childComplexity int, limit *int, after *int, ids []int, where *model.TripFilter) int
+		Users          func(childComplexity int, limit *int, id *string, q *string) int
 	}
 
 	RTTimeRange struct {
@@ -1237,6 +1238,12 @@ type ComplexityRoot struct {
 		WheelchairAccessible func(childComplexity int) int
 	}
 
+	User struct {
+		Email func(childComplexity int) int
+		ID    func(childComplexity int) int
+		Name  func(childComplexity int) int
+	}
+
 	ValidationRealtimeResult struct {
 		JSON func(childComplexity int) int
 		URL  func(childComplexity int) int
@@ -1504,8 +1511,9 @@ type QueryResolver interface {
 	Docks(ctx context.Context, limit *int, where *model.GbfsDockRequest) ([]*model.GbfsStationInformation, error)
 	Me(ctx context.Context) (*model.Me, error)
 	CensusDatasets(ctx context.Context, limit *int, after *int, ids []int, where *model.CensusDatasetFilter) ([]*model.CensusDataset, error)
-	Tenants(ctx context.Context, limit *int) ([]*model.Tenant, error)
-	Groups(ctx context.Context, limit *int) ([]*model.Group, error)
+	Tenants(ctx context.Context, limit *int, id *int) ([]*model.Tenant, error)
+	Groups(ctx context.Context, limit *int, id *int) ([]*model.Group, error)
+	Users(ctx context.Context, limit *int, id *string, q *string) ([]*model.User, error)
 }
 type RouteResolver interface {
 	Geometry(ctx context.Context, obj *model.Route) (*tt.Geometry, error)
@@ -6254,7 +6262,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Groups(childComplexity, args["limit"].(*int)), true
+		return e.complexity.Query.Groups(childComplexity, args["limit"].(*int), args["id"].(*int)), true
 
 	case "Query.me":
 		if e.complexity.Query.Me == nil {
@@ -6321,7 +6329,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Query.Tenants(childComplexity, args["limit"].(*int)), true
+		return e.complexity.Query.Tenants(childComplexity, args["limit"].(*int), args["id"].(*int)), true
 
 	case "Query.trips":
 		if e.complexity.Query.Trips == nil {
@@ -6334,6 +6342,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.Trips(childComplexity, args["limit"].(*int), args["after"].(*int), args["ids"].([]int), args["where"].(*model.TripFilter)), true
+
+	case "Query.users":
+		if e.complexity.Query.Users == nil {
+			break
+		}
+
+		args, err := ec.field_Query_users_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.Users(childComplexity, args["limit"].(*int), args["id"].(*string), args["q"].(*string)), true
 
 	case "RTTimeRange.end":
 		if e.complexity.RTTimeRange.End == nil {
@@ -8011,6 +8031,27 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Trip.WheelchairAccessible(childComplexity), true
 
+	case "User.email":
+		if e.complexity.User.Email == nil {
+			break
+		}
+
+		return e.complexity.User.Email(childComplexity), true
+
+	case "User.id":
+		if e.complexity.User.ID == nil {
+			break
+		}
+
+		return e.complexity.User.ID(childComplexity), true
+
+	case "User.name":
+		if e.complexity.User.Name == nil {
+			break
+		}
+
+		return e.complexity.User.Name(childComplexity), true
+
 	case "ValidationRealtimeResult.json":
 		if e.complexity.ValidationRealtimeResult.JSON == nil {
 			break
@@ -9203,11 +9244,23 @@ input GroupInput {
   name: String!
 }
 
+"""A user in the authorization system"""
+type User {
+  "User identifier"
+  id: String!
+  "Display name"
+  name: String!
+  "Email address"
+  email: String!
+}
+
 extend type Query {
   "List tenants accessible to the current user"
-  tenants(limit: Int): [Tenant!]!
+  tenants(limit: Int, id: Int): [Tenant!]!
   "List groups accessible to the current user"
-  groups(limit: Int): [Group!]!
+  groups(limit: Int, id: Int): [Group!]!
+  "Search for users"
+  users(limit: Int, id: String, q: String): [User!]!
 }
 
 extend type Mutation {
@@ -12699,6 +12752,11 @@ func (ec *executionContext) field_Query_groups_args(ctx context.Context, rawArgs
 		return nil, err
 	}
 	args["limit"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "id", ec.unmarshalOInt2ᚖint)
+	if err != nil {
+		return nil, err
+	}
+	args["id"] = arg1
 	return args, nil
 }
 
@@ -12814,6 +12872,11 @@ func (ec *executionContext) field_Query_tenants_args(ctx context.Context, rawArg
 		return nil, err
 	}
 	args["limit"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "id", ec.unmarshalOInt2ᚖint)
+	if err != nil {
+		return nil, err
+	}
+	args["id"] = arg1
 	return args, nil
 }
 
@@ -12840,6 +12903,27 @@ func (ec *executionContext) field_Query_trips_args(ctx context.Context, rawArgs 
 		return nil, err
 	}
 	args["where"] = arg3
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_users_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "limit", ec.unmarshalOInt2ᚖint)
+	if err != nil {
+		return nil, err
+	}
+	args["limit"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "id", ec.unmarshalOString2ᚖstring)
+	if err != nil {
+		return nil, err
+	}
+	args["id"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "q", ec.unmarshalOString2ᚖstring)
+	if err != nil {
+		return nil, err
+	}
+	args["q"] = arg2
 	return args, nil
 }
 
@@ -44560,7 +44644,7 @@ func (ec *executionContext) _Query_tenants(ctx context.Context, field graphql.Co
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Tenants(rctx, fc.Args["limit"].(*int))
+		return ec.resolvers.Query().Tenants(rctx, fc.Args["limit"].(*int), fc.Args["id"].(*int))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -44625,7 +44709,7 @@ func (ec *executionContext) _Query_groups(ctx context.Context, field graphql.Col
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Groups(rctx, fc.Args["limit"].(*int))
+		return ec.resolvers.Query().Groups(rctx, fc.Args["limit"].(*int), fc.Args["id"].(*int))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -44672,6 +44756,69 @@ func (ec *executionContext) fieldContext_Query_groups(ctx context.Context, field
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_groups_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_users(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_users(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Users(rctx, fc.Args["limit"].(*int), fc.Args["id"].(*string), fc.Args["q"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.User)
+	fc.Result = res
+	return ec.marshalNUser2ᚕᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐUserᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_users(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_User_id(ctx, field)
+			case "name":
+				return ec.fieldContext_User_name(ctx, field)
+			case "email":
+				return ec.fieldContext_User_email(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_users_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -56436,6 +56583,138 @@ func (ec *executionContext) fieldContext_Trip_timestamp(_ context.Context, field
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _User_id(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_User_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_User_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _User_name(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_User_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_User_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _User_email(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_User_email(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Email, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_User_email(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -72524,6 +72803,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "users":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_users(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "__type":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Query___type(ctx, field)
@@ -75980,6 +76281,55 @@ func (ec *executionContext) _Trip(ctx context.Context, sel ast.SelectionSet, obj
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var userImplementors = []string{"User"}
+
+func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj *model.User) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, userImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("User")
+		case "id":
+			out.Values[i] = ec._User_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "name":
+			out.Values[i] = ec._User_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "email":
+			out.Values[i] = ec._User_email(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -79615,6 +79965,60 @@ func (ec *executionContext) unmarshalNUrl2githubᚗcomᚋinterlineᚑioᚋtransi
 
 func (ec *executionContext) marshalNUrl2githubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐUrl(ctx context.Context, sel ast.SelectionSet, v tt.Url) graphql.Marshaler {
 	return v
+}
+
+func (ec *executionContext) marshalNUser2ᚕᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐUserᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.User) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNUser2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐUser(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNUser2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐUser(ctx context.Context, sel ast.SelectionSet, v *model.User) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._User(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNValidationRealtimeResult2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐValidationRealtimeResult(ctx context.Context, sel ast.SelectionSet, v *model.ValidationRealtimeResult) graphql.Marshaler {

--- a/schema/graphql/permissions.graphqls
+++ b/schema/graphql/permissions.graphqls
@@ -98,13 +98,21 @@ type User {
   email: String!
 }
 
+"""Search options for users"""
+input UserFilter {
+  "Search for a user by ID"
+  id: String
+  "Full text search"
+  q: String
+}
+
 extend type Query {
   "List tenants accessible to the current user"
-  tenants(limit: Int, id: Int): [Tenant!]!
+  tenants(limit: Int, ids: [Int!]): [Tenant!]!
   "List groups accessible to the current user"
-  groups(limit: Int, id: Int): [Group!]!
+  groups(limit: Int, ids: [Int!]): [Group!]!
   "Search for users"
-  users(limit: Int, id: String, q: String): [User!]!
+  users(limit: Int, where: UserFilter): [User!]!
 }
 
 extend type Mutation {

--- a/schema/graphql/permissions.graphqls
+++ b/schema/graphql/permissions.graphqls
@@ -88,11 +88,23 @@ input GroupInput {
   name: String!
 }
 
+"""A user in the authorization system"""
+type User {
+  "User identifier"
+  id: String!
+  "Display name"
+  name: String!
+  "Email address"
+  email: String!
+}
+
 extend type Query {
   "List tenants accessible to the current user"
-  tenants(limit: Int): [Tenant!]!
+  tenants(limit: Int, id: Int): [Tenant!]!
   "List groups accessible to the current user"
-  groups(limit: Int): [Group!]!
+  groups(limit: Int, id: Int): [Group!]!
+  "Search for users"
+  users(limit: Int, id: String, q: String): [User!]!
 }
 
 extend type Mutation {

--- a/server/auth/authz/checker.go
+++ b/server/auth/authz/checker.go
@@ -73,6 +73,8 @@ type PermissionManager interface {
 // boundaries, tenant membership, etc.).
 type AdminManager interface {
 	PermissionManager
+	UserList(ctx context.Context, req *UserListRequest) (*UserListResponse, error)
+	User(ctx context.Context, req *UserRequest) (*UserResponse, error)
 	TenantSave(ctx context.Context, req *TenantSaveRequest) (*TenantSaveResponse, error)
 	TenantCreateGroup(ctx context.Context, req *TenantCreateGroupRequest) (*GroupSaveResponse, error)
 	GroupSave(ctx context.Context, req *GroupSaveRequest) (*GroupSaveResponse, error)

--- a/server/gql/permission_resolver.go
+++ b/server/gql/permission_resolver.go
@@ -127,15 +127,20 @@ func (r *queryResolver) Tenants(ctx context.Context, limit *int, id *int) ([]*mo
 	if pm == nil || err != nil {
 		return nil, nil
 	}
+	if id != nil {
+		ref := authz.ObjectRef{Type: authz.TenantType, ID: int64(*id)}
+		perms, err := pm.ObjectPermissions(ctx, ref)
+		if err != nil {
+			return []*model.Tenant{}, nil
+		}
+		return []*model.Tenant{{ID: *id, Name: perms.Ref.Name}}, nil
+	}
 	refs, err := pm.ListObjects(ctx, authz.TenantType)
 	if err != nil {
 		return nil, err
 	}
 	tenants := make([]*model.Tenant, 0, len(refs))
 	for _, ref := range refs {
-		if id != nil && int(ref.ID) != *id {
-			continue
-		}
 		t := &model.Tenant{ID: int(ref.ID)}
 		if perms, err := pm.ObjectPermissions(ctx, ref); err == nil {
 			t.Name = perms.Ref.Name
@@ -153,15 +158,20 @@ func (r *queryResolver) Groups(ctx context.Context, limit *int, id *int) ([]*mod
 	if pm == nil || err != nil {
 		return nil, nil
 	}
+	if id != nil {
+		ref := authz.ObjectRef{Type: authz.GroupType, ID: int64(*id)}
+		perms, err := pm.ObjectPermissions(ctx, ref)
+		if err != nil {
+			return []*model.Group{}, nil
+		}
+		return []*model.Group{{ID: *id, Name: perms.Ref.Name}}, nil
+	}
 	refs, err := pm.ListObjects(ctx, authz.GroupType)
 	if err != nil {
 		return nil, err
 	}
 	groups := make([]*model.Group, 0, len(refs))
 	for _, ref := range refs {
-		if id != nil && int(ref.ID) != *id {
-			continue
-		}
 		g := &model.Group{ID: int(ref.ID)}
 		if perms, err := pm.ObjectPermissions(ctx, ref); err == nil {
 			g.Name = perms.Ref.Name
@@ -177,7 +187,7 @@ func (r *queryResolver) Groups(ctx context.Context, limit *int, id *int) ([]*mod
 func (r *queryResolver) Users(ctx context.Context, limit *int, id *string, q *string) ([]*model.User, error) {
 	am, err := getAdminManager(ctx)
 	if err != nil {
-		return nil, err
+		return []*model.User{}, nil
 	}
 	// Single user lookup by ID
 	if id != nil {

--- a/server/gql/permission_resolver.go
+++ b/server/gql/permission_resolver.go
@@ -122,18 +122,25 @@ func (r *feedVersionResolver) Permissions(ctx context.Context, obj *model.FeedVe
 
 // Query resolvers for tenants and groups
 
-func (r *queryResolver) Tenants(ctx context.Context, limit *int, id *int) ([]*model.Tenant, error) {
+func (r *queryResolver) Tenants(ctx context.Context, limit *int, ids []int) ([]*model.Tenant, error) {
 	pm, err := getPermissionManager(ctx)
 	if pm == nil || err != nil {
 		return nil, nil
 	}
-	if id != nil {
-		ref := authz.ObjectRef{Type: authz.TenantType, ID: int64(*id)}
-		perms, err := pm.ObjectPermissions(ctx, ref)
-		if err != nil {
-			return []*model.Tenant{}, nil
+	if len(ids) > 0 {
+		tenants := make([]*model.Tenant, 0, len(ids))
+		for _, id := range ids {
+			ref := authz.ObjectRef{Type: authz.TenantType, ID: int64(id)}
+			perms, err := pm.ObjectPermissions(ctx, ref)
+			if err != nil {
+				continue
+			}
+			tenants = append(tenants, &model.Tenant{ID: id, Name: perms.Ref.Name})
+			if limit != nil && len(tenants) >= *limit {
+				break
+			}
 		}
-		return []*model.Tenant{{ID: *id, Name: perms.Ref.Name}}, nil
+		return tenants, nil
 	}
 	refs, err := pm.ListObjects(ctx, authz.TenantType)
 	if err != nil {
@@ -153,18 +160,25 @@ func (r *queryResolver) Tenants(ctx context.Context, limit *int, id *int) ([]*mo
 	return tenants, nil
 }
 
-func (r *queryResolver) Groups(ctx context.Context, limit *int, id *int) ([]*model.Group, error) {
+func (r *queryResolver) Groups(ctx context.Context, limit *int, ids []int) ([]*model.Group, error) {
 	pm, err := getPermissionManager(ctx)
 	if pm == nil || err != nil {
 		return nil, nil
 	}
-	if id != nil {
-		ref := authz.ObjectRef{Type: authz.GroupType, ID: int64(*id)}
-		perms, err := pm.ObjectPermissions(ctx, ref)
-		if err != nil {
-			return []*model.Group{}, nil
+	if len(ids) > 0 {
+		groups := make([]*model.Group, 0, len(ids))
+		for _, id := range ids {
+			ref := authz.ObjectRef{Type: authz.GroupType, ID: int64(id)}
+			perms, err := pm.ObjectPermissions(ctx, ref)
+			if err != nil {
+				continue
+			}
+			groups = append(groups, &model.Group{ID: id, Name: perms.Ref.Name})
+			if limit != nil && len(groups) >= *limit {
+				break
+			}
 		}
-		return []*model.Group{{ID: *id, Name: perms.Ref.Name}}, nil
+		return groups, nil
 	}
 	refs, err := pm.ListObjects(ctx, authz.GroupType)
 	if err != nil {
@@ -184,14 +198,14 @@ func (r *queryResolver) Groups(ctx context.Context, limit *int, id *int) ([]*mod
 	return groups, nil
 }
 
-func (r *queryResolver) Users(ctx context.Context, limit *int, id *string, q *string) ([]*model.User, error) {
+func (r *queryResolver) Users(ctx context.Context, limit *int, where *model.UserFilter) ([]*model.User, error) {
 	am, err := getAdminManager(ctx)
 	if err != nil {
 		return []*model.User{}, nil
 	}
 	// Single user lookup by ID
-	if id != nil {
-		resp, err := am.User(ctx, &authz.UserRequest{Id: *id})
+	if where != nil && where.ID != nil {
+		resp, err := am.User(ctx, &authz.UserRequest{Id: *where.ID})
 		if err != nil {
 			return nil, err
 		}
@@ -206,8 +220,8 @@ func (r *queryResolver) Users(ctx context.Context, limit *int, id *string, q *st
 	}
 	// Search/list users
 	searchQ := ""
-	if q != nil {
-		searchQ = *q
+	if where != nil && where.Q != nil {
+		searchQ = *where.Q
 	}
 	resp, err := am.UserList(ctx, &authz.UserListRequest{Q: searchQ})
 	if err != nil {

--- a/server/gql/permission_resolver.go
+++ b/server/gql/permission_resolver.go
@@ -206,10 +206,7 @@ func (r *queryResolver) Users(ctx context.Context, limit *int, where *model.User
 	// Single user lookup by ID
 	if where != nil && where.ID != nil {
 		resp, err := am.User(ctx, &authz.UserRequest{Id: *where.ID})
-		if err != nil {
-			return nil, err
-		}
-		if resp.User == nil {
+		if err != nil || resp.User == nil {
 			return []*model.User{}, nil
 		}
 		return []*model.User{{

--- a/server/gql/permission_resolver.go
+++ b/server/gql/permission_resolver.go
@@ -122,7 +122,7 @@ func (r *feedVersionResolver) Permissions(ctx context.Context, obj *model.FeedVe
 
 // Query resolvers for tenants and groups
 
-func (r *queryResolver) Tenants(ctx context.Context, limit *int) ([]*model.Tenant, error) {
+func (r *queryResolver) Tenants(ctx context.Context, limit *int, id *int) ([]*model.Tenant, error) {
 	pm, err := getPermissionManager(ctx)
 	if pm == nil || err != nil {
 		return nil, nil
@@ -133,6 +133,9 @@ func (r *queryResolver) Tenants(ctx context.Context, limit *int) ([]*model.Tenan
 	}
 	tenants := make([]*model.Tenant, 0, len(refs))
 	for _, ref := range refs {
+		if id != nil && int(ref.ID) != *id {
+			continue
+		}
 		t := &model.Tenant{ID: int(ref.ID)}
 		if perms, err := pm.ObjectPermissions(ctx, ref); err == nil {
 			t.Name = perms.Ref.Name
@@ -145,7 +148,7 @@ func (r *queryResolver) Tenants(ctx context.Context, limit *int) ([]*model.Tenan
 	return tenants, nil
 }
 
-func (r *queryResolver) Groups(ctx context.Context, limit *int) ([]*model.Group, error) {
+func (r *queryResolver) Groups(ctx context.Context, limit *int, id *int) ([]*model.Group, error) {
 	pm, err := getPermissionManager(ctx)
 	if pm == nil || err != nil {
 		return nil, nil
@@ -156,6 +159,9 @@ func (r *queryResolver) Groups(ctx context.Context, limit *int) ([]*model.Group,
 	}
 	groups := make([]*model.Group, 0, len(refs))
 	for _, ref := range refs {
+		if id != nil && int(ref.ID) != *id {
+			continue
+		}
 		g := &model.Group{ID: int(ref.ID)}
 		if perms, err := pm.ObjectPermissions(ctx, ref); err == nil {
 			g.Name = perms.Ref.Name
@@ -166,6 +172,49 @@ func (r *queryResolver) Groups(ctx context.Context, limit *int) ([]*model.Group,
 		}
 	}
 	return groups, nil
+}
+
+func (r *queryResolver) Users(ctx context.Context, limit *int, id *string, q *string) ([]*model.User, error) {
+	am, err := getAdminManager(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// Single user lookup by ID
+	if id != nil {
+		resp, err := am.User(ctx, &authz.UserRequest{Id: *id})
+		if err != nil {
+			return nil, err
+		}
+		if resp.User == nil {
+			return []*model.User{}, nil
+		}
+		return []*model.User{{
+			ID:    resp.User.Id,
+			Name:  resp.User.Name,
+			Email: resp.User.Email,
+		}}, nil
+	}
+	// Search/list users
+	searchQ := ""
+	if q != nil {
+		searchQ = *q
+	}
+	resp, err := am.UserList(ctx, &authz.UserListRequest{Q: searchQ})
+	if err != nil {
+		return nil, err
+	}
+	users := make([]*model.User, 0, len(resp.Users))
+	for _, u := range resp.Users {
+		users = append(users, &model.User{
+			ID:    u.Id,
+			Name:  u.Name,
+			Email: u.Email,
+		})
+		if limit != nil && len(users) >= *limit {
+			break
+		}
+	}
+	return users, nil
 }
 
 // Mutation resolvers

--- a/server/gql/permission_resolver_test.go
+++ b/server/gql/permission_resolver_test.go
@@ -478,7 +478,9 @@ func TestPermissionResolver_Users(t *testing.T) {
 	})
 
 	t.Run("get user by id not found", func(t *testing.T) {
-		postQueryExpectError(t, c, `{ users(where:{id:"nonexistent"}) { id name email } }`)
+		jj := postQuery(t, c, `{ users(where:{id:"nonexistent"}) { id name email } }`, nil)
+		users := gjson.Get(jj, "users").Array()
+		assert.Equal(t, 0, len(users))
 	})
 
 	t.Run("users returns empty without admin manager", func(t *testing.T) {

--- a/server/gql/permission_resolver_test.go
+++ b/server/gql/permission_resolver_test.go
@@ -103,6 +103,31 @@ func TestPermissionResolver_Tenants(t *testing.T) {
 		assert.True(t, found, "expected to find tl-tenant")
 	})
 
+	t.Run("get tenant by id", func(t *testing.T) {
+		// First get the tenant ID
+		jj := postQuery(t, c, `{ tenants { id name } }`, nil)
+		var tenantID int64
+		for _, tenant := range gjson.Get(jj, "tenants").Array() {
+			if tenant.Get("name").Str == "tl-tenant" {
+				tenantID = tenant.Get("id").Int()
+			}
+		}
+		assert.Greater(t, tenantID, int64(0))
+
+		// Look up by ID
+		jj = postQuery(t, c, `query($id: Int) { tenants(id: $id) { id name } }`, map[string]interface{}{"id": tenantID})
+		tenants := gjson.Get(jj, "tenants").Array()
+		assert.Equal(t, 1, len(tenants))
+		assert.Equal(t, tenantID, tenants[0].Get("id").Int())
+		assert.Equal(t, "tl-tenant", tenants[0].Get("name").Str)
+	})
+
+	t.Run("get tenant by id not found", func(t *testing.T) {
+		jj := postQuery(t, c, `query($id: Int) { tenants(id: $id) { id name } }`, map[string]interface{}{"id": 999999})
+		tenants := gjson.Get(jj, "tenants").Array()
+		assert.Equal(t, 0, len(tenants))
+	})
+
 	t.Run("tenant permissions", func(t *testing.T) {
 		jj := postQuery(t, c, `{ tenants { name permissions { actions subjects { type id name relation } children { type id name } } } }`, nil)
 		for _, tenant := range gjson.Get(jj, "tenants").Array() {
@@ -172,6 +197,31 @@ func TestPermissionResolver_Groups(t *testing.T) {
 		}
 		assert.Contains(t, groupNames, "CT-group")
 		assert.Contains(t, groupNames, "BA-group")
+	})
+
+	t.Run("get group by id", func(t *testing.T) {
+		// First get the group ID
+		jj := postQuery(t, c, `{ groups { id name } }`, nil)
+		var groupID int64
+		for _, g := range gjson.Get(jj, "groups").Array() {
+			if g.Get("name").Str == "CT-group" {
+				groupID = g.Get("id").Int()
+			}
+		}
+		assert.Greater(t, groupID, int64(0))
+
+		// Look up by ID
+		jj = postQuery(t, c, `query($id: Int) { groups(id: $id) { id name } }`, map[string]interface{}{"id": groupID})
+		groups := gjson.Get(jj, "groups").Array()
+		assert.Equal(t, 1, len(groups))
+		assert.Equal(t, groupID, groups[0].Get("id").Int())
+		assert.Equal(t, "CT-group", groups[0].Get("name").Str)
+	})
+
+	t.Run("get group by id not found", func(t *testing.T) {
+		jj := postQuery(t, c, `query($id: Int) { groups(id: $id) { id name } }`, map[string]interface{}{"id": 999999})
+		groups := gjson.Get(jj, "groups").Array()
+		assert.Equal(t, 0, len(groups))
 	})
 
 	t.Run("group tenant", func(t *testing.T) {
@@ -376,6 +426,34 @@ func TestPermissionResolver_AdminMutations(t *testing.T) {
 			assert.Equal(t, groupID, gjson.Get(jj, "group_save.id").Int())
 			assert.Equal(t, "CT-group-renamed", gjson.Get(jj, "group_save.name").Str)
 		})
+	})
+}
+
+func TestPermissionResolver_Users(t *testing.T) {
+	c := newPermTestClient(t, "tl-tenant-admin")
+
+	t.Run("list users returns empty with mock provider", func(t *testing.T) {
+		jj := postQuery(t, c, `{ users { id name email } }`, nil)
+		users := gjson.Get(jj, "users").Array()
+		assert.Equal(t, 0, len(users))
+	})
+
+	t.Run("search users with q returns empty with mock provider", func(t *testing.T) {
+		jj := postQuery(t, c, `{ users(q: "test") { id name email } }`, nil)
+		users := gjson.Get(jj, "users").Array()
+		assert.Equal(t, 0, len(users))
+	})
+
+	t.Run("get user by id not found", func(t *testing.T) {
+		postQueryExpectError(t, c, `{ users(id: "nonexistent") { id name email } }`)
+	})
+
+	t.Run("users returns empty without admin manager", func(t *testing.T) {
+		cfg := testconfig.Config(t, testconfig.Options{})
+		noAuthClient := newPermTestClientFromConfig(cfg, "testuser", "testrole")
+		jj := postQuery(t, noAuthClient, `{ users { id name email } }`, nil)
+		users := gjson.Get(jj, "users").Array()
+		assert.Equal(t, 0, len(users))
 	})
 }
 

--- a/server/gql/permission_resolver_test.go
+++ b/server/gql/permission_resolver_test.go
@@ -104,7 +104,7 @@ func TestPermissionResolver_Tenants(t *testing.T) {
 		assert.True(t, found, "expected to find tl-tenant")
 	})
 
-	t.Run("get tenant by id", func(t *testing.T) {
+	t.Run("get tenant by ids", func(t *testing.T) {
 		// First get the tenant ID
 		jj := postQuery(t, c, `{ tenants { id name } }`, nil)
 		var tenantID int64
@@ -115,16 +115,16 @@ func TestPermissionResolver_Tenants(t *testing.T) {
 		}
 		assert.Greater(t, tenantID, int64(0))
 
-		// Look up by ID
-		jj = postQuery(t, c, `query($id: Int) { tenants(id: $id) { id name } }`, map[string]interface{}{"id": tenantID})
+		// Look up by IDs
+		jj = postQuery(t, c, `query($ids: [Int!]) { tenants(ids: $ids) { id name } }`, map[string]interface{}{"ids": []int64{tenantID}})
 		tenants := gjson.Get(jj, "tenants").Array()
 		assert.Equal(t, 1, len(tenants))
 		assert.Equal(t, tenantID, tenants[0].Get("id").Int())
 		assert.Equal(t, "tl-tenant", tenants[0].Get("name").Str)
 	})
 
-	t.Run("get tenant by id not found", func(t *testing.T) {
-		jj := postQuery(t, c, `query($id: Int) { tenants(id: $id) { id name } }`, map[string]interface{}{"id": 999999})
+	t.Run("get tenant by ids not found", func(t *testing.T) {
+		jj := postQuery(t, c, `query($ids: [Int!]) { tenants(ids: $ids) { id name } }`, map[string]interface{}{"ids": []int{999999}})
 		tenants := gjson.Get(jj, "tenants").Array()
 		assert.Equal(t, 0, len(tenants))
 	})
@@ -200,7 +200,7 @@ func TestPermissionResolver_Groups(t *testing.T) {
 		assert.Contains(t, groupNames, "BA-group")
 	})
 
-	t.Run("get group by id", func(t *testing.T) {
+	t.Run("get group by ids", func(t *testing.T) {
 		// First get the group ID
 		jj := postQuery(t, c, `{ groups { id name } }`, nil)
 		var groupID int64
@@ -211,16 +211,16 @@ func TestPermissionResolver_Groups(t *testing.T) {
 		}
 		assert.Greater(t, groupID, int64(0))
 
-		// Look up by ID
-		jj = postQuery(t, c, `query($id: Int) { groups(id: $id) { id name } }`, map[string]interface{}{"id": groupID})
+		// Look up by IDs
+		jj = postQuery(t, c, `query($ids: [Int!]) { groups(ids: $ids) { id name } }`, map[string]interface{}{"ids": []int64{groupID}})
 		groups := gjson.Get(jj, "groups").Array()
 		assert.Equal(t, 1, len(groups))
 		assert.Equal(t, groupID, groups[0].Get("id").Int())
 		assert.Equal(t, "CT-group", groups[0].Get("name").Str)
 	})
 
-	t.Run("get group by id not found", func(t *testing.T) {
-		jj := postQuery(t, c, `query($id: Int) { groups(id: $id) { id name } }`, map[string]interface{}{"id": 999999})
+	t.Run("get group by ids not found", func(t *testing.T) {
+		jj := postQuery(t, c, `query($ids: [Int!]) { groups(ids: $ids) { id name } }`, map[string]interface{}{"ids": []int{999999}})
 		groups := gjson.Get(jj, "groups").Array()
 		assert.Equal(t, 0, len(groups))
 	})
@@ -448,7 +448,7 @@ func TestPermissionResolver_Users(t *testing.T) {
 	})
 
 	t.Run("search users with q", func(t *testing.T) {
-		jj := postQuery(t, c, `{ users(q: "alice") { id name email } }`, nil)
+		jj := postQuery(t, c, `{ users(where:{q:"alice"}) { id name email } }`, nil)
 		users := gjson.Get(jj, "users").Array()
 		assert.Equal(t, 1, len(users))
 		assert.Equal(t, "alice", users[0].Get("id").Str)
@@ -457,7 +457,7 @@ func TestPermissionResolver_Users(t *testing.T) {
 	})
 
 	t.Run("search users with q no match", func(t *testing.T) {
-		jj := postQuery(t, c, `{ users(q: "nobody") { id name email } }`, nil)
+		jj := postQuery(t, c, `{ users(where:{q:"nobody"}) { id name email } }`, nil)
 		users := gjson.Get(jj, "users").Array()
 		assert.Equal(t, 0, len(users))
 	})
@@ -469,7 +469,7 @@ func TestPermissionResolver_Users(t *testing.T) {
 	})
 
 	t.Run("get user by id", func(t *testing.T) {
-		jj := postQuery(t, c, `{ users(id: "bob") { id name email } }`, nil)
+		jj := postQuery(t, c, `{ users(where:{id:"bob"}) { id name email } }`, nil)
 		users := gjson.Get(jj, "users").Array()
 		assert.Equal(t, 1, len(users))
 		assert.Equal(t, "bob", users[0].Get("id").Str)
@@ -478,7 +478,7 @@ func TestPermissionResolver_Users(t *testing.T) {
 	})
 
 	t.Run("get user by id not found", func(t *testing.T) {
-		postQueryExpectError(t, c, `{ users(id: "nonexistent") { id name email } }`)
+		postQueryExpectError(t, c, `{ users(where:{id:"nonexistent"}) { id name email } }`)
 	})
 
 	t.Run("users returns empty without admin manager", func(t *testing.T) {

--- a/server/gql/permission_resolver_test.go
+++ b/server/gql/permission_resolver_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/interline-io/transitland-lib/internal/testconfig"
 	"github.com/interline-io/transitland-lib/server/auth/authn"
 	"github.com/interline-io/transitland-lib/server/auth/authz"
+	"github.com/interline-io/transitland-lib/server/auth/azchecker"
 	"github.com/interline-io/transitland-lib/server/auth/mw/usercheck"
 	"github.com/interline-io/transitland-lib/server/model"
 	"github.com/interline-io/transitland-lib/server/testutil"
@@ -430,18 +431,50 @@ func TestPermissionResolver_AdminMutations(t *testing.T) {
 }
 
 func TestPermissionResolver_Users(t *testing.T) {
-	c := newPermTestClient(t, "tl-tenant-admin")
+	// Build a checker with seeded users
+	mockUsers := azchecker.NewMockUserProvider()
+	mockUsers.AddUser("alice", authn.NewCtxUser("alice", "Alice Smith", "alice@example.com"))
+	mockUsers.AddUser("bob", authn.NewCtxUser("bob", "Bob Jones", "bob@example.com"))
+	mockUsers.AddUser("charlie", authn.NewCtxUser("charlie", "Charlie Brown", "charlie@example.com"))
+	checker := azchecker.NewChecker(mockUsers, azchecker.NewMockFGAClient(), nil)
+	cfg := testconfig.Config(t, testconfig.Options{})
+	cfg.Checker = checker
+	c := newPermTestClientFromConfig(cfg, "tl-tenant-admin", "admin")
 
-	t.Run("list users returns empty with mock provider", func(t *testing.T) {
+	t.Run("list all users", func(t *testing.T) {
 		jj := postQuery(t, c, `{ users { id name email } }`, nil)
+		users := gjson.Get(jj, "users").Array()
+		assert.Equal(t, 3, len(users))
+	})
+
+	t.Run("search users with q", func(t *testing.T) {
+		jj := postQuery(t, c, `{ users(q: "alice") { id name email } }`, nil)
+		users := gjson.Get(jj, "users").Array()
+		assert.Equal(t, 1, len(users))
+		assert.Equal(t, "alice", users[0].Get("id").Str)
+		assert.Equal(t, "Alice Smith", users[0].Get("name").Str)
+		assert.Equal(t, "alice@example.com", users[0].Get("email").Str)
+	})
+
+	t.Run("search users with q no match", func(t *testing.T) {
+		jj := postQuery(t, c, `{ users(q: "nobody") { id name email } }`, nil)
 		users := gjson.Get(jj, "users").Array()
 		assert.Equal(t, 0, len(users))
 	})
 
-	t.Run("search users with q returns empty with mock provider", func(t *testing.T) {
-		jj := postQuery(t, c, `{ users(q: "test") { id name email } }`, nil)
+	t.Run("list users with limit", func(t *testing.T) {
+		jj := postQuery(t, c, `{ users(limit: 2) { id } }`, nil)
 		users := gjson.Get(jj, "users").Array()
-		assert.Equal(t, 0, len(users))
+		assert.Equal(t, 2, len(users))
+	})
+
+	t.Run("get user by id", func(t *testing.T) {
+		jj := postQuery(t, c, `{ users(id: "bob") { id name email } }`, nil)
+		users := gjson.Get(jj, "users").Array()
+		assert.Equal(t, 1, len(users))
+		assert.Equal(t, "bob", users[0].Get("id").Str)
+		assert.Equal(t, "Bob Jones", users[0].Get("name").Str)
+		assert.Equal(t, "bob@example.com", users[0].Get("email").Str)
 	})
 
 	t.Run("get user by id not found", func(t *testing.T) {
@@ -449,8 +482,8 @@ func TestPermissionResolver_Users(t *testing.T) {
 	})
 
 	t.Run("users returns empty without admin manager", func(t *testing.T) {
-		cfg := testconfig.Config(t, testconfig.Options{})
-		noAuthClient := newPermTestClientFromConfig(cfg, "testuser", "testrole")
+		noAuthCfg := testconfig.Config(t, testconfig.Options{})
+		noAuthClient := newPermTestClientFromConfig(noAuthCfg, "testuser", "testrole")
 		jj := postQuery(t, noAuthClient, `{ users { id name email } }`, nil)
 		users := gjson.Get(jj, "users").Array()
 		assert.Equal(t, 0, len(users))

--- a/server/model/models_gen.go
+++ b/server/model/models_gen.go
@@ -1417,6 +1417,14 @@ type User struct {
 	Email string `json:"email"`
 }
 
+// Search options for users
+type UserFilter struct {
+	// Search for a user by ID
+	ID *string `json:"id,omitempty"`
+	// Full text search
+	Q *string `json:"q,omitempty"`
+}
+
 // Source URL and JSON representation of GTFS-RT data used for validation
 type ValidationRealtimeResult struct {
 	// Source URL

--- a/server/model/models_gen.go
+++ b/server/model/models_gen.go
@@ -1407,6 +1407,16 @@ type TripStopTimeFilter struct {
 	End *tt.Seconds `json:"end,omitempty"`
 }
 
+// A user in the authorization system
+type User struct {
+	// User identifier
+	ID string `json:"id"`
+	// Display name
+	Name string `json:"name"`
+	// Email address
+	Email string `json:"email"`
+}
+
 // Source URL and JSON representation of GTFS-RT data used for validation
 type ValidationRealtimeResult struct {
 	// Source URL


### PR DESCRIPTION
## Summary

Adds missing GraphQL query filters and a new `users` resolver to the permissions API, following up on the permissions PR (#581). The `tenants` and `groups` queries now accept `ids: [Int!]` for direct lookup, matching the convention used by `feeds`, `agencies`, and other existing queries. A new `users` query exposes user search through the `AdminManager` interface, using the standard `where` filter pattern.

### Schema changes
- `tenants` and `groups` queries accept `ids: [Int!]` parameter for direct ID lookup
- New `User` type with `id`, `name`, and `email` fields
- New `UserFilter` input with `id` (single lookup) and `q` (search) fields
- New `users(limit: Int, where: UserFilter)` query

### Resolver and interface changes
- `AdminManager` interface now includes `UserList` and `User` methods (already implemented on `azchecker.Checker`)
- `Tenants`/`Groups` resolvers call `ObjectPermissions` directly for each requested ID, skipping the full `ListObjects` call
- `Users` resolver returns empty list gracefully when `AdminManager` is not configured or user is not found

## Test plan
- Verify `tenants(ids: [...])` returns matching tenants and empty list for nonexistent IDs
- Verify `groups(ids: [...])` returns matching groups and empty list for nonexistent IDs
- Verify `users` query lists all users, searches by `q`, looks up by `id`, and respects `limit`
- Verify `users(where:{id:...})` returns empty list for unknown IDs (consistent with tenants/groups)
- Verify `users` returns empty list when no `AdminManager` is configured