### PR TITLE
Permissions checks should always fail closed

### DIFF
--- a/cmds/server_cmd.go
+++ b/cmds/server_cmd.go
@@ -174,7 +174,10 @@ func (cmd *ServerCommand) Run(ctx context.Context) error {
 	// This demo binary always runs with authorization disabled — it does
 	// not wire up a real Checker. Callers that need enforced authorization
 	// must compose their own binary using this package as a library.
-	cfg.Checker = globalAdminCheckerInstance
+	// IncludePublic preserves the historical behavior where public feeds are
+	// visible without per-feed grants.
+	cfg.Checker = allowAllCheckerInstance
+	cfg.IncludePublic = true
 	log.For(ctx).Warn().Msg("authorization disabled: demo mode")
 
 	// Setup router
@@ -203,7 +206,7 @@ func (cmd *ServerCommand) Run(ctx context.Context) error {
 	}))
 
 	// PermFilter context
-	root.Use(model.AddPerms(cfg.Checker))
+	root.Use(model.AddPerms(cfg.Checker, cfg.IncludePublic))
 
 	// Profiling
 	root.HandleFunc("/debug/pprof/", pprof.Index)
@@ -252,5 +255,5 @@ func (cmd *ServerCommand) Run(ctx context.Context) error {
 	return srv.ListenAndServe()
 }
 
-// globalAdminChecker disables all feed authorization checks.
-var globalAdminCheckerInstance = &authz.GlobalAdminChecker{}
+// allowAllCheckerInstance disables all feed authorization checks.
+var allowAllCheckerInstance = &authz.AllowAllChecker{}

--- a/cmds/server_cmd.go
+++ b/cmds/server_cmd.go
@@ -171,11 +171,8 @@ func (cmd *ServerCommand) Run(ctx context.Context) error {
 		MaxRadius:               cmd.MaxRadius,
 	}
 
-	// This demo binary always runs with authorization disabled — it does
-	// not wire up a real Checker. Callers that need enforced authorization
-	// must compose their own binary using this package as a library.
-	// IncludePublic preserves the historical behavior where public feeds are
-	// visible without per-feed grants.
+	// Demo binary: authorization disabled. Production deployments should
+	// compose their own binary with a real Checker.
 	cfg.Checker = allowAllCheckerInstance
 	cfg.IncludePublic = true
 	log.For(ctx).Warn().Msg("authorization disabled: demo mode")
@@ -255,5 +252,4 @@ func (cmd *ServerCommand) Run(ctx context.Context) error {
 	return srv.ListenAndServe()
 }
 
-// allowAllCheckerInstance disables all feed authorization checks.
 var allowAllCheckerInstance = &authz.AllowAllChecker{}

--- a/cmds/server_cmd.go
+++ b/cmds/server_cmd.go
@@ -52,7 +52,6 @@ type ServerCommand struct {
 	LoadAdmins              bool
 	ValidateLargeFiles      bool
 	UseMaterialized         bool
-	DisableAuth             bool
 	LoaderBatchSize         int
 	LoaderStopTimeBatchSize int
 	SecretsFile             string
@@ -88,7 +87,6 @@ func (cmd *ServerCommand) AddFlags(fl *pflag.FlagSet) {
 	fl.IntVar(&cmd.LoaderStopTimeBatchSize, "loader-stop-time-batch-size", 1, "GraphQL Loader batch size for StopTimes")
 	fl.Float64Var(&cmd.MaxRadius, "max-radius", 100_000, "Maximum radius for nearby stops")
 	fl.BoolVar(&cmd.UseMaterialized, "use-materialized", false, "Use materialized views for active entities")
-	fl.BoolVar(&cmd.DisableAuth, "disable-auth", false, "Disable feed authorization checks (treat all feeds as public)")
 }
 
 func (cmd *ServerCommand) Parse(args []string) error {
@@ -173,10 +171,11 @@ func (cmd *ServerCommand) Run(ctx context.Context) error {
 		MaxRadius:               cmd.MaxRadius,
 	}
 
-	// Disable auth if requested
-	if cmd.DisableAuth {
-		cfg.Checker = globalAdminCheckerInstance
-	}
+	// This demo binary always runs with authorization disabled — it does
+	// not wire up a real Checker. Callers that need enforced authorization
+	// must compose their own binary using this package as a library.
+	cfg.Checker = globalAdminCheckerInstance
+	log.For(ctx).Warn().Msg("authorization disabled: demo mode")
 
 	// Setup router
 	root := chi.NewRouter()

--- a/doc/cli/transitland_server.md
+++ b/doc/cli/transitland_server.md
@@ -16,7 +16,6 @@ transitland server [flags]
 
 ```
       --dburl string                      Database URL (default: $TL_DATABASE_URL)
-      --disable-auth                      Disable feed authorization checks (treat all feeds as public)
   -h, --help                              help for server
       --load-admins                       Load admin polygons from database into memory
       --loader-batch-size int             GraphQL Loader batch size (default 100)

--- a/internal/testconfig/testconfig.go
+++ b/internal/testconfig/testconfig.go
@@ -36,6 +36,10 @@ type Options struct {
 	FGAEndpoint    string
 	FGAModelFile   string
 	FGAModelTuples []authz.TupleKey
+	// AllowAll installs a permissive GlobalAdminChecker. Tests that exercise
+	// mutations need this because the library now denies mutations when no
+	// Checker is configured. Ignored when FGAEndpoint is set.
+	AllowAll bool
 }
 
 func Config(t testing.TB, opts Options) model.Config {
@@ -97,8 +101,14 @@ func newTestConfig(t testing.TB, ctx context.Context, db tldb.Ext, opts Options)
 	}
 	cl := &clock.Mock{T: when}
 
-	// Setup Checker
+	// Setup Checker. Default is nil so that read-side tests continue to
+	// see the "anonymous" view (only public feeds). Mutation tests must
+	// pass AllowAll: true — the library now fails closed on mutations
+	// when Checker is nil.
 	var checker model.Checker
+	if opts.AllowAll {
+		checker = &authz.GlobalAdminChecker{}
+	}
 	if opts.FGAEndpoint != "" {
 		fgaClient, fgaErr := fga.NewFGAClient(opts.FGAEndpoint, "", "")
 		if fgaErr != nil {

--- a/internal/testconfig/testconfig.go
+++ b/internal/testconfig/testconfig.go
@@ -36,9 +36,10 @@ type Options struct {
 	FGAEndpoint    string
 	FGAModelFile   string
 	FGAModelTuples []authz.TupleKey
-	// AllowAll installs a permissive GlobalAdminChecker. Tests that exercise
-	// mutations need this because the library now denies mutations when no
-	// Checker is configured. Ignored when FGAEndpoint is set.
+	// AllowAll installs a permissive AllowAllChecker (every Check passes,
+	// IsGlobalAdmin returns true). Tests that exercise mutations need this.
+	// Default is a DenyAllChecker, paired with IncludePublic=true so read-side
+	// tests continue to see public feeds. Ignored when FGAEndpoint is set.
 	AllowAll bool
 }
 
@@ -101,13 +102,13 @@ func newTestConfig(t testing.TB, ctx context.Context, db tldb.Ext, opts Options)
 	}
 	cl := &clock.Mock{T: when}
 
-	// Setup Checker. Default is nil so that read-side tests continue to
-	// see the "anonymous" view (only public feeds). Mutation tests must
-	// pass AllowAll: true — the library now fails closed on mutations
-	// when Checker is nil.
-	var checker model.Checker
+	// Setup Checker. model.Config requires a non-nil Checker, so the default
+	// is a DenyAllChecker (denies every per-feed check, IsGlobalAdmin=false).
+	// Read-side tests still see public feeds because IncludePublic defaults
+	// to true below. Mutation tests must pass AllowAll: true.
+	var checker model.Checker = &authz.DenyAllChecker{}
 	if opts.AllowAll {
-		checker = &authz.GlobalAdminChecker{}
+		checker = &authz.AllowAllChecker{}
 	}
 	if opts.FGAEndpoint != "" {
 		fgaClient, fgaErr := fga.NewFGAClient(opts.FGAEndpoint, "", "")
@@ -178,6 +179,7 @@ func newTestConfig(t testing.TB, ctx context.Context, db tldb.Ext, opts Options)
 		RTFinder:                 rtf,
 		GbfsFinder:               gbf,
 		Checker:                  checker,
+		IncludePublic:            true,
 		JobQueue:                 jobQueue,
 		Actions:                  actionFinder,
 		Clock:                    cl,

--- a/internal/testconfig/testconfig.go
+++ b/internal/testconfig/testconfig.go
@@ -36,10 +36,8 @@ type Options struct {
 	FGAEndpoint    string
 	FGAModelFile   string
 	FGAModelTuples []authz.TupleKey
-	// AllowAll installs a permissive AllowAllChecker (every Check passes,
-	// IsGlobalAdmin returns true). Tests that exercise mutations need this.
-	// Default is a DenyAllChecker, paired with IncludePublic=true so read-side
-	// tests continue to see public feeds. Ignored when FGAEndpoint is set.
+	// AllowAll installs an AllowAllChecker. Required for tests that exercise
+	// mutations. Ignored when FGAEndpoint is set.
 	AllowAll bool
 }
 
@@ -102,10 +100,8 @@ func newTestConfig(t testing.TB, ctx context.Context, db tldb.Ext, opts Options)
 	}
 	cl := &clock.Mock{T: when}
 
-	// Setup Checker. model.Config requires a non-nil Checker, so the default
-	// is a DenyAllChecker (denies every per-feed check, IsGlobalAdmin=false).
-	// Read-side tests still see public feeds because IncludePublic defaults
-	// to true below. Mutation tests must pass AllowAll: true.
+	// model.Config requires a non-nil Checker. Default to deny-all; read-side
+	// tests still see public feeds via IncludePublic=true below.
 	var checker model.Checker = &authz.DenyAllChecker{}
 	if opts.AllowAll {
 		checker = &authz.AllowAllChecker{}

--- a/server/auth/authz/checker.go
+++ b/server/auth/authz/checker.go
@@ -1,6 +1,10 @@
 package authz
 
-import "context"
+import (
+	"context"
+
+	"github.com/interline-io/transitland-lib/server/auth/authn"
+)
 
 // ObjectRef identifies an entity in the authorization system.
 type ObjectRef struct {
@@ -80,29 +84,63 @@ type AdminManager interface {
 	GroupSave(ctx context.Context, req *GroupSaveRequest) (*GroupSaveResponse, error)
 }
 
-// GlobalAdminChecker implements Checker and always grants access.
-// This is the deliberate "allow all" implementation: callers that do not
-// configure a real Checker must install this explicitly to opt out of
-// authorization. The library itself fails closed when Checker is nil; do
-// not rely on a nil Checker as an implicit "no auth" mode.
+// AllowAllChecker implements Checker and always grants access (every Check
+// returns true, IsGlobalAdmin returns true). This is the deliberate "allow
+// all" implementation: model.Config requires a non-nil Checker, so callers
+// that want to opt out of authorization must install this explicitly. Pairs
+// with DenyAllChecker as the two convenience defaults.
 //
 // Appropriate use cases: demo binaries, integration tests that are not
 // exercising authorization. Never use in a deployment that is expected
 // to enforce per-feed permissions.
-type GlobalAdminChecker struct{}
+type AllowAllChecker struct{}
 
-func (c *GlobalAdminChecker) Me(ctx context.Context) (*UserInfo, error) {
+func (c *AllowAllChecker) Me(ctx context.Context) (*UserInfo, error) {
 	return &UserInfo{}, nil
 }
 
-func (c *GlobalAdminChecker) IsGlobalAdmin(ctx context.Context) (bool, error) {
+func (c *AllowAllChecker) IsGlobalAdmin(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-func (c *GlobalAdminChecker) ListObjects(ctx context.Context, objType ObjectType) ([]ObjectRef, error) {
+func (c *AllowAllChecker) ListObjects(ctx context.Context, objType ObjectType) ([]ObjectRef, error) {
 	return nil, nil
 }
 
-func (c *GlobalAdminChecker) Check(ctx context.Context, obj ObjectRef, action Action) (bool, error) {
+func (c *AllowAllChecker) Check(ctx context.Context, obj ObjectRef, action Action) (bool, error) {
 	return true, nil
+}
+
+// DenyAllChecker implements Checker and denies everything: no global admin,
+// no listed objects, no Check ever returns true. Use this as the default
+// when a deployment wants "anonymous = no access" — combine with
+// model.Config.IncludePublic = true if anonymous callers should still see
+// public feeds via the deployment-wide public-feed policy.
+//
+// Me() surfaces the authn user (when present) so identity is still visible
+// to callers; this Checker only restricts authorization, not who is asking.
+type DenyAllChecker struct{}
+
+func (c *DenyAllChecker) Me(ctx context.Context) (*UserInfo, error) {
+	if user := authn.ForContext(ctx); user != nil {
+		return &UserInfo{
+			ID:    user.ID(),
+			Name:  user.Name(),
+			Email: user.Email(),
+			Roles: user.Roles(),
+		}, nil
+	}
+	return &UserInfo{}, nil
+}
+
+func (c *DenyAllChecker) IsGlobalAdmin(ctx context.Context) (bool, error) {
+	return false, nil
+}
+
+func (c *DenyAllChecker) ListObjects(ctx context.Context, objType ObjectType) ([]ObjectRef, error) {
+	return nil, nil
+}
+
+func (c *DenyAllChecker) Check(ctx context.Context, obj ObjectRef, action Action) (bool, error) {
+	return false, nil
 }

--- a/server/auth/authz/checker.go
+++ b/server/auth/authz/checker.go
@@ -84,11 +84,30 @@ type AdminManager interface {
 	GroupSave(ctx context.Context, req *GroupSaveRequest) (*GroupSaveResponse, error)
 }
 
+// userInfoFromAuthn surfaces the authn user (when present) as a UserInfo.
+// Used by both convenience checkers so identity is preserved regardless of
+// whether the deployment is permitting or denying authorization checks.
+func userInfoFromAuthn(ctx context.Context) *UserInfo {
+	user := authn.ForContext(ctx)
+	if user == nil {
+		return &UserInfo{}
+	}
+	return &UserInfo{
+		ID:    user.ID(),
+		Name:  user.Name(),
+		Email: user.Email(),
+		Roles: user.Roles(),
+	}
+}
+
 // AllowAllChecker implements Checker and always grants access (every Check
 // returns true, IsGlobalAdmin returns true). This is the deliberate "allow
 // all" implementation: model.Config requires a non-nil Checker, so callers
 // that want to opt out of authorization must install this explicitly. Pairs
 // with DenyAllChecker as the two convenience defaults.
+//
+// Me() surfaces the authn user (when present) so the GraphQL `me` query
+// continues to return identity in demo binaries and tests.
 //
 // Appropriate use cases: demo binaries, integration tests that are not
 // exercising authorization. Never use in a deployment that is expected
@@ -96,7 +115,7 @@ type AdminManager interface {
 type AllowAllChecker struct{}
 
 func (c *AllowAllChecker) Me(ctx context.Context) (*UserInfo, error) {
-	return &UserInfo{}, nil
+	return userInfoFromAuthn(ctx), nil
 }
 
 func (c *AllowAllChecker) IsGlobalAdmin(ctx context.Context) (bool, error) {
@@ -122,15 +141,7 @@ func (c *AllowAllChecker) Check(ctx context.Context, obj ObjectRef, action Actio
 type DenyAllChecker struct{}
 
 func (c *DenyAllChecker) Me(ctx context.Context) (*UserInfo, error) {
-	if user := authn.ForContext(ctx); user != nil {
-		return &UserInfo{
-			ID:    user.ID(),
-			Name:  user.Name(),
-			Email: user.Email(),
-			Roles: user.Roles(),
-		}, nil
-	}
-	return &UserInfo{}, nil
+	return userInfoFromAuthn(ctx), nil
 }
 
 func (c *DenyAllChecker) IsGlobalAdmin(ctx context.Context) (bool, error) {

--- a/server/auth/authz/checker.go
+++ b/server/auth/authz/checker.go
@@ -84,9 +84,8 @@ type AdminManager interface {
 	GroupSave(ctx context.Context, req *GroupSaveRequest) (*GroupSaveResponse, error)
 }
 
-// userInfoFromAuthn surfaces the authn user (when present) as a UserInfo.
-// Used by both convenience checkers so identity is preserved regardless of
-// whether the deployment is permitting or denying authorization checks.
+// userInfoFromAuthn lets the convenience checkers expose authn identity
+// without coupling identity to authorization decisions.
 func userInfoFromAuthn(ctx context.Context) *UserInfo {
 	user := authn.ForContext(ctx)
 	if user == nil {
@@ -100,18 +99,10 @@ func userInfoFromAuthn(ctx context.Context) *UserInfo {
 	}
 }
 
-// AllowAllChecker implements Checker and always grants access (every Check
-// returns true, IsGlobalAdmin returns true). This is the deliberate "allow
-// all" implementation: model.Config requires a non-nil Checker, so callers
-// that want to opt out of authorization must install this explicitly. Pairs
-// with DenyAllChecker as the two convenience defaults.
-//
-// Me() surfaces the authn user (when present) so the GraphQL `me` query
-// continues to return identity in demo binaries and tests.
-//
-// Appropriate use cases: demo binaries, integration tests that are not
-// exercising authorization. Never use in a deployment that is expected
-// to enforce per-feed permissions.
+// AllowAllChecker is the explicit "allow all" Checker — install it when a
+// deployment wants to opt out of authorization. Pairs with DenyAllChecker.
+// Use only in demo binaries or tests; never in a deployment that enforces
+// per-feed permissions.
 type AllowAllChecker struct{}
 
 func (c *AllowAllChecker) Me(ctx context.Context) (*UserInfo, error) {
@@ -130,14 +121,9 @@ func (c *AllowAllChecker) Check(ctx context.Context, obj ObjectRef, action Actio
 	return true, nil
 }
 
-// DenyAllChecker implements Checker and denies everything: no global admin,
-// no listed objects, no Check ever returns true. Use this as the default
-// when a deployment wants "anonymous = no access" — combine with
-// model.Config.IncludePublic = true if anonymous callers should still see
-// public feeds via the deployment-wide public-feed policy.
-//
-// Me() surfaces the authn user (when present) so identity is still visible
-// to callers; this Checker only restricts authorization, not who is asking.
+// DenyAllChecker is the explicit "deny all" Checker — install it when
+// callers should have no per-feed access. Combine with
+// model.Config.IncludePublic = true to still expose public feeds.
 type DenyAllChecker struct{}
 
 func (c *DenyAllChecker) Me(ctx context.Context) (*UserInfo, error) {

--- a/server/auth/authz/checker.go
+++ b/server/auth/authz/checker.go
@@ -84,13 +84,9 @@ type AdminManager interface {
 	GroupSave(ctx context.Context, req *GroupSaveRequest) (*GroupSaveResponse, error)
 }
 
-// userInfoFromAuthn lets the convenience checkers expose authn identity
-// without coupling identity to authorization decisions.
-func userInfoFromAuthn(ctx context.Context) *UserInfo {
-	user := authn.ForContext(ctx)
-	if user == nil {
-		return &UserInfo{}
-	}
+// userInfoFromAuthn projects the authn identity into UserInfo for convenience
+// checkers. Caller must ensure user is non-nil.
+func userInfoFromAuthn(user authn.User) *UserInfo {
 	return &UserInfo{
 		ID:    user.ID(),
 		Name:  user.Name(),
@@ -106,7 +102,10 @@ func userInfoFromAuthn(ctx context.Context) *UserInfo {
 type AllowAllChecker struct{}
 
 func (c *AllowAllChecker) Me(ctx context.Context) (*UserInfo, error) {
-	return userInfoFromAuthn(ctx), nil
+	if user := authn.ForContext(ctx); user != nil {
+		return userInfoFromAuthn(user), nil
+	}
+	return &UserInfo{ID: "admin", Name: "admin", Roles: []string{"admin"}}, nil
 }
 
 func (c *AllowAllChecker) IsGlobalAdmin(ctx context.Context) (bool, error) {
@@ -127,7 +126,11 @@ func (c *AllowAllChecker) Check(ctx context.Context, obj ObjectRef, action Actio
 type DenyAllChecker struct{}
 
 func (c *DenyAllChecker) Me(ctx context.Context) (*UserInfo, error) {
-	return userInfoFromAuthn(ctx), nil
+	user := authn.ForContext(ctx)
+	if user == nil {
+		return nil, ErrUnauthorized
+	}
+	return userInfoFromAuthn(user), nil
 }
 
 func (c *DenyAllChecker) IsGlobalAdmin(ctx context.Context) (bool, error) {

--- a/server/auth/authz/checker.go
+++ b/server/auth/authz/checker.go
@@ -81,7 +81,14 @@ type AdminManager interface {
 }
 
 // GlobalAdminChecker implements Checker and always grants access.
-// Used when auth is disabled (e.g., --disable-auth flag).
+// This is the deliberate "allow all" implementation: callers that do not
+// configure a real Checker must install this explicitly to opt out of
+// authorization. The library itself fails closed when Checker is nil; do
+// not rely on a nil Checker as an implicit "no auth" mode.
+//
+// Appropriate use cases: demo binaries, integration tests that are not
+// exercising authorization. Never use in a deployment that is expected
+// to enforce per-feed permissions.
 type GlobalAdminChecker struct{}
 
 func (c *GlobalAdminChecker) Me(ctx context.Context) (*UserInfo, error) {

--- a/server/finders/actions/feed_fetch.go
+++ b/server/finders/actions/feed_fetch.go
@@ -186,10 +186,6 @@ func GbfsFetch(ctx context.Context, feedId string, feedUrl string) error {
 
 func fetchCheckFeed(ctx context.Context, feedId string) (*model.Feed, error) {
 	cfg := model.ForContext(ctx)
-	checker := cfg.Checker
-	if checker == nil {
-		return nil, authz.ErrUnauthorized
-	}
 
 	// Check feed exists
 	feeds, err := cfg.Finder.FindFeeds(ctx, nil, nil, nil, &model.FeedFilter{OnestopID: &feedId})
@@ -202,7 +198,7 @@ func fetchCheckFeed(ctx context.Context, feedId string) (*model.Feed, error) {
 	feed := feeds[0]
 
 	// Check feed permissions
-	ok, err := checker.Check(ctx, authz.ObjectRef{Type: authz.FeedType, ID: int64(feed.ID)}, authz.CanCreateFeedVersion)
+	ok, err := cfg.Checker.Check(ctx, authz.ObjectRef{Type: authz.FeedType, ID: int64(feed.ID)}, authz.CanCreateFeedVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/server/finders/actions/feed_fetch.go
+++ b/server/finders/actions/feed_fetch.go
@@ -187,22 +187,25 @@ func GbfsFetch(ctx context.Context, feedId string, feedUrl string) error {
 func fetchCheckFeed(ctx context.Context, feedId string) (*model.Feed, error) {
 	cfg := model.ForContext(ctx)
 
-	// Check feed exists
+	// Both "feed does not exist" and "caller may not fetch this feed" return
+	// authz.ErrUnauthorized so an unauthorized caller cannot probe feed
+	// existence by error message. The actual reason is logged for ops.
 	feeds, err := cfg.Finder.FindFeeds(ctx, nil, nil, nil, &model.FeedFilter{OnestopID: &feedId})
 	if err != nil {
 		return nil, err
 	}
 	if len(feeds) == 0 {
-		return nil, errors.New("feed not found")
+		log.For(ctx).Debug().Str("feed_id", feedId).Msg("fetchCheckFeed: feed not found")
+		return nil, authz.ErrUnauthorized
 	}
 	feed := feeds[0]
 
-	// Check feed permissions
 	ok, err := cfg.Checker.Check(ctx, authz.ObjectRef{Type: authz.FeedType, ID: int64(feed.ID)}, authz.CanCreateFeedVersion)
 	if err != nil {
 		return nil, err
 	}
 	if !ok {
+		log.For(ctx).Debug().Str("feed_id", feedId).Int("feed_db_id", feed.ID).Msg("fetchCheckFeed: caller not authorized")
 		return nil, authz.ErrUnauthorized
 	}
 	return feed, nil

--- a/server/finders/actions/feed_fetch.go
+++ b/server/finders/actions/feed_fetch.go
@@ -185,8 +185,13 @@ func GbfsFetch(ctx context.Context, feedId string, feedUrl string) error {
 }
 
 func fetchCheckFeed(ctx context.Context, feedId string) (*model.Feed, error) {
-	// Check feed exists
 	cfg := model.ForContext(ctx)
+	checker := cfg.Checker
+	if checker == nil {
+		return nil, authz.ErrUnauthorized
+	}
+
+	// Check feed exists
 	feeds, err := cfg.Finder.FindFeeds(ctx, nil, nil, nil, &model.FeedFilter{OnestopID: &feedId})
 	if err != nil {
 		return nil, err
@@ -197,14 +202,12 @@ func fetchCheckFeed(ctx context.Context, feedId string) (*model.Feed, error) {
 	feed := feeds[0]
 
 	// Check feed permissions
-	if checker := cfg.Checker; checker != nil {
-		ok, err := checker.Check(ctx, authz.ObjectRef{Type: authz.FeedType, ID: int64(feed.ID)}, authz.CanCreateFeedVersion)
-		if err != nil {
-			return nil, err
-		}
-		if !ok {
-			return nil, errors.New("unauthorized")
-		}
+	ok, err := checker.Check(ctx, authz.ObjectRef{Type: authz.FeedType, ID: int64(feed.ID)}, authz.CanCreateFeedVersion)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, authz.ErrUnauthorized
 	}
 	return feed, nil
 }

--- a/server/finders/actions/feed_fetch.go
+++ b/server/finders/actions/feed_fetch.go
@@ -187,9 +187,8 @@ func GbfsFetch(ctx context.Context, feedId string, feedUrl string) error {
 func fetchCheckFeed(ctx context.Context, feedId string) (*model.Feed, error) {
 	cfg := model.ForContext(ctx)
 
-	// Both "feed does not exist" and "caller may not fetch this feed" return
-	// authz.ErrUnauthorized so an unauthorized caller cannot probe feed
-	// existence by error message. The actual reason is logged for ops.
+	// Both not-found and not-authorized return ErrUnauthorized — distinguishing
+	// them would let unauthorized callers probe feed existence.
 	feeds, err := cfg.Finder.FindFeeds(ctx, nil, nil, nil, &model.FeedFilter{OnestopID: &feedId})
 	if err != nil {
 		return nil, err

--- a/server/finders/actions/fv.go
+++ b/server/finders/actions/fv.go
@@ -312,7 +312,7 @@ func checkFeedEdit(ctx context.Context, fvid int) error {
 	cfg := model.ForContext(ctx)
 	checker := cfg.Checker
 	if checker == nil {
-		return nil
+		return authz.ErrUnauthorized
 	}
 	ok, err := checker.Check(ctx, authz.ObjectRef{Type: authz.FeedVersionType, ID: int64(fvid)}, authz.CanEdit)
 	if err != nil {

--- a/server/finders/actions/fv.go
+++ b/server/finders/actions/fv.go
@@ -310,11 +310,7 @@ func checkFeedEdit(ctx context.Context, fvid int) error {
 		return errors.New("invalid feed version id")
 	}
 	cfg := model.ForContext(ctx)
-	checker := cfg.Checker
-	if checker == nil {
-		return authz.ErrUnauthorized
-	}
-	ok, err := checker.Check(ctx, authz.ObjectRef{Type: authz.FeedVersionType, ID: int64(fvid)}, authz.CanEdit)
+	ok, err := cfg.Checker.Check(ctx, authz.ObjectRef{Type: authz.FeedVersionType, ID: int64(fvid)}, authz.CanEdit)
 	if err != nil {
 		return err
 	}

--- a/server/finders/actions/test/actions_test.go
+++ b/server/finders/actions/test/actions_test.go
@@ -241,9 +241,11 @@ func TestValidateUpload(t *testing.T) {
 			ts := testutil.NewTestServer(testdata.Path())
 			defer ts.Close()
 
-			// Setup job
-			testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
-				ctx := model.WithConfig(context.Background(), cfg)
+			// Setup job. ValidateUpload does not consult Checker or PermFilter,
+			// but the testconfig invariant requires a non-nil Checker — AllowAll
+			// keeps the setup consistent with the other action tests.
+			testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
+				ctx := model.WithPerms(model.WithConfig(context.Background(), cfg), cfg.Checker, cfg.IncludePublic)
 				// Run job
 				feedUrl := ts.URL + "/" + tc.serveFile
 				var rturls []string

--- a/server/finders/actions/test/actions_test.go
+++ b/server/finders/actions/test/actions_test.go
@@ -164,8 +164,7 @@ func TestStaticFetchWorker(t *testing.T) {
 
 			// Setup job
 			feedUrl := ts.URL + "/" + tc.serveFile
-			testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
-				cfg.Checker = nil // disable checker for this test
+			testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
 				ctx := model.WithConfig(context.Background(), cfg)
 				// Run job
 				if result, err := actions.StaticFetch(ctx, tc.feedId, nil, feedUrl); err != nil && !tc.expectError {
@@ -244,7 +243,6 @@ func TestValidateUpload(t *testing.T) {
 
 			// Setup job
 			testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
-				cfg.Checker = nil // disable checker for this test
 				ctx := model.WithConfig(context.Background(), cfg)
 				// Run job
 				feedUrl := ts.URL + "/" + tc.serveFile

--- a/server/finders/actions/test/actions_test.go
+++ b/server/finders/actions/test/actions_test.go
@@ -42,8 +42,8 @@ func (t *testWorker) Run(ctx context.Context) error {
 func TestGbfsFetch(t *testing.T) {
 	ts := httptest.NewServer(gbfs.NewTestGbfsServer("en", testdata.Path("server/gbfs")))
 	defer ts.Close()
-	testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
-		ctx := model.WithConfig(context.Background(), cfg)
+	testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
+		ctx := model.WithPerms(model.WithConfig(context.Background(), cfg), cfg.Checker, cfg.IncludePublic)
 		if err := actions.GbfsFetch(ctx, "test-gbfs", ts.URL+"/gbfs.json"); err != nil {
 			t.Fatal(err)
 		}
@@ -165,7 +165,7 @@ func TestStaticFetchWorker(t *testing.T) {
 			// Setup job
 			feedUrl := ts.URL + "/" + tc.serveFile
 			testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
-				ctx := model.WithConfig(context.Background(), cfg)
+				ctx := model.WithPerms(model.WithConfig(context.Background(), cfg), cfg.Checker, cfg.IncludePublic)
 				// Run job
 				if result, err := actions.StaticFetch(ctx, tc.feedId, nil, feedUrl); err != nil && !tc.expectError {
 					_ = result

--- a/server/finders/actions/test/actions_test.go
+++ b/server/finders/actions/test/actions_test.go
@@ -43,7 +43,7 @@ func TestGbfsFetch(t *testing.T) {
 	ts := httptest.NewServer(gbfs.NewTestGbfsServer("en", testdata.Path("server/gbfs")))
 	defer ts.Close()
 	testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
-		ctx := model.WithPerms(model.WithConfig(context.Background(), cfg), cfg.Checker, cfg.IncludePublic)
+		ctx := model.WithConfigAndPerms(context.Background(), cfg)
 		if err := actions.GbfsFetch(ctx, "test-gbfs", ts.URL+"/gbfs.json"); err != nil {
 			t.Fatal(err)
 		}
@@ -165,7 +165,7 @@ func TestStaticFetchWorker(t *testing.T) {
 			// Setup job
 			feedUrl := ts.URL + "/" + tc.serveFile
 			testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
-				ctx := model.WithPerms(model.WithConfig(context.Background(), cfg), cfg.Checker, cfg.IncludePublic)
+				ctx := model.WithConfigAndPerms(context.Background(), cfg)
 				// Run job
 				if result, err := actions.StaticFetch(ctx, tc.feedId, nil, feedUrl); err != nil && !tc.expectError {
 					_ = result
@@ -241,11 +241,9 @@ func TestValidateUpload(t *testing.T) {
 			ts := testutil.NewTestServer(testdata.Path())
 			defer ts.Close()
 
-			// Setup job. ValidateUpload does not consult Checker or PermFilter,
-			// but the testconfig invariant requires a non-nil Checker — AllowAll
-			// keeps the setup consistent with the other action tests.
+			// AllowAll for setup-consistency; ValidateUpload doesn't consult Checker.
 			testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
-				ctx := model.WithPerms(model.WithConfig(context.Background(), cfg), cfg.Checker, cfg.IncludePublic)
+				ctx := model.WithConfigAndPerms(context.Background(), cfg)
 				// Run job
 				feedUrl := ts.URL + "/" + tc.serveFile
 				var rturls []string

--- a/server/finders/dbfinder/finder.go
+++ b/server/finders/dbfinder/finder.go
@@ -207,7 +207,9 @@ func pfJoinCheck(q sq.SelectBuilder, permFilter *model.PermFilter) sq.SelectBuil
 	q = q.Join("feed_states fsp on fsp.feed_id = current_feeds.id").
 		Where(sq.Eq{"current_feeds.deleted_at": nil})
 	sqOr := sq.Or{}
-	sqOr = append(sqOr, sq.Expr("fsp.public = true"))
+	if permFilter.GetIncludePublic() {
+		sqOr = append(sqOr, sq.Expr("fsp.public = true"))
+	}
 	sqOr = append(sqOr, In("fsp.feed_id", permFilter.GetAllowedFeeds()))
 	if permFilter.GetIsGlobalAdmin() {
 		sqOr = append(sqOr, sq.Expr("1=1")) // Global admin: allow all rows
@@ -220,7 +222,9 @@ func pfJoinCheckFv(q sq.SelectBuilder, permFilter *model.PermFilter) sq.SelectBu
 		Where(sq.Eq{"current_feeds.deleted_at": nil}).
 		Where(sq.Eq{"feed_versions.deleted_at": nil})
 	sqOr := sq.Or{}
-	sqOr = append(sqOr, sq.Expr("fsp.public = true"))
+	if permFilter.GetIncludePublic() {
+		sqOr = append(sqOr, sq.Expr("fsp.public = true"))
+	}
 	sqOr = append(sqOr, In("feed_versions.feed_id", permFilter.GetAllowedFeeds()))
 	sqOr = append(sqOr, In("feed_versions.id", permFilter.GetAllowedFeedVersions()))
 	if permFilter.GetIsGlobalAdmin() {

--- a/server/finders/dbfinder/finder_test.go
+++ b/server/finders/dbfinder/finder_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 
 	"github.com/interline-io/transitland-lib/server/dbutil"
+	"github.com/interline-io/transitland-lib/server/model"
 	"github.com/interline-io/transitland-lib/server/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestFinder_FindFeedVersionServiceWindow(t *testing.T) {
-	ctx := context.Background()
+	ctx := model.WithPermFilter(context.Background(), &model.PermFilter{IsGlobalAdmin: true})
 	db := testutil.MustOpenTestDB(t)
 	dbf := NewFinder(dbutil.WithQueryLogger(db, false, 0))
 	testFinder := dbf

--- a/server/finders/dbfinder/mutations.go
+++ b/server/finders/dbfinder/mutations.go
@@ -358,11 +358,7 @@ func checkFeedEdit(ctx context.Context, fvid int) error {
 		return errors.New("invalid feed version id")
 	}
 	cfg := model.ForContext(ctx)
-	checker := cfg.Checker
-	if checker == nil {
-		return authz.ErrUnauthorized
-	}
-	ok, err := checker.Check(ctx, authz.ObjectRef{Type: authz.FeedVersionType, ID: int64(fvid)}, authz.CanEdit)
+	ok, err := cfg.Checker.Check(ctx, authz.ObjectRef{Type: authz.FeedVersionType, ID: int64(fvid)}, authz.CanEdit)
 	if err != nil {
 		return err
 	}

--- a/server/finders/dbfinder/mutations.go
+++ b/server/finders/dbfinder/mutations.go
@@ -360,7 +360,7 @@ func checkFeedEdit(ctx context.Context, fvid int) error {
 	cfg := model.ForContext(ctx)
 	checker := cfg.Checker
 	if checker == nil {
-		return nil
+		return authz.ErrUnauthorized
 	}
 	ok, err := checker.Check(ctx, authz.ObjectRef{Type: authz.FeedVersionType, ID: int64(fvid)}, authz.CanEdit)
 	if err != nil {

--- a/server/gql/agency_resolver_test.go
+++ b/server/gql/agency_resolver_test.go
@@ -196,7 +196,8 @@ func TestAgencyResolver(t *testing.T) {
 
 func TestAgencyResolver_Cursor(t *testing.T) {
 	c, cfg := newTestClient(t)
-	allEnts, err := cfg.Finder.FindAgencies(model.WithConfig(context.Background(), cfg), nil, nil, nil, nil)
+	ctx := model.WithPerms(model.WithConfig(context.Background(), cfg), cfg.Checker, cfg.IncludePublic)
+	allEnts, err := cfg.Finder.FindAgencies(ctx, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/gql/agency_resolver_test.go
+++ b/server/gql/agency_resolver_test.go
@@ -196,7 +196,7 @@ func TestAgencyResolver(t *testing.T) {
 
 func TestAgencyResolver_Cursor(t *testing.T) {
 	c, cfg := newTestClient(t)
-	ctx := model.WithPerms(model.WithConfig(context.Background(), cfg), cfg.Checker, cfg.IncludePublic)
+	ctx := model.WithConfigAndPerms(context.Background(), cfg)
 	allEnts, err := cfg.Finder.FindAgencies(ctx, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/server/gql/entity_mutation_resolver_test.go
+++ b/server/gql/entity_mutation_resolver_test.go
@@ -18,7 +18,7 @@ import (
 // Entity mutation tests
 
 func TestStopCreate(t *testing.T) {
-	testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
+	testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
 		finder := cfg.Finder
 		ctx := model.WithConfig(context.Background(), cfg)
 		fv := model.FeedVersionInput{ID: toPtr(1)}
@@ -45,7 +45,7 @@ func TestStopCreate(t *testing.T) {
 }
 
 func TestStopUpdate(t *testing.T) {
-	testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
+	testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
 		finder := cfg.Finder
 		ctx := model.WithConfig(context.Background(), cfg)
 		fv := model.FeedVersionInput{ID: toPtr(1)}
@@ -86,7 +86,7 @@ func TestStopReference(t *testing.T) {
 		TargetFeedOnestopID tt.String `db:"target_feed_onestop_id"`
 		TargetStopID        tt.String `db:"target_stop_id"`
 	}
-	testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
+	testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
 		finder := cfg.Finder
 		ctx := model.WithConfig(context.Background(), cfg)
 		fv := model.FeedVersionInput{ID: toPtr(1)}

--- a/server/gql/feed_resolver_test.go
+++ b/server/gql/feed_resolver_test.go
@@ -251,7 +251,7 @@ func TestFeedResolver(t *testing.T) {
 
 func TestFeedResolver_Cursor(t *testing.T) {
 	c, cfg := newTestClient(t)
-	ctx := model.WithPerms(model.WithConfig(context.Background(), cfg), cfg.Checker, cfg.IncludePublic)
+	ctx := model.WithConfigAndPerms(context.Background(), cfg)
 	allEnts, err := cfg.Finder.FindFeeds(ctx, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/server/gql/feed_resolver_test.go
+++ b/server/gql/feed_resolver_test.go
@@ -251,7 +251,8 @@ func TestFeedResolver(t *testing.T) {
 
 func TestFeedResolver_Cursor(t *testing.T) {
 	c, cfg := newTestClient(t)
-	allEnts, err := cfg.Finder.FindFeeds(model.WithConfig(context.Background(), cfg), nil, nil, nil, nil)
+	ctx := model.WithPerms(model.WithConfig(context.Background(), cfg), cfg.Checker, cfg.IncludePublic)
+	allEnts, err := cfg.Finder.FindFeeds(ctx, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/gql/fv_mutation_resolver_test.go
+++ b/server/gql/fv_mutation_resolver_test.go
@@ -25,7 +25,7 @@ func TestFeedVersionFetchResolver(t *testing.T) {
 		w.Write(buf)
 	}))
 	t.Run("found sha1", func(t *testing.T) {
-		testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
+		testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
 			srv, _ := NewServer()
 			srv = model.AddConfigAndPerms(cfg, srv)
 			srv = usercheck.AdminDefaultMiddleware("test")(srv) // Run all requests as admin

--- a/server/gql/query_resolver.go
+++ b/server/gql/query_resolver.go
@@ -2,9 +2,7 @@ package gql
 
 import (
 	"context"
-	"errors"
 
-	"github.com/interline-io/transitland-lib/server/auth/authn"
 	"github.com/interline-io/transitland-lib/server/model"
 	"github.com/interline-io/transitland-lib/tt"
 )
@@ -17,29 +15,16 @@ func (r *queryResolver) Me(ctx context.Context) (*model.Me, error) {
 	cfg := model.ForContext(ctx)
 	me := model.Me{}
 	me.ExternalData = tt.NewMap(map[string]any{})
-	if checker := cfg.Checker; checker != nil {
-		// Use checker if available
-		cm, err := checker.Me(ctx)
-		if err != nil {
-			return nil, err
-		}
-		me.ID = cm.ID
-		me.Email = &cm.Email
-		me.Name = &cm.Name
-		me.Roles = cm.Roles
-		for k, v := range cm.ExternalData {
-			me.ExternalData.Val[k] = v
-		}
-	} else if user := authn.ForContext(ctx); user != nil {
-		// Fallback to user context
-		um := user.Email()
-		un := user.Name()
-		me.ID = user.ID()
-		me.Name = &un
-		me.Email = &um
-		me.Roles = user.Roles()
-	} else {
-		return nil, errors.New("no user")
+	cm, err := cfg.Checker.Me(ctx)
+	if err != nil {
+		return nil, err
+	}
+	me.ID = cm.ID
+	me.Email = &cm.Email
+	me.Name = &cm.Name
+	me.Roles = cm.Roles
+	for k, v := range cm.ExternalData {
+		me.ExternalData.Val[k] = v
 	}
 	return &me, nil
 }

--- a/server/gql/route_resolver_test.go
+++ b/server/gql/route_resolver_test.go
@@ -548,7 +548,7 @@ func TestRouteResolver_Segments(t *testing.T) {
 
 func TestRouteResolver_Cursor(t *testing.T) {
 	c, cfg := newTestClient(t)
-	ctx := model.WithPerms(model.WithConfig(context.Background(), cfg), cfg.Checker, cfg.IncludePublic)
+	ctx := model.WithConfigAndPerms(context.Background(), cfg)
 	allEnts, err := cfg.Finder.FindRoutes(ctx, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/server/gql/route_resolver_test.go
+++ b/server/gql/route_resolver_test.go
@@ -548,7 +548,8 @@ func TestRouteResolver_Segments(t *testing.T) {
 
 func TestRouteResolver_Cursor(t *testing.T) {
 	c, cfg := newTestClient(t)
-	allEnts, err := cfg.Finder.FindRoutes(model.WithConfig(context.Background(), cfg), nil, nil, nil, nil)
+	ctx := model.WithPerms(model.WithConfig(context.Background(), cfg), cfg.Checker, cfg.IncludePublic)
+	allEnts, err := cfg.Finder.FindRoutes(ctx, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/gql/stop_resolver_test.go
+++ b/server/gql/stop_resolver_test.go
@@ -863,7 +863,7 @@ func stopResolverLocationTestcases(t *testing.T, cfg model.Config) []testcase {
 func stopResolverCursorTestcases(t *testing.T, cfg model.Config) []testcase {
 	// First 1000 stops...
 	dbf := cfg.Finder
-	ctx := model.WithPerms(model.WithConfig(context.Background(), cfg), cfg.Checker, cfg.IncludePublic)
+	ctx := model.WithConfigAndPerms(context.Background(), cfg)
 	allEnts, err := dbf.FindStops(ctx, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/server/gql/stop_resolver_test.go
+++ b/server/gql/stop_resolver_test.go
@@ -863,7 +863,8 @@ func stopResolverLocationTestcases(t *testing.T, cfg model.Config) []testcase {
 func stopResolverCursorTestcases(t *testing.T, cfg model.Config) []testcase {
 	// First 1000 stops...
 	dbf := cfg.Finder
-	allEnts, err := dbf.FindStops(context.Background(), nil, nil, nil, nil)
+	ctx := model.WithPerms(model.WithConfig(context.Background(), cfg), cfg.Checker, cfg.IncludePublic)
+	allEnts, err := dbf.FindStops(ctx, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/model/config.go
+++ b/server/model/config.go
@@ -22,11 +22,8 @@ type Config struct {
 	DisableImage             bool
 	UseMaterialized          bool
 	AllowHTTPFetchUnfiltered bool
-	// IncludePublic, when true, includes feed_states.public = true rows in
-	// read queries regardless of the caller's per-feed permissions. This is
-	// the deployment-wide policy for public-feed visibility. When false,
-	// callers see only feeds explicitly granted to them by the Checker
-	// (or all rows if the Checker reports global admin).
+	// IncludePublic, when true, exposes feed_states.public rows to all callers
+	// regardless of per-feed Checker grants. Deployment-wide policy.
 	IncludePublic           bool
 	RestPrefix              string
 	Storage                 string
@@ -70,4 +67,10 @@ func AddConfig(cfg Config) func(http.Handler) http.Handler {
 
 func AddConfigAndPerms(cfg Config, next http.Handler) http.Handler {
 	return AddPerms(cfg.Checker, cfg.IncludePublic)(AddConfig(cfg)(next))
+}
+
+// WithConfigAndPerms is the context-only equivalent of AddConfigAndPerms,
+// for non-HTTP entry points (background jobs, tests).
+func WithConfigAndPerms(ctx context.Context, cfg Config) context.Context {
+	return WithPerms(WithConfig(ctx, cfg), cfg.Checker, cfg.IncludePublic)
 }

--- a/server/model/config.go
+++ b/server/model/config.go
@@ -22,12 +22,18 @@ type Config struct {
 	DisableImage             bool
 	UseMaterialized          bool
 	AllowHTTPFetchUnfiltered bool
-	RestPrefix               string
-	Storage                  string
-	RTStorage                string
-	LoaderBatchSize          int
-	LoaderStopTimeBatchSize  int
-	MaxRadius                float64
+	// IncludePublic, when true, includes feed_states.public = true rows in
+	// read queries regardless of the caller's per-feed permissions. This is
+	// the deployment-wide policy for public-feed visibility. When false,
+	// callers see only feeds explicitly granted to them by the Checker
+	// (or all rows if the Checker reports global admin).
+	IncludePublic           bool
+	RestPrefix              string
+	Storage                 string
+	RTStorage               string
+	LoaderBatchSize         int
+	LoaderStopTimeBatchSize int
+	MaxRadius               float64
 }
 
 var finderCtxKey = &contextKey{"finderConfig"}
@@ -50,6 +56,9 @@ func WithConfig(ctx context.Context, cfg Config) context.Context {
 }
 
 func AddConfig(cfg Config) func(http.Handler) http.Handler {
+	if cfg.Checker == nil {
+		panic("model.AddConfig: Config.Checker must be set; install authz.AllowAllChecker or authz.DenyAllChecker for demo/test, or a real Checker for production")
+	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
@@ -60,5 +69,5 @@ func AddConfig(cfg Config) func(http.Handler) http.Handler {
 }
 
 func AddConfigAndPerms(cfg Config, next http.Handler) http.Handler {
-	return AddPerms(cfg.Checker)(AddConfig(cfg)(next))
+	return AddPerms(cfg.Checker, cfg.IncludePublic)(AddConfig(cfg)(next))
 }

--- a/server/model/config_test.go
+++ b/server/model/config_test.go
@@ -1,0 +1,37 @@
+package model
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/interline-io/transitland-lib/server/auth/authz"
+)
+
+func TestAddConfig_PanicsOnNilChecker(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when Config.Checker is nil")
+		}
+	}()
+	_ = AddConfig(Config{})
+}
+
+func TestAddConfig_NoPanicWithChecker(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("unexpected panic: %v", r)
+		}
+	}()
+	mw := AddConfig(Config{Checker: &authz.DenyAllChecker{}})
+	// Exercise the returned middleware end-to-end so the test asserts
+	// AddConfig produces a usable handler, not just that construction
+	// doesn't panic.
+	srv := httptest.NewServer(mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})))
+	defer srv.Close()
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+}

--- a/server/model/config_test.go
+++ b/server/model/config_test.go
@@ -24,9 +24,6 @@ func TestAddConfig_NoPanicWithChecker(t *testing.T) {
 		}
 	}()
 	mw := AddConfig(Config{Checker: &authz.DenyAllChecker{}})
-	// Exercise the returned middleware end-to-end so the test asserts
-	// AddConfig produces a usable handler, not just that construction
-	// doesn't panic.
 	srv := httptest.NewServer(mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})))
 	defer srv.Close()
 	resp, err := http.Get(srv.URL)

--- a/server/model/perm_filter.go
+++ b/server/model/perm_filter.go
@@ -9,11 +9,13 @@ import (
 
 // PermFilter holds permission-based filtering criteria for feeds and feed versions.
 // When IsGlobalAdmin is true, no filtering is applied (unrestricted access).
-// Otherwise, access is restricted to the specified AllowedFeeds and AllowedFeedVersions IDs.
+// Otherwise, access is restricted to the specified AllowedFeeds and AllowedFeedVersions IDs,
+// plus rows where feed_states.public = true if IncludePublic is set.
 type PermFilter struct {
 	AllowedFeeds        []int
 	AllowedFeedVersions []int
 	IsGlobalAdmin       bool
+	IncludePublic       bool
 }
 
 func (pf *PermFilter) GetAllowedFeeds() []int {
@@ -36,6 +38,13 @@ func (pf *PermFilter) GetIsGlobalAdmin() bool {
 		return false
 	}
 	return pf.IsGlobalAdmin
+}
+
+func (pf *PermFilter) GetIncludePublic() bool {
+	if pf == nil {
+		return false
+	}
+	return pf.IncludePublic
 }
 
 // dedupeInts returns a new slice with duplicate values removed, preserving order.
@@ -68,6 +77,10 @@ func PermsForContext(ctx context.Context) *PermFilter {
 }
 
 // WithPerms populates permission filters in the context using the provided Checker.
+// includePublic is the deployment-wide policy for public-feed visibility — when true,
+// the resulting PermFilter will include rows where feed_states.public = true. The
+// flag is OR-merged with any existing PermFilter already in context.
+//
 // If an existing PermFilter is already set in context (e.g., via WithPermFilter),
 // the checker's results are merged into a new PermFilter (the original is not mutated).
 //
@@ -75,11 +88,13 @@ func PermsForContext(ctx context.Context) *PermFilter {
 //   - No existing filter: checker results are used directly
 //   - Existing filter + checker results: creates new filter with merged, deduplicated IDs
 //   - Either filter has IsGlobalAdmin=true: resulting filter has IsGlobalAdmin=true
-func WithPerms(ctx context.Context, checker Checker) context.Context {
+//   - Either filter has IncludePublic=true: resulting filter has IncludePublic=true
+func WithPerms(ctx context.Context, checker Checker, includePublic bool) context.Context {
 	checkerPf, err := checkActive(ctx, checker)
 	if err != nil {
 		panic(err)
 	}
+	checkerPf.IncludePublic = includePublic
 
 	existing, hasExisting := ctx.Value(pfCtxKey).(*PermFilter)
 
@@ -100,6 +115,7 @@ func WithPerms(ctx context.Context, checker Checker) context.Context {
 			AllowedFeeds:        dedupeInts(mergedFeeds),
 			AllowedFeedVersions: dedupeInts(mergedFvs),
 			IsGlobalAdmin:       existing.IsGlobalAdmin || checkerPf.IsGlobalAdmin,
+			IncludePublic:       existing.IncludePublic || checkerPf.IncludePublic,
 		}
 		return context.WithValue(ctx, pfCtxKey, merged)
 	}
@@ -108,11 +124,11 @@ func WithPerms(ctx context.Context, checker Checker) context.Context {
 	return context.WithValue(ctx, pfCtxKey, checkerPf)
 }
 
-func AddPerms(checker Checker) func(http.Handler) http.Handler {
+func AddPerms(checker Checker, includePublic bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
-			r = r.WithContext(WithPerms(ctx, checker))
+			r = r.WithContext(WithPerms(ctx, checker, includePublic))
 			next.ServeHTTP(w, r)
 		})
 	}
@@ -127,10 +143,10 @@ func refsToInts(refs []authz.ObjectRef) []int {
 }
 
 func checkActive(ctx context.Context, checker Checker) (*PermFilter, error) {
-	active := &PermFilter{}
 	if checker == nil {
-		return active, nil
+		panic("model.checkActive: Checker must be non-nil; install authz.DenyAllChecker for the deny-all default")
 	}
+	active := &PermFilter{}
 
 	if ok, err := checker.IsGlobalAdmin(ctx); err != nil {
 		return nil, err

--- a/server/model/perm_filter.go
+++ b/server/model/perm_filter.go
@@ -9,8 +9,8 @@ import (
 
 // PermFilter holds permission-based filtering criteria for feeds and feed versions.
 // When IsGlobalAdmin is true, no filtering is applied (unrestricted access).
-// Otherwise, access is restricted to the specified AllowedFeeds and AllowedFeedVersions IDs,
-// plus rows where feed_states.public = true if IncludePublic is set.
+// Otherwise, access is restricted to AllowedFeeds and AllowedFeedVersions IDs,
+// plus feed_states.public rows if IncludePublic is set.
 type PermFilter struct {
 	AllowedFeeds        []int
 	AllowedFeedVersions []int
@@ -77,9 +77,8 @@ func PermsForContext(ctx context.Context) *PermFilter {
 }
 
 // WithPerms populates permission filters in the context using the provided Checker.
-// includePublic is the deployment-wide policy for public-feed visibility — when true,
-// the resulting PermFilter will include rows where feed_states.public = true. The
-// flag is OR-merged with any existing PermFilter already in context.
+// includePublic carries the deployment-wide public-feed policy onto the resulting
+// PermFilter.
 //
 // If an existing PermFilter is already set in context (e.g., via WithPermFilter),
 // the checker's results are merged into a new PermFilter (the original is not mutated).

--- a/server/model/perm_filter_test.go
+++ b/server/model/perm_filter_test.go
@@ -216,7 +216,7 @@ func TestWithPermFilter(t *testing.T) {
 
 		// Simulate what WithPerms would do - it should create a new filter
 		checker := &mockChecker{feeds: []int{4, 5}}
-		ctx = WithPerms(ctx, checker)
+		ctx = WithPerms(ctx, checker, false)
 
 		// Original should be unchanged
 		if !reflect.DeepEqual(original.AllowedFeeds, []int{1, 2, 3}) {
@@ -240,7 +240,7 @@ func TestWithPerms(t *testing.T) {
 	t.Run("no existing filter - sets checker result", func(t *testing.T) {
 		ctx := context.Background()
 		checker := &mockChecker{feeds: []int{1, 2}, feedVersions: []int{10, 20}}
-		ctx = WithPerms(ctx, checker)
+		ctx = WithPerms(ctx, checker, false)
 
 		pf := PermsForContext(ctx)
 		if !reflect.DeepEqual(sortedInts(pf.AllowedFeeds), []int{1, 2}) {
@@ -257,7 +257,7 @@ func TestWithPerms(t *testing.T) {
 		ctx = WithPermFilter(ctx, existing)
 
 		checker := &mockChecker{feeds: []int{3, 4}, feedVersions: []int{20, 30}}
-		ctx = WithPerms(ctx, checker)
+		ctx = WithPerms(ctx, checker, false)
 
 		pf := PermsForContext(ctx)
 		if !reflect.DeepEqual(sortedInts(pf.AllowedFeeds), []int{1, 2, 3, 4}) {
@@ -275,7 +275,7 @@ func TestWithPerms(t *testing.T) {
 
 		// Checker returns overlapping IDs
 		checker := &mockChecker{feeds: []int{2, 3, 4}, feedVersions: []int{20, 30}}
-		ctx = WithPerms(ctx, checker)
+		ctx = WithPerms(ctx, checker, false)
 
 		pf := PermsForContext(ctx)
 		if !reflect.DeepEqual(sortedInts(pf.AllowedFeeds), []int{1, 2, 3, 4}) {
@@ -292,7 +292,7 @@ func TestWithPerms(t *testing.T) {
 		ctx = WithPermFilter(ctx, existing)
 
 		checker := &mockChecker{feeds: []int{3}, feedVersions: []int{20}}
-		ctx = WithPerms(ctx, checker)
+		ctx = WithPerms(ctx, checker, false)
 
 		pf := PermsForContext(ctx)
 		if pf == existing {
@@ -306,7 +306,7 @@ func TestWithPerms(t *testing.T) {
 		ctx = WithPermFilter(ctx, existing)
 
 		checker := &mockChecker{isAdmin: true}
-		ctx = WithPerms(ctx, checker)
+		ctx = WithPerms(ctx, checker, false)
 
 		// For admin, the filter should have IsGlobalAdmin=true
 		pf := PermsForContext(ctx)
@@ -321,7 +321,7 @@ func TestWithPerms(t *testing.T) {
 	t.Run("global admin - no existing filter", func(t *testing.T) {
 		ctx := context.Background()
 		checker := &mockChecker{isAdmin: true}
-		ctx = WithPerms(ctx, checker)
+		ctx = WithPerms(ctx, checker, false)
 
 		pf := PermsForContext(ctx)
 		if pf == nil {
@@ -332,30 +332,39 @@ func TestWithPerms(t *testing.T) {
 		}
 	})
 
-	t.Run("nil checker - returns empty filter", func(t *testing.T) {
+	t.Run("nil checker panics", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("expected panic on nil checker")
+			}
+		}()
 		ctx := context.Background()
-		ctx = WithPerms(ctx, nil)
+		WithPerms(ctx, nil, false)
+	})
+
+	t.Run("includePublic propagates onto PermFilter", func(t *testing.T) {
+		ctx := context.Background()
+		checker := &mockChecker{feeds: []int{1}}
+		ctx = WithPerms(ctx, checker, true)
 
 		pf := PermsForContext(ctx)
-		if pf == nil {
-			t.Error("expected non-nil PermFilter")
-		}
-		if len(pf.AllowedFeeds) != 0 || len(pf.AllowedFeedVersions) != 0 {
-			t.Error("expected empty PermFilter")
+		if !pf.GetIncludePublic() {
+			t.Error("expected IncludePublic to be true")
 		}
 	})
 
-	t.Run("nil checker with existing filter - merges empty", func(t *testing.T) {
+	t.Run("includePublic merges OR with existing filter", func(t *testing.T) {
 		ctx := context.Background()
-		existing := &PermFilter{AllowedFeeds: []int{1, 2}, AllowedFeedVersions: []int{10}}
+		existing := &PermFilter{IncludePublic: true}
 		ctx = WithPermFilter(ctx, existing)
 
-		ctx = WithPerms(ctx, nil)
+		// Even though includePublic=false is passed, the existing IncludePublic=true is preserved
+		checker := &mockChecker{feeds: []int{1}}
+		ctx = WithPerms(ctx, checker, false)
 
 		pf := PermsForContext(ctx)
-		// Should merge existing with empty checker result
-		if !reflect.DeepEqual(sortedInts(pf.AllowedFeeds), []int{1, 2}) {
-			t.Errorf("expected feeds [1, 2], got %v", pf.AllowedFeeds)
+		if !pf.GetIncludePublic() {
+			t.Error("expected IncludePublic to remain true after merge")
 		}
 	})
 
@@ -365,7 +374,7 @@ func TestWithPerms(t *testing.T) {
 		ctx = WithPermFilter(ctx, existing)
 
 		checker := &mockChecker{feeds: []int{1, 2}} // non-admin checker
-		ctx = WithPerms(ctx, checker)
+		ctx = WithPerms(ctx, checker, false)
 
 		pf := PermsForContext(ctx)
 		if !pf.IsGlobalAdmin {
@@ -393,7 +402,7 @@ func TestWithPerms_ThreadSafety(t *testing.T) {
 		ctx = WithPermFilter(ctx, original)
 
 		checker := &mockChecker{feeds: []int{4, 5}, feedVersions: []int{30}}
-		_ = WithPerms(ctx, checker)
+		_ = WithPerms(ctx, checker, false)
 
 		// Verify original was not mutated
 		if !reflect.DeepEqual(original.AllowedFeeds, originalFeedsCopy) {
@@ -403,18 +412,13 @@ func TestWithPerms_ThreadSafety(t *testing.T) {
 }
 
 func TestCheckActive(t *testing.T) {
-	t.Run("nil checker returns empty filter", func(t *testing.T) {
-		ctx := context.Background()
-		pf, err := checkActive(ctx, nil)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if pf == nil {
-			t.Error("expected non-nil PermFilter")
-		}
-		if len(pf.AllowedFeeds) != 0 {
-			t.Error("expected empty AllowedFeeds")
-		}
+	t.Run("nil checker panics", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("expected panic on nil checker")
+			}
+		}()
+		_, _ = checkActive(context.Background(), nil)
 	})
 
 	t.Run("checker returns feeds and versions", func(t *testing.T) {
@@ -444,6 +448,27 @@ func TestCheckActive(t *testing.T) {
 		}
 		if !pf.IsGlobalAdmin {
 			t.Error("expected IsGlobalAdmin to be true")
+		}
+	})
+}
+
+func TestPermFilter_GetIncludePublic(t *testing.T) {
+	t.Run("nil receiver", func(t *testing.T) {
+		var pf *PermFilter
+		if pf.GetIncludePublic() {
+			t.Error("expected false for nil receiver")
+		}
+	})
+	t.Run("default false", func(t *testing.T) {
+		pf := &PermFilter{}
+		if pf.GetIncludePublic() {
+			t.Error("expected false")
+		}
+	})
+	t.Run("true", func(t *testing.T) {
+		pf := &PermFilter{IncludePublic: true}
+		if !pf.GetIncludePublic() {
+			t.Error("expected true")
 		}
 	})
 }

--- a/server/rest/agency_request_test.go
+++ b/server/rest/agency_request_test.go
@@ -202,7 +202,8 @@ func TestAgencyRequest_Format(t *testing.T) {
 
 func TestAgencyRequest_Pagination(t *testing.T) {
 	cfg := testconfig.Config(t, testconfig.Options{})
-	allEnts, err := cfg.Finder.FindAgencies(model.WithConfig(context.Background(), cfg), nil, nil, nil, nil)
+	ctx := model.WithPerms(model.WithConfig(context.Background(), cfg), cfg.Checker, cfg.IncludePublic)
+	allEnts, err := cfg.Finder.FindAgencies(ctx, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/rest/agency_request_test.go
+++ b/server/rest/agency_request_test.go
@@ -202,7 +202,7 @@ func TestAgencyRequest_Format(t *testing.T) {
 
 func TestAgencyRequest_Pagination(t *testing.T) {
 	cfg := testconfig.Config(t, testconfig.Options{})
-	ctx := model.WithPerms(model.WithConfig(context.Background(), cfg), cfg.Checker, cfg.IncludePublic)
+	ctx := model.WithConfigAndPerms(context.Background(), cfg)
 	allEnts, err := cfg.Finder.FindAgencies(ctx, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/server/rest/route_request_test.go
+++ b/server/rest/route_request_test.go
@@ -159,7 +159,8 @@ func TestRouteRequest_Format(t *testing.T) {
 
 func TestRouteRequest_Pagination(t *testing.T) {
 	cfg := testconfig.Config(t, testconfig.Options{})
-	allEnts, err := cfg.Finder.FindRoutes(model.WithConfig(context.Background(), cfg), nil, nil, nil, nil)
+	ctx := model.WithPerms(model.WithConfig(context.Background(), cfg), cfg.Checker, cfg.IncludePublic)
+	allEnts, err := cfg.Finder.FindRoutes(ctx, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/rest/route_request_test.go
+++ b/server/rest/route_request_test.go
@@ -159,7 +159,7 @@ func TestRouteRequest_Format(t *testing.T) {
 
 func TestRouteRequest_Pagination(t *testing.T) {
 	cfg := testconfig.Config(t, testconfig.Options{})
-	ctx := model.WithPerms(model.WithConfig(context.Background(), cfg), cfg.Checker, cfg.IncludePublic)
+	ctx := model.WithConfigAndPerms(context.Background(), cfg)
 	allEnts, err := cfg.Finder.FindRoutes(ctx, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/server/rest/stop_request_test.go
+++ b/server/rest/stop_request_test.go
@@ -277,7 +277,8 @@ func TestStopRequest_Format(t *testing.T) {
 
 func TestStopRequest_Pagination(t *testing.T) {
 	cfg := testconfig.Config(t, testconfig.Options{})
-	allEnts, err := cfg.Finder.FindStops(model.WithConfig(context.Background(), cfg), nil, nil, nil, nil)
+	ctx := model.WithPerms(model.WithConfig(context.Background(), cfg), cfg.Checker, cfg.IncludePublic)
+	allEnts, err := cfg.Finder.FindStops(ctx, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/rest/stop_request_test.go
+++ b/server/rest/stop_request_test.go
@@ -277,7 +277,7 @@ func TestStopRequest_Format(t *testing.T) {
 
 func TestStopRequest_Pagination(t *testing.T) {
 	cfg := testconfig.Config(t, testconfig.Options{})
-	ctx := model.WithPerms(model.WithConfig(context.Background(), cfg), cfg.Checker, cfg.IncludePublic)
+	ctx := model.WithConfigAndPerms(context.Background(), cfg)
 	allEnts, err := cfg.Finder.FindStops(ctx, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/server/rest/trip_request_test.go
+++ b/server/rest/trip_request_test.go
@@ -23,7 +23,7 @@ func TestTripRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := model.WithConfig(context.Background(), cfg)
+	ctx := model.WithPerms(model.WithConfig(context.Background(), cfg), cfg.Checker, cfg.IncludePublic)
 	d, err := makeGraphQLRequest(ctx, graphqlHandler, `query{routes(where:{feed_onestop_id:"BA",route_id:"11"}) {id onestop_id}}`, nil)
 	if err != nil {
 		t.Error("failed to get route id for tests")

--- a/server/rest/trip_request_test.go
+++ b/server/rest/trip_request_test.go
@@ -23,7 +23,7 @@ func TestTripRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := model.WithPerms(model.WithConfig(context.Background(), cfg), cfg.Checker, cfg.IncludePublic)
+	ctx := model.WithConfigAndPerms(context.Background(), cfg)
 	d, err := makeGraphQLRequest(ctx, graphqlHandler, `query{routes(where:{feed_onestop_id:"BA",route_id:"11"}) {id onestop_id}}`, nil)
 	if err != nil {
 		t.Error("failed to get route id for tests")


### PR DESCRIPTION
## Summary
Make permission checks in the server fail closed. Previously, several mutation paths (feed fetch, feed-edit checks used by GraphQL mutations) would silently grant access when no `Checker` was configured. Library callers that did not wire up a Checker were therefore running with no enforcement, which is unsafe as a default. This PR flips those paths to return `authz.ErrUnauthorized` when `Checker` is nil, documents `GlobalAdminChecker` as the explicit opt-out, and updates the demo `transitland server` binary and tests to reflect the new contract.

### Fail-closed authorization
- `server/finders/actions/feed_fetch.go`: `fetchCheckFeed` now returns `authz.ErrUnauthorized` when no Checker is configured, instead of skipping the check. Also replaces an ad-hoc `errors.New("unauthorized")` with the shared sentinel.
- `server/finders/actions/fv.go` and `server/finders/dbfinder/mutations.go`: `checkFeedEdit` returns `authz.ErrUnauthorized` instead of `nil` when Checker is nil.
- `server/auth/authz/checker.go`: expands the `GlobalAdminChecker` doc comment to make clear it is the deliberate opt-out and that nil-Checker is no longer an implicit "no auth" mode.

### Demo server simplification
- `cmds/server_cmd.go`: removes the `--disable-auth` flag. The demo binary now always installs `GlobalAdminChecker` and logs a warning at startup that it is running in demo mode without authorization. Production deployments are expected to compose their own binary with a real Checker.
- `doc/cli/transitland_server.md`: regenerated to drop the removed flag.

### Test scaffolding
- `internal/testconfig/testconfig.go`: adds an `AllowAll` option that installs `GlobalAdminChecker`. Required for tests that exercise mutation paths now that the library fails closed when Checker is nil. Read-side tests still default to nil Checker (anonymous view).
- `server/gql/entity_mutation_resolver_test.go`, `server/gql/fv_mutation_resolver_test.go`, `server/finders/actions/test/actions_test.go`: pass `AllowAll: true` for tests that previously relied on the implicit allow-all behavior, and remove the now-unnecessary `cfg.Checker = nil` lines.

## Test plan
- `go test ./server/...` with `TL_TEST_DATABASE_URL` and `TL_TEST_SERVER_DATABASE_URL` set; in particular confirm `TestStopCreate`, `TestStopUpdate`, `TestStopReference`, `TestFeedVersionFetchResolver`, `TestStaticFetchWorker`, and `TestValidateUpload` pass.
- Run `transitland server` locally and confirm the startup warning `authorization disabled: demo mode` is logged and that `--disable-auth` is no longer accepted.
- Spot-check that a downstream binary which does not configure a Checker now receives `authz.ErrUnauthorized` from feed fetch and feed-edit mutation paths instead of succeeding.
