### PR TITLE
Use safer http fetch by default

### DIFF
--- a/cmds/e2e_test.go
+++ b/cmds/e2e_test.go
@@ -141,8 +141,9 @@ func TestE2E(t *testing.T) {
 				Adapter: atx,
 				Options: fetch.StaticFetchOptions{
 					Options: fetch.Options{
-						Storage:   tmpdir,
-						FetchedAt: time.Now(),
+						Storage:                  tmpdir,
+						FetchedAt:                time.Now(),
+						AllowHTTPFetchUnfiltered: true,
 					},
 				},
 			}

--- a/cmds/fetch_cmd.go
+++ b/cmds/fetch_cmd.go
@@ -78,6 +78,7 @@ func (cmd *FetchCommand) AddFlags(fl *pflag.FlagSet) {
 	fl.BoolVar(&cmd.Options.AllowFTPFetch, "allow-ftp-fetch", false, "Allow fetching from FTP urls")
 	fl.BoolVar(&cmd.Options.AllowLocalFetch, "allow-local-fetch", false, "Allow fetching from filesystem directories/zip files")
 	fl.BoolVar(&cmd.Options.AllowS3Fetch, "allow-s3-fetch", false, "Allow fetching from S3 urls")
+	fl.BoolVar(&cmd.Options.AllowHTTPFetchUnfiltered, "allow-http-fetch-unfiltered", false, "Disable SSRF protection for http(s) fetches; allow private/loopback/metadata IPs (use only for local CLI runs)")
 	fl.BoolVar(&cmd.Options.SaveValidationReport, "validation-report", false, "Save validation report")
 	fl.BoolVar(&cmd.Options.StrictValidation, "strict", false, "Reject feeds with validation errors")
 	fl.StringVar(&cmd.Options.FeedURL, "feed-url", "", "Manually fetch a single URL; you must specify exactly one feed_id")

--- a/cmds/fetch_cmd_test.go
+++ b/cmds/fetch_cmd_test.go
@@ -101,6 +101,7 @@ func TestFetchCommand(t *testing.T) {
 			c.Adapter = adapter
 			tmpDir := t.TempDir()
 			c.Options.Storage = tmpDir
+			c.Options.AllowHTTPFetchUnfiltered = true
 			c.Options.StrictValidation = exp.strict
 			c.Fail = exp.fail
 			if err := c.Parse(exp.command); err != nil {
@@ -168,6 +169,7 @@ func TestFetchCommand_FetchJobs(t *testing.T) {
 		c.Adapter = adapter
 		tmpDir := t.TempDir()
 		c.Options.Storage = tmpDir
+		c.Options.AllowHTTPFetchUnfiltered = true
 		// Provide URLs via FetchJobs instead of FeedIDs or database lookup
 		c.FetchJobs = []FetchJob{
 			{FeedID: "f-job1", FeedURL: fmt.Sprintf("%s/gtfs-examples/example.zip", ts.URL)},
@@ -197,6 +199,7 @@ func TestFetchCommand_FetchJobs(t *testing.T) {
 		c.CreateFeed = true
 		tmpDir := t.TempDir()
 		c.Options.Storage = tmpDir
+		c.Options.AllowHTTPFetchUnfiltered = true
 		// Provide a feed that doesn't exist yet
 		c.FetchJobs = []FetchJob{
 			{FeedID: "f-new-feed", FeedURL: fmt.Sprintf("%s/gtfs-examples/example.zip", ts.URL)},

--- a/doc/cli/transitland_fetch.md
+++ b/doc/cli/transitland_fetch.md
@@ -16,6 +16,7 @@ transitland fetch [flags] [feeds...]
 
 ```
       --allow-ftp-fetch                    Allow fetching from FTP urls
+      --allow-http-fetch-unfiltered        Disable SSRF protection for http(s) fetches; allow private/loopback/metadata IPs (use only for local CLI runs)
       --allow-local-fetch                  Allow fetching from filesystem directories/zip files
       --allow-s3-fetch                     Allow fetching from S3 urls
       --create-feed                        Create feed record if not found

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -14,17 +14,18 @@ import (
 
 // Options sets options for a fetch operation.
 type Options struct {
-	FeedURL         string
-	FeedID          int
-	URLType         string
-	Storage         string
-	AllowFTPFetch   bool
-	AllowLocalFetch bool
-	AllowS3Fetch    bool
-	MaxSize         uint64
-	HideURL         bool
-	FetchedAt       time.Time
-	Secrets         []dmfr.Secret
+	FeedURL                  string
+	FeedID                   int
+	URLType                  string
+	Storage                  string
+	AllowFTPFetch            bool
+	AllowLocalFetch          bool
+	AllowS3Fetch             bool
+	AllowHTTPFetchUnfiltered bool
+	MaxSize                  uint64
+	HideURL                  bool
+	FetchedAt                time.Time
+	Secrets                  []dmfr.Secret
 }
 
 // Result contains results of a fetch operation.
@@ -76,6 +77,9 @@ func Fetch(ctx context.Context, atx tldb.Adapter, opts Options, cb FetchValidato
 	}
 	if opts.AllowS3Fetch {
 		reqOpts = append(reqOpts, request.WithAllowS3)
+	}
+	if opts.AllowHTTPFetchUnfiltered {
+		reqOpts = append(reqOpts, request.WithAllowHTTPUnfiltered)
 	}
 	if opts.MaxSize > 0 {
 		reqOpts = append(reqOpts, request.WithMaxSize(opts.MaxSize))

--- a/fetch/rt_fetch_test.go
+++ b/fetch/rt_fetch_test.go
@@ -53,7 +53,7 @@ func TestRTFetch(t *testing.T) {
 			testdb.TempSqlite(func(atx tldb.Adapter) error {
 				url := ts.URL + "/" + tc.requestPath
 				feed := testdb.CreateTestFeed(atx, url)
-				fr, err := RTFetch(ctx, atx, RTFetchOptions{Options: Options{FeedID: feed.ID, FeedURL: url, Storage: tmpdir}})
+				fr, err := RTFetch(ctx, atx, RTFetchOptions{Options: Options{FeedID: feed.ID, FeedURL: url, Storage: tmpdir, AllowHTTPFetchUnfiltered: true}})
 				if err != nil {
 					t.Error(err)
 					return err

--- a/fetch/static_fetch_test.go
+++ b/fetch/static_fetch_test.go
@@ -124,7 +124,7 @@ func TestStaticFetch(t *testing.T) {
 			testdb.TempSqlite(func(atx tldb.Adapter) error {
 				url := ts.URL + "/" + tc.requestPath
 				feed := testdb.CreateTestFeed(atx, url)
-				fr, err := StaticFetch(ctx, atx, StaticFetchOptions{Options: Options{FeedID: feed.ID, FeedURL: url, Storage: tmpdir}})
+				fr, err := StaticFetch(ctx, atx, StaticFetchOptions{Options: Options{FeedID: feed.ID, FeedURL: url, Storage: tmpdir, AllowHTTPFetchUnfiltered: true}})
 				if err != nil {
 					t.Error(err)
 					return err
@@ -177,11 +177,11 @@ func TestStaticFetch_Exists(t *testing.T) {
 		feed := testdb.CreateTestFeed(atx, url)
 		_ = feed
 		tmpdir := t.TempDir()
-		fr1, err := StaticFetch(ctx, atx, StaticFetchOptions{Options: Options{FeedID: feed.ID, FeedURL: url, Storage: tmpdir}})
+		fr1, err := StaticFetch(ctx, atx, StaticFetchOptions{Options: Options{FeedID: feed.ID, FeedURL: url, Storage: tmpdir, AllowHTTPFetchUnfiltered: true}})
 		if err != nil {
 			t.Fatal(err)
 		}
-		fr2, err2 := StaticFetch(ctx, atx, StaticFetchOptions{Options: Options{FeedID: feed.ID, FeedURL: url, Storage: tmpdir}})
+		fr2, err2 := StaticFetch(ctx, atx, StaticFetchOptions{Options: Options{FeedID: feed.ID, FeedURL: url, Storage: tmpdir, AllowHTTPFetchUnfiltered: true}})
 		if err2 != nil {
 			t.Error(err2)
 		}
@@ -226,7 +226,7 @@ func TestStaticFetch_AdditionalTests(t *testing.T) {
 		//
 		url := ts.URL
 		feed := testdb.CreateTestFeed(atx, ts.URL)
-		fr, err := StaticFetch(ctx, atx, StaticFetchOptions{Options: Options{FeedID: feed.ID, FeedURL: feed.URLs.StaticCurrent, Storage: tmpdir}})
+		fr, err := StaticFetch(ctx, atx, StaticFetchOptions{Options: Options{FeedID: feed.ID, FeedURL: feed.URLs.StaticCurrent, Storage: tmpdir, AllowHTTPFetchUnfiltered: true}})
 		if err != nil {
 			t.Error(err)
 			return nil
@@ -312,7 +312,7 @@ func TestStaticFetch_NestedTwoFeeds(t *testing.T) {
 		for _, tc := range tcs {
 			_ = tc
 			feed := testdb.CreateTestFeed(atx, ts.URL+"/"+tc.url)
-			fr, err := StaticFetch(ctx, atx, StaticFetchOptions{Options: Options{FeedID: feed.ID, FeedURL: feed.URLs.StaticCurrent, Storage: tmpdir}})
+			fr, err := StaticFetch(ctx, atx, StaticFetchOptions{Options: Options{FeedID: feed.ID, FeedURL: feed.URLs.StaticCurrent, Storage: tmpdir, AllowHTTPFetchUnfiltered: true}})
 			if err != nil {
 				t.Error(err)
 				return nil
@@ -385,7 +385,7 @@ func TestStaticStateFetch_FetchError(t *testing.T) {
 		defer os.RemoveAll(tmpdir) // clean up
 		feed := testdb.CreateTestFeed(atx, ts.URL)
 		// Fetch
-		_, err = StaticFetch(ctx, atx, StaticFetchOptions{Options: Options{FeedID: feed.ID, FeedURL: feed.URLs.StaticCurrent, Storage: tmpdir}})
+		_, err = StaticFetch(ctx, atx, StaticFetchOptions{Options: Options{FeedID: feed.ID, FeedURL: feed.URLs.StaticCurrent, Storage: tmpdir, AllowHTTPFetchUnfiltered: true}})
 		if err != nil {
 			t.Error(err)
 			return nil
@@ -418,7 +418,7 @@ func TestStaticStateFetch_HideURL(t *testing.T) {
 		defer os.RemoveAll(tmpdir) // clean up
 		feed := testdb.CreateTestFeed(atx, ts.URL)
 		// Fetch
-		_, err = StaticFetch(ctx, atx, StaticFetchOptions{Options: Options{FeedID: feed.ID, FeedURL: feed.URLs.StaticCurrent, Storage: tmpdir, HideURL: true}})
+		_, err = StaticFetch(ctx, atx, StaticFetchOptions{Options: Options{FeedID: feed.ID, FeedURL: feed.URLs.StaticCurrent, Storage: tmpdir, HideURL: true, AllowHTTPFetchUnfiltered: true}})
 		if err != nil {
 			t.Error(err)
 			return nil

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/interline-io/transitland-lib
 go 1.26.0
 
 require (
+	code.dny.dev/ssrf v0.2.0
 	github.com/99designs/gqlgen v0.17.78
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+code.dny.dev/ssrf v0.2.0 h1:wCBP990rQQ1CYfRpW+YK1+8xhwUjv189AQ3WMo1jQaI=
+code.dny.dev/ssrf v0.2.0/go.mod h1:B+91l25OnyaLIeCx0WRJN5qfJ/4/ZTZxRXgm0lj/2w8=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/99designs/gqlgen v0.17.78 h1:bhIi7ynrc3js2O8wu1sMQj1YHPENDt3jQGyifoBvoVI=

--- a/internal/gbfs/fetch.go
+++ b/internal/gbfs/fetch.go
@@ -33,6 +33,9 @@ func Fetch(ctx context.Context, atx tldb.Adapter, opts Options) ([]GbfsFeed, Res
 	if opts.AllowS3Fetch {
 		reqOpts = append(reqOpts, request.WithAllowS3)
 	}
+	if opts.AllowHTTPFetchUnfiltered {
+		reqOpts = append(reqOpts, request.WithAllowHTTPUnfiltered)
+	}
 
 	// Fetch system file
 	systemFile := SystemFile{}
@@ -50,7 +53,7 @@ func Fetch(ctx context.Context, atx tldb.Adapter, opts Options) ([]GbfsFeed, Res
 		if sflang == nil {
 			continue
 		}
-		if feed, err := fetchAll(ctx, *sflang); err == nil {
+		if feed, err := fetchAll(ctx, *sflang, reqOpts...); err == nil {
 			feeds = append(feeds, feed)
 		}
 	}

--- a/internal/gbfs/fetch_test.go
+++ b/internal/gbfs/fetch_test.go
@@ -15,6 +15,7 @@ func TestGbfsFetch(t *testing.T) {
 	defer ts.Close()
 	opts := Options{}
 	opts.FeedURL = fmt.Sprintf("%s/%s", ts.URL, "gbfs.json")
+	opts.AllowHTTPFetchUnfiltered = true
 	feeds, _, err := Fetch(context.Background(), nil, opts)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/testconfig/testconfig.go
+++ b/internal/testconfig/testconfig.go
@@ -164,15 +164,16 @@ func newTestConfig(t testing.TB, ctx context.Context, db tldb.Ext, opts Options)
 	actionFinder := &actions.Actions{}
 
 	return model.Config{
-		Finder:     dbf,
-		RTFinder:   rtf,
-		GbfsFinder: gbf,
-		Checker:    checker,
-		JobQueue:   jobQueue,
-		Actions:    actionFinder,
-		Clock:      cl,
-		Storage:    opts.Storage,
-		RTStorage:  opts.RTStorage,
-		MaxRadius:  100_000,
+		Finder:                   dbf,
+		RTFinder:                 rtf,
+		GbfsFinder:               gbf,
+		Checker:                  checker,
+		JobQueue:                 jobQueue,
+		Actions:                  actionFinder,
+		Clock:                    cl,
+		Storage:                  opts.Storage,
+		RTStorage:                opts.RTStorage,
+		MaxRadius:                100_000,
+		AllowHTTPFetchUnfiltered: true,
 	}
 }

--- a/request/http.go
+++ b/request/http.go
@@ -30,7 +30,12 @@ var defaultGuardian = ssrf.New()
 // safeTransport is shared across all DownloadAuth calls so that connection
 // pooling and HTTP/2 reuse work across feed fetches.
 var safeTransport = func() *http.Transport {
-	t := http.DefaultTransport.(*http.Transport).Clone()
+	var t *http.Transport
+	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+		t = dt.Clone()
+	} else {
+		t = &http.Transport{}
+	}
 	t.DialContext = (&net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,

--- a/request/http.go
+++ b/request/http.go
@@ -25,7 +25,13 @@ import (
 // net.Dialer.Control hook, so it sees the resolved IP rather than the
 // hostname, closing basic DNS rebinding and multi-A-record gaps. Connections
 // to private destinations require opting out via Http.AllowHTTPUnfiltered.
-var defaultGuardian = ssrf.New()
+//
+// Port restriction is disabled (WithAnyPort): legitimate public GTFS feeds
+// commonly serve from non-standard HTTPS ports (8443, 4443, etc.). The
+// library only ever uses http.Client, so the dial port doesn't change the
+// protocol — port allowlisting would block real feeds without preventing
+// any attack the IP-based filter doesn't already cover.
+var defaultGuardian = ssrf.New(ssrf.WithAnyPort())
 
 // safeTransport is shared across all DownloadAuth calls so that connection
 // pooling and HTTP/2 reuse work across feed fetches.

--- a/request/http.go
+++ b/request/http.go
@@ -6,16 +6,38 @@ import (
 	"fmt"
 	"io"
 	"math/rand/v2"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
 
+	"code.dny.dev/ssrf"
 	"github.com/interline-io/log"
 	tl "github.com/interline-io/transitland-lib"
 	"github.com/interline-io/transitland-lib/dmfr"
 )
+
+// defaultGuardian denies connections to IP ranges in the IANA Special-Purpose
+// Registries (loopback, RFC1918, link-local, multicast, the cloud metadata
+// address, etc.) and restricts IPv6 to global unicast. It runs as a
+// net.Dialer.Control hook, so it sees the resolved IP rather than the
+// hostname, closing basic DNS rebinding and multi-A-record gaps. Connections
+// to private destinations require opting out via Http.AllowHTTPUnfiltered.
+var defaultGuardian = ssrf.New()
+
+// safeTransport is shared across all DownloadAuth calls so that connection
+// pooling and HTTP/2 reuse work across feed fetches.
+var safeTransport = func() *http.Transport {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.DialContext = (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control:   defaultGuardian.Safe,
+	}).DialContext
+	return t
+}()
 
 func init() {
 	var _ Downloader = &Http{}
@@ -47,6 +69,10 @@ type Http struct {
 	// BackoffSchedule defines the backoff duration for each retry attempt.
 	// If nil or empty, defaultBackoffSchedule is used.
 	BackoffSchedule []time.Duration
+	// AllowHTTPUnfiltered disables SSRF protection (private/loopback/metadata
+	// IPs are allowed). Off by default — only set in CLI contexts where the
+	// operator legitimately fetches from internal addresses.
+	AllowHTTPUnfiltered bool
 }
 
 func (r *Http) SetSecret(secret dmfr.Secret) error {
@@ -195,6 +221,9 @@ func (r Http) DownloadAuth(ctx context.Context, ustr string, auth dmfr.FeedAutho
 			removeDefaultPortFromHost(req)
 			return nil
 		},
+	}
+	if !r.AllowHTTPUnfiltered {
+		client.Transport = safeTransport
 	}
 
 	maxRetries := r.getMaxRetries()

--- a/request/http_test.go
+++ b/request/http_test.go
@@ -357,6 +357,36 @@ func TestHttp_DownloadAuth_NonRetryableError(t *testing.T) {
 	assert.Nil(t, body)
 }
 
+func TestHttp_DownloadAuth_SSRFRejectsLoopbackByDefault(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	defer ts.Close()
+
+	h := &Http{}
+	body, _, err := h.DownloadAuth(context.Background(), ts.URL, dmfr.FeedAuthorization{})
+	assert.Error(t, err, "default Http should reject loopback")
+	assert.Nil(t, body)
+}
+
+func TestHttp_DownloadAuth_AllowHTTPUnfilteredPermitsLoopback(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}))
+	defer ts.Close()
+
+	h := &Http{AllowHTTPUnfiltered: true}
+	body, statusCode, err := h.DownloadAuth(context.Background(), ts.URL, dmfr.FeedAuthorization{})
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.NotNil(t, body)
+	if body != nil {
+		body.Close()
+	}
+}
+
 func TestHttp_DefaultValues(t *testing.T) {
 	h := &Http{}
 

--- a/request/http_test.go
+++ b/request/http_test.go
@@ -196,8 +196,9 @@ func TestHttp_DownloadAuth_429Retry(t *testing.T) {
 	defer ts.Close()
 
 	h := &Http{
-		MaxRetries:      3,
-		BackoffSchedule: []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond},
+		MaxRetries:          3,
+		BackoffSchedule:     []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond},
+		AllowHTTPUnfiltered: true,
 	}
 
 	ctx := context.Background()
@@ -229,8 +230,9 @@ func TestHttp_DownloadAuth_503Retry(t *testing.T) {
 	defer ts.Close()
 
 	h := &Http{
-		MaxRetries:      3,
-		BackoffSchedule: []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond},
+		MaxRetries:          3,
+		BackoffSchedule:     []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond},
+		AllowHTTPUnfiltered: true,
 	}
 
 	ctx := context.Background()
@@ -257,8 +259,9 @@ func TestHttp_DownloadAuth_429MaxRetriesExceeded(t *testing.T) {
 	defer ts.Close()
 
 	h := &Http{
-		MaxRetries:      2,
-		BackoffSchedule: []time.Duration{10 * time.Millisecond, 20 * time.Millisecond},
+		MaxRetries:          2,
+		BackoffSchedule:     []time.Duration{10 * time.Millisecond, 20 * time.Millisecond},
+		AllowHTTPUnfiltered: true,
 	}
 
 	ctx := context.Background()
@@ -288,8 +291,9 @@ func TestHttp_DownloadAuth_429WithRetryAfterHeader(t *testing.T) {
 	defer ts.Close()
 
 	h := &Http{
-		MaxRetries:      3,
-		BackoffSchedule: []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond},
+		MaxRetries:          3,
+		BackoffSchedule:     []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond},
+		AllowHTTPUnfiltered: true,
 	}
 
 	ctx := context.Background()
@@ -318,8 +322,9 @@ func TestHttp_DownloadAuth_ContextCancellation(t *testing.T) {
 	defer ts.Close()
 
 	h := &Http{
-		MaxRetries:      3,
-		BackoffSchedule: []time.Duration{1 * time.Second, 2 * time.Second, 3 * time.Second},
+		MaxRetries:          3,
+		BackoffSchedule:     []time.Duration{1 * time.Second, 2 * time.Second, 3 * time.Second},
+		AllowHTTPUnfiltered: true,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
@@ -339,8 +344,9 @@ func TestHttp_DownloadAuth_NonRetryableError(t *testing.T) {
 	defer ts.Close()
 
 	h := &Http{
-		MaxRetries:      3,
-		BackoffSchedule: []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond},
+		MaxRetries:          3,
+		BackoffSchedule:     []time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond},
+		AllowHTTPUnfiltered: true,
 	}
 
 	ctx := context.Background()

--- a/request/request.go
+++ b/request/request.go
@@ -71,13 +71,14 @@ type FetchResponse struct {
 }
 
 type Request struct {
-	URL        string
-	AllowFTP   bool
-	AllowLocal bool
-	AllowS3    bool
-	MaxSize    uint64
-	Secret     dmfr.Secret
-	Auth       dmfr.FeedAuthorization
+	URL                 string
+	AllowFTP            bool
+	AllowLocal          bool
+	AllowS3             bool
+	AllowHTTPUnfiltered bool
+	MaxSize             uint64
+	Secret              dmfr.Secret
+	Auth                dmfr.FeedAuthorization
 }
 
 func (req *Request) Request(ctx context.Context) (io.ReadCloser, int, error) {
@@ -103,9 +104,9 @@ func (req *Request) newDownloader(ustr string) (Downloader, string, error) {
 	reqUrl := req.URL
 	switch u.Scheme {
 	case "http":
-		downloader = &Http{}
+		downloader = &Http{AllowHTTPUnfiltered: req.AllowHTTPUnfiltered}
 	case "https":
-		downloader = &Http{}
+		downloader = &Http{AllowHTTPUnfiltered: req.AllowHTTPUnfiltered}
 	case "ftp":
 		if req.AllowFTP {
 			downloader = &Ftp{}
@@ -155,6 +156,10 @@ func WithAllowLocal(req *Request) {
 
 func WithAllowS3(req *Request) {
 	req.AllowS3 = true
+}
+
+func WithAllowHTTPUnfiltered(req *Request) {
+	req.AllowHTTPUnfiltered = true
 }
 
 func WithMaxSize(s uint64) RequestOption {

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -240,7 +240,7 @@ func TestAuthorizedRequest(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			var out bytes.Buffer
-			fr, err := AuthenticatedRequest(ctx, &out, ts.URL+tc.url, WithAuth(tc.secret, tc.auth))
+			fr, err := AuthenticatedRequest(ctx, &out, ts.URL+tc.url, WithAuth(tc.secret, tc.auth), WithAllowHTTPUnfiltered)
 			if err != nil {
 				t.Error(err)
 				return

--- a/server/finders/actions/feed_fetch.go
+++ b/server/finders/actions/feed_fetch.go
@@ -39,13 +39,14 @@ func StaticFetch(ctx context.Context, feedId string, feedSrc io.Reader, feedUrl 
 	// Prepare
 	fetchOpts := fetch.StaticFetchOptions{
 		Options: fetch.Options{
-			FeedID:        feed.ID,
-			URLType:       urlType,
-			FeedURL:       feedUrl,
-			Storage:       cfg.Storage,
-			Secrets:       cfg.Secrets,
-			FetchedAt:     time.Now().In(time.UTC),
-			AllowFTPFetch: true,
+			FeedID:                   feed.ID,
+			URLType:                  urlType,
+			FeedURL:                  feedUrl,
+			Storage:                  cfg.Storage,
+			Secrets:                  cfg.Secrets,
+			FetchedAt:                time.Now().In(time.UTC),
+			AllowFTPFetch:            true,
+			AllowHTTPFetchUnfiltered: cfg.AllowHTTPFetchUnfiltered,
 		},
 	}
 	if user := authn.ForContext(ctx); user != nil {
@@ -102,12 +103,13 @@ func RTFetch(ctx context.Context, target string, feedId string, feedUrl string, 
 	// Prepare
 	fetchOpts := fetch.RTFetchOptions{
 		Options: fetch.Options{
-			FeedID:    feed.ID,
-			URLType:   urlType,
-			FeedURL:   feedUrl,
-			Storage:   cfg.RTStorage,
-			Secrets:   cfg.Secrets,
-			FetchedAt: time.Now().In(time.UTC),
+			FeedID:                   feed.ID,
+			URLType:                  urlType,
+			FeedURL:                  feedUrl,
+			Storage:                  cfg.RTStorage,
+			Secrets:                  cfg.Secrets,
+			FetchedAt:                time.Now().In(time.UTC),
+			AllowHTTPFetchUnfiltered: cfg.AllowHTTPFetchUnfiltered,
 		},
 	}
 
@@ -156,6 +158,7 @@ func GbfsFetch(ctx context.Context, feedId string, feedUrl string) error {
 	opts.FeedID = gfeeds[0].ID
 	opts.URLType = "gbfs_auto_discovery"
 	opts.FetchedAt = time.Now().In(time.UTC)
+	opts.AllowHTTPFetchUnfiltered = cfg.AllowHTTPFetchUnfiltered
 	if feedUrl != "" {
 		opts.FeedURL = feedUrl
 	}

--- a/server/finders/actions/fv.go
+++ b/server/finders/actions/fv.go
@@ -11,6 +11,7 @@ import (
 	"github.com/interline-io/transitland-lib/copier"
 	"github.com/interline-io/transitland-lib/dmfr"
 	"github.com/interline-io/transitland-lib/importer"
+	"github.com/interline-io/transitland-lib/request"
 	"github.com/interline-io/transitland-lib/server/auth/authz"
 	"github.com/interline-io/transitland-lib/server/model"
 	"github.com/interline-io/transitland-lib/tlcsv"
@@ -145,7 +146,11 @@ func ValidateUpload(ctx context.Context, src io.Reader, feedURL *string, rturls 
 		}
 	} else if feedURL != nil {
 		var err error
-		reader, err = tlcsv.NewReader(*feedURL)
+		var reqOpts []request.RequestOption
+		if cfg.AllowHTTPFetchUnfiltered {
+			reqOpts = append(reqOpts, request.WithAllowHTTPUnfiltered)
+		}
+		reader, err = tlcsv.NewReaderFromAdapter(tlcsv.NewURLAdapter(*feedURL, reqOpts...))
 		if err != nil {
 			result.FailureReason = strptr("Could not load URL")
 			return &result, nil
@@ -170,6 +175,7 @@ func ValidateUpload(ctx context.Context, src io.Reader, feedURL *string, rturls 
 		IncludeRealtimeJson:      true,
 		IncludeEntitiesLimit:     10_000,
 		MaxRTMessageSize:         10_000_000,
+		AllowHTTPFetchUnfiltered: cfg.AllowHTTPFetchUnfiltered,
 		ValidateRealtimeMessages: rturls,
 		Options:                  copier.Options{Quiet: true},
 	}

--- a/server/finders/gbfsfinder/finder_test.go
+++ b/server/finders/gbfsfinder/finder_test.go
@@ -66,6 +66,7 @@ func testSetupGbfs(gbf model.GbfsFinder) error {
 	defer ts.Close()
 	opts := gbfs.Options{}
 	opts.FeedURL = fmt.Sprintf("%s/%s", ts.URL, "gbfs.json")
+	opts.AllowHTTPFetchUnfiltered = true
 	feeds, _, err := gbfs.Fetch(context.Background(), nil, opts)
 	if err != nil {
 		return err

--- a/server/gql/gbfs_resolver_test.go
+++ b/server/gql/gbfs_resolver_test.go
@@ -18,6 +18,7 @@ func setupGbfs(ctx context.Context, gbf model.GbfsFinder) error {
 	defer ts.Close()
 	opts := gbfs.Options{}
 	opts.FeedURL = fmt.Sprintf("%s/%s", ts.URL, "gbfs.json")
+	opts.AllowHTTPFetchUnfiltered = true
 	feeds, _, err := gbfs.Fetch(ctx, nil, opts)
 	if err != nil {
 		return err

--- a/server/model/config.go
+++ b/server/model/config.go
@@ -10,23 +10,24 @@ import (
 )
 
 type Config struct {
-	Finder                  Finder
-	RTFinder                RTFinder
-	GbfsFinder              GbfsFinder
-	Checker                 Checker
-	Actions                 Actions
-	JobQueue                jobs.JobQueue
-	Clock                   clock.Clock
-	Secrets                 []dmfr.Secret
-	ValidateLargeFiles      bool
-	DisableImage            bool
-	UseMaterialized         bool
-	RestPrefix              string
-	Storage                 string
-	RTStorage               string
-	LoaderBatchSize         int
-	LoaderStopTimeBatchSize int
-	MaxRadius               float64
+	Finder                   Finder
+	RTFinder                 RTFinder
+	GbfsFinder               GbfsFinder
+	Checker                  Checker
+	Actions                  Actions
+	JobQueue                 jobs.JobQueue
+	Clock                    clock.Clock
+	Secrets                  []dmfr.Secret
+	ValidateLargeFiles       bool
+	DisableImage             bool
+	UseMaterialized          bool
+	AllowHTTPFetchUnfiltered bool
+	RestPrefix               string
+	Storage                  string
+	RTStorage                string
+	LoaderBatchSize          int
+	LoaderStopTimeBatchSize  int
+	MaxRadius                float64
 }
 
 var finderCtxKey = &contextKey{"finderConfig"}

--- a/tlcsv/adapter_test.go
+++ b/tlcsv/adapter_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/interline-io/transitland-lib/gtfs"
 	"github.com/interline-io/transitland-lib/internal/testpath"
 	"github.com/interline-io/transitland-lib/internal/testreader"
+	"github.com/interline-io/transitland-lib/request"
 )
 
 func getTestAdapters() map[string]func() Adapter {
@@ -177,10 +178,10 @@ func TestURLAdapter(t *testing.T) {
 	}))
 	defer ts.Close()
 	// Main tests
-	testAdapter(t, &URLAdapter{url: ts.URL})
+	testAdapter(t, &URLAdapter{url: ts.URL, reqOpts: []request.RequestOption{request.WithAllowHTTPUnfiltered}})
 	//
 	t.Run("Download", func(t *testing.T) {
-		a := URLAdapter{url: ts.URL}
+		a := URLAdapter{url: ts.URL, reqOpts: []request.RequestOption{request.WithAllowHTTPUnfiltered}}
 		if err := a.Open(); err != nil {
 			t.Error(err)
 		}

--- a/tlcsv/reader_test.go
+++ b/tlcsv/reader_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/interline-io/transitland-lib/adapters"
 	"github.com/interline-io/transitland-lib/internal/testreader"
+	"github.com/interline-io/transitland-lib/request"
 )
 
 func TestReader(t *testing.T) {
@@ -22,7 +23,9 @@ func TestReader(t *testing.T) {
 	defer ts.Close()
 	//
 	tsa := getTestAdapters()
-	tsa["URL"] = func() Adapter { return &URLAdapter{url: ts.URL} }
+	tsa["URL"] = func() Adapter {
+		return &URLAdapter{url: ts.URL, reqOpts: []request.RequestOption{request.WithAllowHTTPUnfiltered}}
+	}
 	for k, v := range tsa {
 		t.Run(k, func(t *testing.T) {
 			testreader.TestReader(t, testreader.ExampleDir, func() adapters.Reader {

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -49,6 +49,7 @@ type Options struct {
 	ValidateRealtimeMessages []string
 	IncludeRealtimeJson      bool
 	MaxRTMessageSize         uint64
+	AllowHTTPFetchUnfiltered bool
 	EvaluateAt               time.Time
 	EvaluateAtTimezone       string
 	// ErrorThreshold sets the maximum error percentage (0-100) allowed per file.
@@ -327,7 +328,11 @@ func (v *Validator) ValidateRT(ctx context.Context, fn string, evaluateAt time.T
 		Url: fn,
 	}
 	var rterrs []error
-	msg, err := rt.ReadURL(ctx, fn, request.WithMaxSize(v.Options.MaxRTMessageSize), request.WithAllowLocal)
+	rtOpts := []request.RequestOption{request.WithMaxSize(v.Options.MaxRTMessageSize), request.WithAllowLocal}
+	if v.Options.AllowHTTPFetchUnfiltered {
+		rtOpts = append(rtOpts, request.WithAllowHTTPUnfiltered)
+	}
+	msg, err := rt.ReadURL(ctx, fn, rtOpts...)
 	if err != nil {
 		rterrs = append(rterrs, err)
 	} else {


### PR DESCRIPTION
## Summary

GTFS feed fetches now refuse by default to dial private IPs (loopback, RFC1918, link-local, multicast, cloud metadata, IPv6 non-global-unicast). Closes the SSRF oracle in the GraphQL `feed_version_fetch` and `validate_gtfs` mutations, where the returned status code, response size, and SHA1 leaked enough info to probe internal services.

Implemented via `code.dny.dev/ssrf` as a `net.Dialer.Control` hook, so it runs against the resolved IP and isn't fooled by basic DNS rebinding or multi-A-record tricks. A package-level `safeTransport` is shared across all fetches to preserve connection pooling and HTTP/2 reuse.

**Ports are intentionally unrestricted** (`ssrf.WithAnyPort()`). A scan of prod feeds turned up ~20 legitimate public providers on non-standard ports (8443, 4443, 8080, etc.); since we only ever use `http.Client`, the dial port can't change the protocol, so port allowlisting would just block real feeds.

### Opt-out

Plumbed through every layer so CLI users, tests, and self-composing deployers can keep fetching from internal addresses when needed:

- Library: `request.WithAllowHTTPUnfiltered`
- Fetch / validator: `Options.AllowHTTPFetchUnfiltered`
- Server: `model.Config.AllowHTTPFetchUnfiltered` (default `false`; tlv2 explicitly enables in test config only)
- CLI: `--allow-http-fetch-unfiltered` on `transitland fetch`

### Notable

- `ValidateUpload` switched from `tlcsv.NewReader(url)` to `tlcsv.NewURLAdapter(url, reqOpts...)` so it can honor the opt-out for validate-by-URL.
- Pre-existing bug fixed: `internal/gbfs.fetchAll` was discarding caller `reqOpts`. Surfaced because the new default broke localhost test fixtures.

## Test plan

- `transitland fetch <localhost-url>` fails by default; with `--allow-http-fetch-unfiltered` it succeeds.
- `transitland fetch <https-url-with-non-standard-port>` succeeds without the opt-out (regression check for the port-restriction discussion above).
- GraphQL `feed_version_fetch` against a real public URL still works; against `127.0.0.1` it returns an SSRF dial error in `FetchError`.
- `validate_gtfs` with a `realtime_urls` pointing at `127.0.0.1` fails the same way.
- `HTTPS_PROXY` env var still routes through the proxy (we clone from `http.DefaultTransport`, which honors `ProxyFromEnvironment`).