### PR TITLE
Cap HTTP redirect hops

### DIFF
--- a/request/http.go
+++ b/request/http.go
@@ -30,6 +30,10 @@ const (
 	//   Attempt 4: after ~90s (90s + jitter)
 	// Total max wait time: ~130s (~2 minutes)
 	defaultMaxRetries = 3
+
+	// defaultMaxRedirects matches the Go net/http default, which is otherwise
+	// replaced when a custom CheckRedirect is set.
+	defaultMaxRedirects = 10
 )
 
 // defaultBackoffSchedule defines the backoff duration for each retry attempt.
@@ -44,6 +48,9 @@ type Http struct {
 	// MaxRetries sets the maximum number of retry attempts for a request.
 	// If MaxRetries is zero or negative, a default value (defaultMaxRetries) is used.
 	MaxRetries int
+	// MaxRedirects caps the number of HTTP redirects that will be followed.
+	// If MaxRedirects is zero or negative, a default value (defaultMaxRedirects) is used.
+	MaxRedirects int
 	// BackoffSchedule defines the backoff duration for each retry attempt.
 	// If nil or empty, defaultBackoffSchedule is used.
 	BackoffSchedule []time.Duration
@@ -66,6 +73,13 @@ func (r *Http) getBackoffSchedule() []time.Duration {
 		return r.BackoffSchedule
 	}
 	return defaultBackoffSchedule
+}
+
+func (r *Http) getMaxRedirects() int {
+	if r.MaxRedirects > 0 {
+		return r.MaxRedirects
+	}
+	return defaultMaxRedirects
 }
 
 // isRetryableStatus returns true for HTTP status codes that indicate
@@ -190,8 +204,12 @@ func (r Http) DownloadAuth(ctx context.Context, ustr string, auth dmfr.FeedAutho
 	// may break pre-signed S3 URLs or other systems that rely on the host header
 	removeDefaultPortFromHost(req)
 
+	maxRedirects := r.getMaxRedirects()
 	client := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= maxRedirects {
+				return fmt.Errorf("stopped after %d redirects", maxRedirects)
+			}
 			removeDefaultPortFromHost(req)
 			return nil
 		},

--- a/request/http.go
+++ b/request/http.go
@@ -48,8 +48,11 @@ type Http struct {
 	// MaxRetries sets the maximum number of retry attempts for a request.
 	// If MaxRetries is zero or negative, a default value (defaultMaxRetries) is used.
 	MaxRetries int
-	// MaxRedirects caps the number of HTTP redirects that will be followed.
-	// If MaxRedirects is zero or negative, a default value (defaultMaxRedirects) is used.
+	// MaxRedirects follows Go net/http CheckRedirect semantics and limits the
+	// total number of requests in a redirect chain, including the initial
+	// request — a value of N therefore allows up to N-1 redirects to be
+	// followed. If MaxRedirects is zero or negative, defaultMaxRedirects (10)
+	// is used, matching the net/http default.
 	MaxRedirects int
 	// BackoffSchedule defines the backoff duration for each retry attempt.
 	// If nil or empty, defaultBackoffSchedule is used.

--- a/request/http_test.go
+++ b/request/http_test.go
@@ -356,15 +356,44 @@ func TestHttp_DefaultValues(t *testing.T) {
 
 	assert.Equal(t, defaultMaxRetries, h.getMaxRetries())
 	assert.Equal(t, defaultBackoffSchedule, h.getBackoffSchedule())
+	assert.Equal(t, defaultMaxRedirects, h.getMaxRedirects())
 }
 
 func TestHttp_CustomValues(t *testing.T) {
 	customSchedule := []time.Duration{5 * time.Second, 15 * time.Second, 45 * time.Second}
 	h := &Http{
 		MaxRetries:      10,
+		MaxRedirects:    5,
 		BackoffSchedule: customSchedule,
 	}
 
 	assert.Equal(t, 10, h.getMaxRetries())
+	assert.Equal(t, 5, h.getMaxRedirects())
 	assert.Equal(t, customSchedule, h.getBackoffSchedule())
+}
+
+func TestHttp_DownloadAuth_RedirectLoop(t *testing.T) {
+	var requestCount int32
+
+	// Server redirects to itself indefinitely (mimics an OIDC login loop
+	// that never completes without valid auth).
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		// Rotate a query param so URL-equality cycle detection wouldn't trigger.
+		w.Header().Set("Location", r.URL.Path+"?n="+fmt.Sprint(atomic.LoadInt32(&requestCount)))
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer ts.Close()
+
+	h := &Http{MaxRedirects: 3}
+
+	ctx := context.Background()
+	body, _, err := h.DownloadAuth(ctx, ts.URL, dmfr.FeedAuthorization{})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "stopped after 3 redirects")
+	assert.Nil(t, body)
+	// CheckRedirect fires when len(via) >= MaxRedirects, so the initial request
+	// plus (MaxRedirects - 1) redirects are followed before the cap triggers.
+	assert.Equal(t, int32(3), atomic.LoadInt32(&requestCount))
 }


### PR DESCRIPTION
## Summary
Fixes a pre-existing bug where the custom `CheckRedirect` in `request/http.go` silently disabled Go stdlib's default 10-redirect cap. Setting a custom `CheckRedirect` replaces the default — it doesn't wrap it (see [golang/go#42832](https://github.com/golang/go/issues/42832)) — so once `removeDefaultPortFromHost` was wired up in #438, the hop cap was gone.

Real-world symptom: a server returning an OIDC login-loop redirect chain (e.g. `developer.tmb.cat` without valid auth) causes fetches to follow redirects until the 10-minute `AuthenticatedRequest` context timeout.

## Change
- Add `MaxRedirects` field to `Http`, defaulting to 10, following the existing `MaxRetries`/`BackoffSchedule` pattern.
- Enforce the cap in `CheckRedirect` while preserving the `removeDefaultPortFromHost` hook.
- Test with an `httptest` server that redirects to itself with a rotating query param (URL-cycle detection wouldn't catch this; hop cap is the right tool).

## Test plan
- [x] New `TestHttp_DownloadAuth_RedirectLoop` passes
- [x] `TestHttp_DefaultValues` / `TestHttp_CustomValues` updated to cover the new field
- [x] Full `./request/...` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)