### PR TITLE
Fix Redis connection leak in RTFinder pub/sub

### DIFF
--- a/cmds/server_cmd.go
+++ b/cmds/server_cmd.go
@@ -130,6 +130,7 @@ func (cmd *ServerCommand) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		defer redisClient.Close()
 	}
 
 	// Create Finder
@@ -143,7 +144,9 @@ func (cmd *ServerCommand) Run(ctx context.Context) error {
 	var gbfsFinder model.GbfsFinder
 	if redisClient != nil {
 		// Use redis backed finders
-		rtFinder = rtfinder.NewFinder(rtfinder.NewRedisCache(redisClient), db)
+		rtf := rtfinder.NewFinder(rtfinder.NewRedisCache(redisClient), db)
+		defer rtf.Close()
+		rtFinder = rtf
 		gbfsFinder = gbfsfinder.NewFinder(redisClient)
 	} else {
 		// Default to in-memory cache

--- a/server/dbutil/redis.go
+++ b/server/dbutil/redis.go
@@ -40,5 +40,5 @@ func getRedisOpts(v string) (*redis.Options, error) {
 			return nil, err
 		}
 	}
-	return &redis.Options{Addr: addr, DB: dbNo}, nil
+	return &redis.Options{Addr: addr, DB: dbNo, PoolSize: 50, MinIdleConns: 5}, nil
 }

--- a/server/finders/rtfinder/finder.go
+++ b/server/finders/rtfinder/finder.go
@@ -38,6 +38,10 @@ func NewFinder(cache Cache, db tldb.Ext) *Finder {
 	}
 }
 
+func (f *Finder) Close() error {
+	return f.cache.Close()
+}
+
 func (f *Finder) AddData(ctx context.Context, topic string, data []byte) error {
 	return f.cache.AddData(ctx, topic, data)
 }

--- a/server/finders/rtfinder/redis.go
+++ b/server/finders/rtfinder/redis.go
@@ -3,6 +3,7 @@ package rtfinder
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -11,50 +12,43 @@ import (
 	"github.com/interline-io/transitland-lib/rt/pb"
 )
 
-type listener struct {
-	source *Source
-	ctx    context.Context
-	cancel context.CancelFunc
-}
-
-func newListener(s *Source, parent context.Context) *listener {
-	cc, cf := context.WithCancel(parent)
-	return &listener{
-		source: s,
-		ctx:    cc,
-		cancel: cf,
-	}
-}
-
 type RedisCache struct {
-	ctx       context.Context
-	lock      sync.Mutex
-	client    *redis.Client
-	listeners map[string]*listener
+	ctx     context.Context
+	cancel  context.CancelFunc
+	lock    sync.Mutex
+	client  *redis.Client
+	sources map[string]*Source
 }
 
 func NewRedisCache(client *redis.Client) *RedisCache {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 	f := RedisCache{
-		client:    client,
-		listeners: map[string]*listener{},
-		ctx:       ctx,
+		client:  client,
+		sources: map[string]*Source{},
+		ctx:     ctx,
+		cancel:  cancel,
 	}
+	// Start a single subscription for all RT topics
+	go f.subscribeAll()
 	return &f
 }
 
 func (f *RedisCache) GetSource(ctx context.Context, topic string) (*Source, bool) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
-	if a, ok := f.listeners[topic]; ok {
-		return a.source, true
+	if s, ok := f.sources[topic]; ok {
+		return s, true
 	}
-	a, err := f.startListener(ctx, topic)
+	// Fetch last known data from Redis
+	s, err := f.fetchLast(ctx, topic)
 	if err != nil {
 		return nil, false
 	}
-	f.listeners[topic] = a
-	return a.source, true
+	if s != nil {
+		f.sources[topic] = s
+		return s, true
+	}
+	return nil, false
 }
 
 func (f *RedisCache) AddFeedMessage(ctx context.Context, topic string, rtmsg *pb.FeedMessage) error {
@@ -77,12 +71,7 @@ func (f *RedisCache) AddData(ctx context.Context, topic string, data []byte) err
 }
 
 func (f *RedisCache) Close() error {
-	f.lock.Lock()
-	defer f.lock.Unlock()
-	for k, ls := range f.listeners {
-		ls.cancel()
-		delete(f.listeners, k)
-	}
+	f.cancel()
 	return nil
 }
 
@@ -94,39 +83,64 @@ func subKey(topic string) string {
 	return fmt.Sprintf("rtfetch:sub:%s", topic)
 }
 
-func (f *RedisCache) startListener(ctx context.Context, topic string) (*listener, error) {
-	// Create new source
-	s, err := NewSource(topic)
-	if err != nil {
-		return nil, err
-	}
-	// Add subscription for future data
-	ls := newListener(s, f.ctx)
-	go func(client *redis.Client, topic string, lst *listener) {
-		sub := client.Subscribe(lst.ctx, subKey(topic))
-		defer sub.Close()
-		subch := sub.Channel()
-		for rmsg := range subch {
-			if err := s.process(ctx, []byte(rmsg.Payload)); err != nil {
-				log.For(ctx).Error().Err(err).Str("topic", topic).Int("bytes", len(rmsg.Payload)).Msg("cache: error processing update")
-			} else {
-				log.For(ctx).Trace().Str("topic", topic).Int("bytes", len(rmsg.Payload)).Msg("cache: processed update")
-			}
+// topicFromSubKey extracts the topic from a subscription channel key.
+func topicFromSubKey(channel string) string {
+	return strings.TrimPrefix(channel, "rtfetch:sub:")
+}
+
+// subscribeAll uses a single PSubscribe connection for all RT topics.
+func (f *RedisCache) subscribeAll() {
+	sub := f.client.PSubscribe(f.ctx, "rtfetch:sub:*")
+	defer sub.Close()
+	ch := sub.Channel()
+	for msg := range ch {
+		topic := topicFromSubKey(msg.Channel)
+		if err := f.processMessage(topic, []byte(msg.Payload)); err != nil {
+			log.For(f.ctx).Error().Err(err).Str("topic", topic).Int("bytes", len(msg.Payload)).Msg("cache: error processing update")
+		} else {
+			log.For(f.ctx).Trace().Str("topic", topic).Int("bytes", len(msg.Payload)).Msg("cache: processed update")
 		}
-	}(f.client, topic, ls)
-	log.For(ctx).Trace().Str("topic", topic).Msgf("cache: listener created")
-	// get the first message
+	}
+}
+
+// processMessage updates or creates the Source for a given topic.
+func (f *RedisCache) processMessage(topic string, data []byte) error {
+	f.lock.Lock()
+	s, ok := f.sources[topic]
+	if !ok {
+		var err error
+		s, err = NewSource(topic)
+		if err != nil {
+			f.lock.Unlock()
+			return err
+		}
+		f.sources[topic] = s
+	}
+	f.lock.Unlock()
+	return s.process(f.ctx, data)
+}
+
+// fetchLast retrieves the last cached data from Redis for a topic.
+func (f *RedisCache) fetchLast(ctx context.Context, topic string) (*Source, error) {
 	rctx, cc := context.WithTimeout(f.ctx, 1*time.Second)
 	defer cc()
 	lastData := f.client.Get(rctx, lastKey(topic))
 	if err := lastData.Err(); err == redis.Nil {
-		// ok
+		return nil, nil
 	} else if err != nil {
-		// also ok, hope we get data on future updates
 		log.For(ctx).Error().Err(err).Str("topic", topic).Msg("cache: error getting last data for topic")
-	} else {
-		lb, _ := lastData.Bytes()
-		s.process(ctx, lb)
+		return nil, nil
 	}
-	return ls, nil
+	lb, _ := lastData.Bytes()
+	if len(lb) == 0 {
+		return nil, nil
+	}
+	s, err := NewSource(topic)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.process(ctx, lb); err != nil {
+		return nil, err
+	}
+	return s, nil
 }

--- a/server/finders/rtfinder/redis.go
+++ b/server/finders/rtfinder/redis.go
@@ -35,20 +35,25 @@ func NewRedisCache(client *redis.Client) *RedisCache {
 
 func (f *RedisCache) GetSource(ctx context.Context, topic string) (*Source, bool) {
 	f.lock.Lock()
-	defer f.lock.Unlock()
 	if s, ok := f.sources[topic]; ok {
+		f.lock.Unlock()
 		return s, true
 	}
-	// Fetch last known data from Redis
+	f.lock.Unlock()
+	// Fetch last known data from Redis without holding lock
 	s, err := f.fetchLast(ctx, topic)
-	if err != nil {
+	if err != nil || s == nil {
 		return nil, false
 	}
-	if s != nil {
-		f.sources[topic] = s
-		return s, true
+	f.lock.Lock()
+	// Double-check: processMessage may have inserted it while we were fetching
+	if existing, ok := f.sources[topic]; ok {
+		f.lock.Unlock()
+		return existing, true
 	}
-	return nil, false
+	f.sources[topic] = s
+	f.lock.Unlock()
+	return s, true
 }
 
 func (f *RedisCache) AddFeedMessage(ctx context.Context, topic string, rtmsg *pb.FeedMessage) error {
@@ -92,6 +97,10 @@ func topicFromSubKey(channel string) string {
 func (f *RedisCache) subscribeAll() {
 	sub := f.client.PSubscribe(f.ctx, "rtfetch:sub:*")
 	defer sub.Close()
+	if _, err := sub.Receive(f.ctx); err != nil {
+		log.For(f.ctx).Error().Err(err).Msg("cache: error subscribing to updates")
+		return
+	}
 	ch := sub.Channel()
 	for msg := range ch {
 		topic := topicFromSubKey(msg.Channel)


### PR DESCRIPTION
Use a single PSubscribe connection instead of one Subscribe per topic. Also add pool size limits and graceful shutdown for Redis client.

## Changes
- Refactor `RedisCache` to use `PSubscribe("rtfetch:sub:*")` with message dispatch
- Set `PoolSize` and `MinIdleConns` on Redis client options
- Add `defer redisClient.Close()` and `rtFinder.Close()` on shutdown