### PR TITLE
Filter tenant/group children

### DIFF
--- a/server/auth/azchecker/checker.go
+++ b/server/auth/azchecker/checker.go
@@ -359,6 +359,7 @@ func (c *Checker) ListObjects(ctx context.Context, objType ObjectType) ([]authz.
 	for i, id := range ids {
 		refs[i] = authz.ObjectRef{Type: objType, ID: id}
 	}
+	c.hydrateObjectRefs(ctx, refs)
 	return refs, nil
 }
 
@@ -414,11 +415,16 @@ func (c *Checker) ObjectPermissions(ctx context.Context, obj authz.ObjectRef) (*
 	}
 	c.hydrateSubjectRefs(ctx, ret.Subjects)
 
-	// Children
+	// Children — only include children the current user can view
 	if childType, ok := childTypeForType(obj.Type); ok {
 		childIds, _ := c.listSubjectRelations(ctx, entKey, childType, ParentRelation)
 		for _, id := range childIds {
-			ret.Children = append(ret.Children, authz.ObjectRef{Type: childType, ID: id})
+			childRef := authz.ObjectRef{Type: childType, ID: id}
+			childCtxTuples := c.contextualTuples(ctx, childRef)
+			childKey := newEntityID(childType, id)
+			if ok, _ := c.checkAction(ctx, CanView, childKey, childCtxTuples...); ok {
+				ret.Children = append(ret.Children, childRef)
+			}
 		}
 	}
 

--- a/server/auth/azchecker/checker_test.go
+++ b/server/auth/azchecker/checker_test.go
@@ -529,6 +529,124 @@ func TestChecker(t *testing.T) {
 		}
 	})
 
+	t.Run("TenantPermissions children filtered", func(t *testing.T) {
+		checker := newTestChecker(t, fgaUrl, checkerTestData)
+		dbx := testutil.MustOpenTestDB(t)
+		type childrenTest struct {
+			Notes          string
+			CheckAsUser    string
+			Object         EntityKey
+			ExpectChildren []EntityKey
+		}
+		checks := []childrenTest{
+			{
+				Notes:          "admin sees all groups under tl-tenant",
+				CheckAsUser:    "tl-tenant-admin",
+				Object:         newEntityKey(TenantType, "tl-tenant"),
+				ExpectChildren: newEntityKeys(GroupType, "CT-group", "BA-group", "HA-group", "EX-group"),
+			},
+			{
+				Notes:          "ian sees CT-group, BA-group, HA-group (viewer/editor + tenant member on HA)",
+				CheckAsUser:    "ian",
+				Object:         newEntityKey(TenantType, "tl-tenant"),
+				ExpectChildren: newEntityKeys(GroupType, "CT-group", "BA-group", "HA-group"),
+			},
+			{
+				Notes:          "drew sees CT-group and HA-group (manager of CT + tenant member on HA)",
+				CheckAsUser:    "drew",
+				Object:         newEntityKey(TenantType, "tl-tenant"),
+				ExpectChildren: newEntityKeys(GroupType, "CT-group", "HA-group"),
+			},
+			{
+				Notes:          "tl-tenant-member sees only HA-group (tenant member on HA)",
+				CheckAsUser:    "tl-tenant-member",
+				Object:         newEntityKey(TenantType, "tl-tenant"),
+				ExpectChildren: newEntityKeys(GroupType, "HA-group"),
+			},
+		}
+		for _, tc := range checks {
+			t.Run(tc.Notes, func(t *testing.T) {
+				ltk := dbTupleLookup(t, dbx, TupleKey{Object: tc.Object})
+				ret, err := checker.ObjectPermissions(
+					newUserCtx(tc.CheckAsUser),
+					authz.ObjectRef{Type: TenantType, ID: ltk.Object.ID()},
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var gotIDs []int64
+				for _, child := range ret.Children {
+					gotIDs = append(gotIDs, child.ID)
+				}
+				var expectIDs []int64
+				for _, v := range tc.ExpectChildren {
+					ek := dbTupleLookup(t, dbx, TupleKey{Object: v})
+					expectIDs = append(expectIDs, ek.Object.ID())
+				}
+				assert.ElementsMatch(t, expectIDs, gotIDs)
+			})
+		}
+	})
+
+	t.Run("GroupPermissions children filtered", func(t *testing.T) {
+		checker := newTestChecker(t, fgaUrl, checkerTestData)
+		dbx := testutil.MustOpenTestDB(t)
+		type childrenTest struct {
+			Notes          string
+			CheckAsUser    string
+			Object         EntityKey
+			ExpectChildren []EntityKey
+		}
+		checks := []childrenTest{
+			{
+				Notes:          "admin sees all feeds under CT-group",
+				CheckAsUser:    "tl-tenant-admin",
+				Object:         newEntityKey(GroupType, "CT-group"),
+				ExpectChildren: newEntityKeys(FeedType, "CT"),
+			},
+			{
+				Notes:          "admin sees all feeds under BA-group",
+				CheckAsUser:    "tl-tenant-admin",
+				Object:         newEntityKey(GroupType, "BA-group"),
+				ExpectChildren: newEntityKeys(FeedType, "BA"),
+			},
+			{
+				Notes:          "ian (viewer of CT-group) sees feed CT",
+				CheckAsUser:    "ian",
+				Object:         newEntityKey(GroupType, "CT-group"),
+				ExpectChildren: newEntityKeys(FeedType, "CT"),
+			},
+			{
+				Notes:          "ian (editor of BA-group) sees feed BA",
+				CheckAsUser:    "ian",
+				Object:         newEntityKey(GroupType, "BA-group"),
+				ExpectChildren: newEntityKeys(FeedType, "BA"),
+			},
+		}
+		for _, tc := range checks {
+			t.Run(tc.Notes, func(t *testing.T) {
+				ltk := dbTupleLookup(t, dbx, TupleKey{Object: tc.Object})
+				ret, err := checker.ObjectPermissions(
+					newUserCtx(tc.CheckAsUser),
+					authz.ObjectRef{Type: GroupType, ID: ltk.Object.ID()},
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var gotIDs []int64
+				for _, child := range ret.Children {
+					gotIDs = append(gotIDs, child.ID)
+				}
+				var expectIDs []int64
+				for _, v := range tc.ExpectChildren {
+					ek := dbTupleLookup(t, dbx, TupleKey{Object: v})
+					expectIDs = append(expectIDs, ek.Object.ID())
+				}
+				assert.ElementsMatch(t, expectIDs, gotIDs)
+			})
+		}
+	})
+
 	t.Run("TenantAddPermission", func(t *testing.T) {
 		checks := []testCase{
 			// User checks

--- a/server/gql/permission_resolver.go
+++ b/server/gql/permission_resolver.go
@@ -94,6 +94,9 @@ func (r *groupResolver) Feeds(ctx context.Context, obj *model.Group, limit *int)
 	if err != nil {
 		return nil, err
 	}
+	// No per-child ObjectPermissions check needed here: feed IDs are passed
+	// to FindFeeds which applies PermFilter at the SQL layer, so unauthorized
+	// feeds are filtered out before results are returned.
 	var ids []int
 	for _, child := range perms.Children {
 		if child.Type == authz.FeedType {

--- a/server/gql/permission_resolver.go
+++ b/server/gql/permission_resolver.go
@@ -42,9 +42,15 @@ func (r *tenantResolver) Groups(ctx context.Context, obj *model.Tenant, limit *i
 	}
 	groups := []*model.Group{}
 	for _, child := range perms.Children {
-		if child.Type == authz.GroupType {
-			groups = append(groups, &model.Group{ID: int(child.ID), Name: child.Name})
+		if child.Type != authz.GroupType {
+			continue
 		}
+		// Check that user has permission to view each group
+		childPerms, err := pm.ObjectPermissions(ctx, child)
+		if err != nil {
+			continue
+		}
+		groups = append(groups, &model.Group{ID: int(child.ID), Name: childPerms.Ref.Name})
 		if limit != nil && len(groups) >= *limit {
 			break
 		}
@@ -407,12 +413,16 @@ func resolvePermissions(ctx context.Context, objType authz.ObjectType, id int64)
 			Name: perms.Parent.Name,
 		}
 	}
-	// Children
+	// Children - filter to only include children the user can view
 	for _, child := range perms.Children {
+		childPerms, err := pm.ObjectPermissions(ctx, child)
+		if err != nil {
+			continue
+		}
 		result.Children = append(result.Children, &model.PermissionRef{
 			Type: displayTypeName(child.Type),
 			ID:   int(child.ID),
-			Name: child.Name,
+			Name: childPerms.Ref.Name,
 		})
 	}
 	return result, nil

--- a/server/gql/permission_resolver.go
+++ b/server/gql/permission_resolver.go
@@ -45,12 +45,7 @@ func (r *tenantResolver) Groups(ctx context.Context, obj *model.Tenant, limit *i
 		if child.Type != authz.GroupType {
 			continue
 		}
-		// Check that user has permission to view each group
-		childPerms, err := pm.ObjectPermissions(ctx, child)
-		if err != nil {
-			continue
-		}
-		groups = append(groups, &model.Group{ID: int(child.ID), Name: childPerms.Ref.Name})
+		groups = append(groups, &model.Group{ID: int(child.ID), Name: child.Name})
 		if limit != nil && len(groups) >= *limit {
 			break
 		}
@@ -136,32 +131,25 @@ func (r *queryResolver) Tenants(ctx context.Context, limit *int, ids []int) ([]*
 	if pm == nil || err != nil {
 		return nil, nil
 	}
+	var refs []authz.ObjectRef
 	if len(ids) > 0 {
-		tenants := make([]*model.Tenant, 0, len(ids))
 		for _, id := range ids {
 			ref := authz.ObjectRef{Type: authz.TenantType, ID: int64(id)}
 			perms, err := pm.ObjectPermissions(ctx, ref)
 			if err != nil {
 				continue
 			}
-			tenants = append(tenants, &model.Tenant{ID: id, Name: perms.Ref.Name})
-			if limit != nil && len(tenants) >= *limit {
-				break
-			}
+			refs = append(refs, perms.Ref)
 		}
-		return tenants, nil
-	}
-	refs, err := pm.ListObjects(ctx, authz.TenantType)
-	if err != nil {
-		return nil, err
+	} else {
+		refs, err = pm.ListObjects(ctx, authz.TenantType)
+		if err != nil {
+			return nil, err
+		}
 	}
 	tenants := make([]*model.Tenant, 0, len(refs))
 	for _, ref := range refs {
-		t := &model.Tenant{ID: int(ref.ID)}
-		if perms, err := pm.ObjectPermissions(ctx, ref); err == nil {
-			t.Name = perms.Ref.Name
-		}
-		tenants = append(tenants, t)
+		tenants = append(tenants, &model.Tenant{ID: int(ref.ID), Name: ref.Name})
 		if limit != nil && len(tenants) >= *limit {
 			break
 		}
@@ -174,32 +162,25 @@ func (r *queryResolver) Groups(ctx context.Context, limit *int, ids []int) ([]*m
 	if pm == nil || err != nil {
 		return nil, nil
 	}
+	var refs []authz.ObjectRef
 	if len(ids) > 0 {
-		groups := make([]*model.Group, 0, len(ids))
 		for _, id := range ids {
 			ref := authz.ObjectRef{Type: authz.GroupType, ID: int64(id)}
 			perms, err := pm.ObjectPermissions(ctx, ref)
 			if err != nil {
 				continue
 			}
-			groups = append(groups, &model.Group{ID: id, Name: perms.Ref.Name})
-			if limit != nil && len(groups) >= *limit {
-				break
-			}
+			refs = append(refs, perms.Ref)
 		}
-		return groups, nil
-	}
-	refs, err := pm.ListObjects(ctx, authz.GroupType)
-	if err != nil {
-		return nil, err
+	} else {
+		refs, err = pm.ListObjects(ctx, authz.GroupType)
+		if err != nil {
+			return nil, err
+		}
 	}
 	groups := make([]*model.Group, 0, len(refs))
 	for _, ref := range refs {
-		g := &model.Group{ID: int(ref.ID)}
-		if perms, err := pm.ObjectPermissions(ctx, ref); err == nil {
-			g.Name = perms.Ref.Name
-		}
-		groups = append(groups, g)
+		groups = append(groups, &model.Group{ID: int(ref.ID), Name: ref.Name})
 		if limit != nil && len(groups) >= *limit {
 			break
 		}
@@ -416,16 +397,12 @@ func resolvePermissions(ctx context.Context, objType authz.ObjectType, id int64)
 			Name: perms.Parent.Name,
 		}
 	}
-	// Children - filter to only include children the user can view
+	// Children (already filtered to viewable by ObjectPermissions)
 	for _, child := range perms.Children {
-		childPerms, err := pm.ObjectPermissions(ctx, child)
-		if err != nil {
-			continue
-		}
 		result.Children = append(result.Children, &model.PermissionRef{
 			Type: displayTypeName(child.Type),
 			ID:   int(child.ID),
-			Name: childPerms.Ref.Name,
+			Name: child.Name,
 		})
 	}
 	return result, nil

--- a/server/gql/permission_resolver.go
+++ b/server/gql/permission_resolver.go
@@ -140,6 +140,9 @@ func (r *queryResolver) Tenants(ctx context.Context, limit *int, ids []int) ([]*
 				continue
 			}
 			refs = append(refs, perms.Ref)
+			if limit != nil && len(refs) >= *limit {
+				break
+			}
 		}
 	} else {
 		refs, err = pm.ListObjects(ctx, authz.TenantType)
@@ -171,6 +174,9 @@ func (r *queryResolver) Groups(ctx context.Context, limit *int, ids []int) ([]*m
 				continue
 			}
 			refs = append(refs, perms.Ref)
+			if limit != nil && len(refs) >= *limit {
+				break
+			}
 		}
 	} else {
 		refs, err = pm.ListObjects(ctx, authz.GroupType)

--- a/server/gql/permission_resolver_test.go
+++ b/server/gql/permission_resolver_test.go
@@ -561,6 +561,22 @@ func TestPermissionResolver_Filtering(t *testing.T) {
 		assert.NotContains(t, tenantGroups, "HA-group", "traversal should not widen to HA-group")
 	})
 
+	t.Run("partial-user tenant permissions children filtered", func(t *testing.T) {
+		c := newPermTestClientFromConfig(cfg, "partial-user")
+		jj := postQuery(t, c, `{ tenants { name permissions { children { type name } } } }`, nil)
+		for _, tenant := range gjson.Get(jj, "tenants").Array() {
+			if tenant.Get("name").Str != "tl-tenant" {
+				continue
+			}
+			childNames := names(tenant.Get("permissions.children").Array(), "name")
+			assert.Contains(t, childNames, "CT-group")
+			assert.NotContains(t, childNames, "BA-group", "permissions children should not include BA-group")
+			assert.NotContains(t, childNames, "HA-group", "permissions children should not include HA-group")
+			return
+		}
+		t.Fatal("tl-tenant not found")
+	})
+
 	t.Run("partial-user group feeds", func(t *testing.T) {
 		c := newPermTestClientFromConfig(cfg, "partial-user")
 		jj := postQuery(t, c, `{ groups { name feeds { onestop_id } } }`, nil)

--- a/server/gql/permission_resolver_test.go
+++ b/server/gql/permission_resolver_test.go
@@ -662,6 +662,52 @@ func TestPermissionResolver_Filtering(t *testing.T) {
 		assert.NotContains(t, groupNames, "HA-group")
 	})
 
+	t.Run("partial-user group permissions children filtered", func(t *testing.T) {
+		// Verify resolvePermissions filters children on a non-tenant type (group)
+		c := newPermTestClientFromConfig(cfg, "partial-user")
+		jj := postQuery(t, c, `{ groups { name permissions { children { type name } } } }`, nil)
+		groups := gjson.Get(jj, "groups").Array()
+		assert.Equal(t, 1, len(groups), "partial-user should see exactly 1 group")
+		assert.Equal(t, "CT-group", groups[0].Get("name").Str)
+		childNames := names(groups[0].Get("permissions.children").Array(), "name")
+		assert.Contains(t, childNames, "CT")
+		assert.NotContains(t, childNames, "BA", "group permissions children should not include feeds from other groups")
+	})
+
+	t.Run("partial-user tenant groups with limit", func(t *testing.T) {
+		// Verify that limit is applied after filtering, not before.
+		// tl-tenant has 3 groups but partial-user can only see CT-group.
+		// With limit=1 the user should still get CT-group (not an empty
+		// result from limiting before filtering).
+		c := newPermTestClientFromConfig(cfg, "partial-user")
+		jj := postQuery(t, c, `{ tenants { name groups(limit: 1) { name } } }`, nil)
+		for _, tenant := range gjson.Get(jj, "tenants").Array() {
+			if tenant.Get("name").Str != "tl-tenant" {
+				continue
+			}
+			groupNames := names(tenant.Get("groups").Array(), "name")
+			assert.Equal(t, 1, len(groupNames), "should return exactly 1 group")
+			assert.Contains(t, groupNames, "CT-group")
+			return
+		}
+		t.Fatal("tl-tenant not found")
+	})
+
+	t.Run("full-user tenant groups with limit", func(t *testing.T) {
+		// full-user can see all 3 groups; limit=2 should cap at 2
+		c := newPermTestClientFromConfig(cfg, "full-user")
+		jj := postQuery(t, c, `{ tenants { name groups(limit: 2) { name } } }`, nil)
+		for _, tenant := range gjson.Get(jj, "tenants").Array() {
+			if tenant.Get("name").Str != "tl-tenant" {
+				continue
+			}
+			groupNames := names(tenant.Get("groups").Array(), "name")
+			assert.Equal(t, 2, len(groupNames), "should return exactly 2 groups")
+			return
+		}
+		t.Fatal("tl-tenant not found")
+	})
+
 	t.Run("nobody sees nothing", func(t *testing.T) {
 		c := newPermTestClientFromConfig(cfg, "nobody")
 		jj := postQuery(t, c, `{ tenants { id } }`, nil)

--- a/server/gql/permission_resolver_test.go
+++ b/server/gql/permission_resolver_test.go
@@ -492,6 +492,185 @@ func TestPermissionResolver_Users(t *testing.T) {
 	})
 }
 
+// TestPermissionResolver_Filtering verifies that traversing relationships
+// (tenant→groups, group→tenant→groups, permissions→children, group→feeds)
+// never widens the result set beyond what the querying user is authorized to see.
+func TestPermissionResolver_Filtering(t *testing.T) {
+	// Hierarchy:
+	//   tl-tenant
+	//     ├── CT-group  → feed CT (public)
+	//     ├── BA-group  → feed BA (public)
+	//     └── HA-group  → feed HA (public), feed EG (non-public)
+	//   restricted-tenant
+	//     └── EX-group  (no feeds)
+	//
+	// Users:
+	//   "full-user"    : admin of tl-tenant → sees all groups/feeds under tl-tenant
+	//   "partial-user" : viewer of CT-group only → sees only CT-group
+	//   "multi-user"   : viewer of CT-group + editor of EX-group → spans two tenants
+	//   "nobody"       : no tuples → sees nothing
+	filterTuples := []authz.TupleKey{
+		// tl-tenant groups
+		{Subject: authz.NewEntityKey(authz.TenantType, "tl-tenant"), Object: authz.NewEntityKey(authz.GroupType, "CT-group"), Relation: authz.ParentRelation},
+		{Subject: authz.NewEntityKey(authz.TenantType, "tl-tenant"), Object: authz.NewEntityKey(authz.GroupType, "BA-group"), Relation: authz.ParentRelation},
+		{Subject: authz.NewEntityKey(authz.TenantType, "tl-tenant"), Object: authz.NewEntityKey(authz.GroupType, "HA-group"), Relation: authz.ParentRelation},
+		// restricted-tenant groups
+		{Subject: authz.NewEntityKey(authz.TenantType, "restricted-tenant"), Object: authz.NewEntityKey(authz.GroupType, "EX-group"), Relation: authz.ParentRelation},
+		// Feed assignments
+		{Subject: authz.NewEntityKey(authz.GroupType, "CT-group"), Object: authz.NewEntityKey(authz.FeedType, "CT"), Relation: authz.ParentRelation},
+		{Subject: authz.NewEntityKey(authz.GroupType, "BA-group"), Object: authz.NewEntityKey(authz.FeedType, "BA"), Relation: authz.ParentRelation},
+		{Subject: authz.NewEntityKey(authz.GroupType, "HA-group"), Object: authz.NewEntityKey(authz.FeedType, "HA"), Relation: authz.ParentRelation},
+		{Subject: authz.NewEntityKey(authz.GroupType, "HA-group"), Object: authz.NewEntityKey(authz.FeedType, "EG"), Relation: authz.ParentRelation},
+		// full-user: admin of tl-tenant (inherits access to all children)
+		{Subject: authz.NewEntityKey(authz.UserType, "full-user"), Object: authz.NewEntityKey(authz.TenantType, "tl-tenant"), Relation: authz.AdminRelation},
+		// partial-user: viewer of CT-group only, member of tl-tenant
+		{Subject: authz.NewEntityKey(authz.UserType, "partial-user"), Object: authz.NewEntityKey(authz.TenantType, "tl-tenant"), Relation: authz.MemberRelation},
+		{Subject: authz.NewEntityKey(authz.UserType, "partial-user"), Object: authz.NewEntityKey(authz.GroupType, "CT-group"), Relation: authz.ViewerRelation},
+		// multi-user: viewer of CT-group + editor of EX-group (spans two tenants)
+		{Subject: authz.NewEntityKey(authz.UserType, "multi-user"), Object: authz.NewEntityKey(authz.TenantType, "tl-tenant"), Relation: authz.MemberRelation},
+		{Subject: authz.NewEntityKey(authz.UserType, "multi-user"), Object: authz.NewEntityKey(authz.GroupType, "CT-group"), Relation: authz.ViewerRelation},
+		{Subject: authz.NewEntityKey(authz.UserType, "multi-user"), Object: authz.NewEntityKey(authz.TenantType, "restricted-tenant"), Relation: authz.MemberRelation},
+		{Subject: authz.NewEntityKey(authz.UserType, "multi-user"), Object: authz.NewEntityKey(authz.GroupType, "EX-group"), Relation: authz.EditorRelation},
+	}
+	opts := testconfig.Options{
+		FGAEndpoint:    testutil.FGAServer(t),
+		FGAModelFile:   testdata.Path("server/authz/tls.json"),
+		FGAModelTuples: filterTuples,
+	}
+	cfg := testconfig.Config(t, opts)
+
+	// Helper to collect names from a gjson array
+	names := func(arr []gjson.Result, key string) []string {
+		var out []string
+		for _, r := range arr {
+			out = append(out, r.Get(key).Str)
+		}
+		return out
+	}
+
+	t.Run("partial-user tenant groups filtered", func(t *testing.T) {
+		c := newPermTestClientFromConfig(cfg, "partial-user")
+		jj := postQuery(t, c, `{ tenants { name groups { name } } }`, nil)
+		for _, tenant := range gjson.Get(jj, "tenants").Array() {
+			if tenant.Get("name").Str != "tl-tenant" {
+				continue
+			}
+			groupNames := names(tenant.Get("groups").Array(), "name")
+			assert.Contains(t, groupNames, "CT-group")
+			assert.NotContains(t, groupNames, "BA-group", "partial-user should not see BA-group")
+			assert.NotContains(t, groupNames, "HA-group", "partial-user should not see HA-group")
+			return
+		}
+		t.Fatal("tl-tenant not found")
+	})
+
+	t.Run("partial-user group tenant groups no leak", func(t *testing.T) {
+		// Traversing group → tenant → groups must not widen results
+		c := newPermTestClientFromConfig(cfg, "partial-user")
+		jj := postQuery(t, c, `{ groups { name tenant { name groups { name } } } }`, nil)
+		groups := gjson.Get(jj, "groups").Array()
+		assert.Equal(t, 1, len(groups), "partial-user should see exactly 1 group")
+		assert.Equal(t, "CT-group", groups[0].Get("name").Str)
+		tenantGroups := names(groups[0].Get("tenant.groups").Array(), "name")
+		assert.Contains(t, tenantGroups, "CT-group")
+		assert.NotContains(t, tenantGroups, "BA-group", "traversal should not widen to BA-group")
+		assert.NotContains(t, tenantGroups, "HA-group", "traversal should not widen to HA-group")
+	})
+
+	t.Run("partial-user permissions children filtered", func(t *testing.T) {
+		c := newPermTestClientFromConfig(cfg, "partial-user")
+		jj := postQuery(t, c, `{ tenants { name permissions { children { type name } } } }`, nil)
+		for _, tenant := range gjson.Get(jj, "tenants").Array() {
+			if tenant.Get("name").Str != "tl-tenant" {
+				continue
+			}
+			childNames := names(tenant.Get("permissions.children").Array(), "name")
+			assert.Contains(t, childNames, "CT-group")
+			assert.NotContains(t, childNames, "BA-group", "permissions children should not include BA-group")
+			assert.NotContains(t, childNames, "HA-group", "permissions children should not include HA-group")
+			return
+		}
+		t.Fatal("tl-tenant not found")
+	})
+
+	t.Run("partial-user group feeds", func(t *testing.T) {
+		c := newPermTestClientFromConfig(cfg, "partial-user")
+		jj := postQuery(t, c, `{ groups { name feeds { onestop_id } } }`, nil)
+		groups := gjson.Get(jj, "groups").Array()
+		assert.Equal(t, 1, len(groups))
+		feedIDs := names(groups[0].Get("feeds").Array(), "onestop_id")
+		assert.Contains(t, feedIDs, "CT")
+		assert.NotContains(t, feedIDs, "BA")
+	})
+
+	t.Run("full-user sees all tenant groups", func(t *testing.T) {
+		c := newPermTestClientFromConfig(cfg, "full-user")
+		jj := postQuery(t, c, `{ tenants { name groups { name } } }`, nil)
+		for _, tenant := range gjson.Get(jj, "tenants").Array() {
+			if tenant.Get("name").Str != "tl-tenant" {
+				continue
+			}
+			groupNames := names(tenant.Get("groups").Array(), "name")
+			assert.Contains(t, groupNames, "CT-group")
+			assert.Contains(t, groupNames, "BA-group")
+			assert.Contains(t, groupNames, "HA-group")
+			return
+		}
+		t.Fatal("tl-tenant not found")
+	})
+
+	t.Run("full-user sees non-public feed via group", func(t *testing.T) {
+		c := newPermTestClientFromConfig(cfg, "full-user")
+		jj := postQuery(t, c, `{ groups { name feeds { onestop_id } } }`, nil)
+		for _, group := range gjson.Get(jj, "groups").Array() {
+			if group.Get("name").Str != "HA-group" {
+				continue
+			}
+			feedIDs := names(group.Get("feeds").Array(), "onestop_id")
+			assert.Contains(t, feedIDs, "HA")
+			assert.Contains(t, feedIDs, "EG", "admin should see non-public feed EG via HA-group")
+			return
+		}
+		t.Fatal("HA-group not found")
+	})
+
+	t.Run("multi-user cross-tenant isolation", func(t *testing.T) {
+		c := newPermTestClientFromConfig(cfg, "multi-user")
+		jj := postQuery(t, c, `{ tenants { name groups { name } } }`, nil)
+		tenants := gjson.Get(jj, "tenants").Array()
+		assert.GreaterOrEqual(t, len(tenants), 2, "multi-user should see two tenants")
+		for _, tenant := range tenants {
+			groupNames := names(tenant.Get("groups").Array(), "name")
+			switch tenant.Get("name").Str {
+			case "tl-tenant":
+				assert.Contains(t, groupNames, "CT-group")
+				assert.NotContains(t, groupNames, "BA-group", "multi-user should not see BA-group")
+				assert.NotContains(t, groupNames, "HA-group", "multi-user should not see HA-group")
+			case "restricted-tenant":
+				assert.Contains(t, groupNames, "EX-group")
+			}
+		}
+	})
+
+	t.Run("multi-user top-level groups", func(t *testing.T) {
+		c := newPermTestClientFromConfig(cfg, "multi-user")
+		jj := postQuery(t, c, `{ groups { name } }`, nil)
+		groupNames := names(gjson.Get(jj, "groups").Array(), "name")
+		assert.Contains(t, groupNames, "CT-group")
+		assert.Contains(t, groupNames, "EX-group")
+		assert.NotContains(t, groupNames, "BA-group")
+		assert.NotContains(t, groupNames, "HA-group")
+	})
+
+	t.Run("nobody sees nothing", func(t *testing.T) {
+		c := newPermTestClientFromConfig(cfg, "nobody")
+		jj := postQuery(t, c, `{ tenants { id } }`, nil)
+		assert.Equal(t, 0, len(gjson.Get(jj, "tenants").Array()))
+		jj = postQuery(t, c, `{ groups { id } }`, nil)
+		assert.Equal(t, 0, len(gjson.Get(jj, "groups").Array()))
+	})
+}
+
 func TestPermissionResolver_NilPermissionManager(t *testing.T) {
 	srv, _ := NewServer()
 	cfg := testconfig.Config(t, testconfig.Options{})

--- a/server/gql/permission_resolver_test.go
+++ b/server/gql/permission_resolver_test.go
@@ -548,22 +548,6 @@ func TestPermissionResolver_Filtering(t *testing.T) {
 		return out
 	}
 
-	t.Run("partial-user tenant groups filtered", func(t *testing.T) {
-		c := newPermTestClientFromConfig(cfg, "partial-user")
-		jj := postQuery(t, c, `{ tenants { name groups { name } } }`, nil)
-		for _, tenant := range gjson.Get(jj, "tenants").Array() {
-			if tenant.Get("name").Str != "tl-tenant" {
-				continue
-			}
-			groupNames := names(tenant.Get("groups").Array(), "name")
-			assert.Contains(t, groupNames, "CT-group")
-			assert.NotContains(t, groupNames, "BA-group", "partial-user should not see BA-group")
-			assert.NotContains(t, groupNames, "HA-group", "partial-user should not see HA-group")
-			return
-		}
-		t.Fatal("tl-tenant not found")
-	})
-
 	t.Run("partial-user group tenant groups no leak", func(t *testing.T) {
 		// Traversing group → tenant → groups must not widen results
 		c := newPermTestClientFromConfig(cfg, "partial-user")
@@ -577,22 +561,6 @@ func TestPermissionResolver_Filtering(t *testing.T) {
 		assert.NotContains(t, tenantGroups, "HA-group", "traversal should not widen to HA-group")
 	})
 
-	t.Run("partial-user permissions children filtered", func(t *testing.T) {
-		c := newPermTestClientFromConfig(cfg, "partial-user")
-		jj := postQuery(t, c, `{ tenants { name permissions { children { type name } } } }`, nil)
-		for _, tenant := range gjson.Get(jj, "tenants").Array() {
-			if tenant.Get("name").Str != "tl-tenant" {
-				continue
-			}
-			childNames := names(tenant.Get("permissions.children").Array(), "name")
-			assert.Contains(t, childNames, "CT-group")
-			assert.NotContains(t, childNames, "BA-group", "permissions children should not include BA-group")
-			assert.NotContains(t, childNames, "HA-group", "permissions children should not include HA-group")
-			return
-		}
-		t.Fatal("tl-tenant not found")
-	})
-
 	t.Run("partial-user group feeds", func(t *testing.T) {
 		c := newPermTestClientFromConfig(cfg, "partial-user")
 		jj := postQuery(t, c, `{ groups { name feeds { onestop_id } } }`, nil)
@@ -601,22 +569,6 @@ func TestPermissionResolver_Filtering(t *testing.T) {
 		feedIDs := names(groups[0].Get("feeds").Array(), "onestop_id")
 		assert.Contains(t, feedIDs, "CT")
 		assert.NotContains(t, feedIDs, "BA")
-	})
-
-	t.Run("full-user sees all tenant groups", func(t *testing.T) {
-		c := newPermTestClientFromConfig(cfg, "full-user")
-		jj := postQuery(t, c, `{ tenants { name groups { name } } }`, nil)
-		for _, tenant := range gjson.Get(jj, "tenants").Array() {
-			if tenant.Get("name").Str != "tl-tenant" {
-				continue
-			}
-			groupNames := names(tenant.Get("groups").Array(), "name")
-			assert.Contains(t, groupNames, "CT-group")
-			assert.Contains(t, groupNames, "BA-group")
-			assert.Contains(t, groupNames, "HA-group")
-			return
-		}
-		t.Fatal("tl-tenant not found")
 	})
 
 	t.Run("full-user sees non-public feed via group", func(t *testing.T) {
@@ -660,20 +612,6 @@ func TestPermissionResolver_Filtering(t *testing.T) {
 		assert.Contains(t, groupNames, "EX-group")
 		assert.NotContains(t, groupNames, "BA-group")
 		assert.NotContains(t, groupNames, "HA-group")
-	})
-
-	t.Run("partial-user group permissions children filtered", func(t *testing.T) {
-		// Verify resolvePermissions filters children on a non-tenant type (group).
-		// CT-group has one feed child (CT); the permissions.children list should
-		// contain exactly that feed and nothing from other groups.
-		c := newPermTestClientFromConfig(cfg, "partial-user")
-		jj := postQuery(t, c, `{ groups { name permissions { children { type id } } } }`, nil)
-		groups := gjson.Get(jj, "groups").Array()
-		assert.Equal(t, 1, len(groups), "partial-user should see exactly 1 group")
-		assert.Equal(t, "CT-group", groups[0].Get("name").Str)
-		children := groups[0].Get("permissions.children").Array()
-		assert.Equal(t, 1, len(children), "CT-group should have exactly 1 visible child feed")
-		assert.Equal(t, "feed", children[0].Get("type").Str)
 	})
 
 	t.Run("partial-user tenant groups with limit", func(t *testing.T) {

--- a/server/gql/permission_resolver_test.go
+++ b/server/gql/permission_resolver_test.go
@@ -663,15 +663,17 @@ func TestPermissionResolver_Filtering(t *testing.T) {
 	})
 
 	t.Run("partial-user group permissions children filtered", func(t *testing.T) {
-		// Verify resolvePermissions filters children on a non-tenant type (group)
+		// Verify resolvePermissions filters children on a non-tenant type (group).
+		// CT-group has one feed child (CT); the permissions.children list should
+		// contain exactly that feed and nothing from other groups.
 		c := newPermTestClientFromConfig(cfg, "partial-user")
-		jj := postQuery(t, c, `{ groups { name permissions { children { type name } } } }`, nil)
+		jj := postQuery(t, c, `{ groups { name permissions { children { type id } } } }`, nil)
 		groups := gjson.Get(jj, "groups").Array()
 		assert.Equal(t, 1, len(groups), "partial-user should see exactly 1 group")
 		assert.Equal(t, "CT-group", groups[0].Get("name").Str)
-		childNames := names(groups[0].Get("permissions.children").Array(), "name")
-		assert.Contains(t, childNames, "CT")
-		assert.NotContains(t, childNames, "BA", "group permissions children should not include feeds from other groups")
+		children := groups[0].Get("permissions.children").Array()
+		assert.Equal(t, 1, len(children), "CT-group should have exactly 1 visible child feed")
+		assert.Equal(t, "feed", children[0].Get("type").Str)
 	})
 
 	t.Run("partial-user tenant groups with limit", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Several GraphQL resolvers returned unfiltered structural children from the FGA authorization model, allowing users to discover entities they shouldn't have access to by traversing relationships (e.g. `group → tenant → groups` or `tenant → permissions → children`).

### Children filtering in Checker

- `ObjectPermissions` in `azchecker` now filters `Children` to only include entities the current user can `CanView`, making it the single enforcement point for children visibility
- `ListObjects` now hydrates `ObjectRef.Name` via batch DB lookup, so callers don't need `ObjectPermissions` just for names
- `groupResolver.Feeds()` was already safe — feed IDs from `perms.Children` pass through `FindFeeds` which applies `PermFilter` at the SQL layer. Added a comment clarifying this.

### Resolver simplifications

- `tenantResolver.Groups()` and `resolvePermissions()` simplified to consume pre-filtered `perms.Children` directly, no per-child permission checks needed
- `Tenants()` and `Groups()` query resolvers unified: build refs from IDs (via `ObjectPermissions`) or `ListObjects`, then a single loop to build model objects
- Early `limit` short-circuit in the IDs path to avoid unnecessary FGA calls

### Tests

- New `TenantPermissions children filtered` and `GroupPermissions children filtered` tests in `checker_test.go` — authoritative tests for the filtering behavior with multiple users and permission levels
- New `TestPermissionResolver_Filtering` in resolver tests for GraphQL integration coverage: traversal no-leak (`group → tenant → groups`), `permissions.children` filtering, cross-tenant isolation, limit interaction, non-public feed visibility, and zero-access baseline

## Test plan

- Verify `partial-user` (viewer of one group) cannot see sibling groups through `group.tenant.groups` or `tenant.permissions.children`
- Verify `full-user` (tenant admin) still sees all groups and non-public feeds
- Verify `multi-user` spanning two tenants sees correct groups in each tenant
- Verify limit is applied after filtering (partial-user with limit=1 still gets their one visible group)
- Verify zero-permission user gets empty results everywhere