### PR TITLE
Expose created_at/updated_at on Stop, Pathway, and Level GraphQL types

### DIFF
--- a/internal/generated/gqlout/generated.go
+++ b/internal/generated/gqlout/generated.go
@@ -796,12 +796,14 @@ type ComplexityRoot struct {
 	}
 
 	Level struct {
+		CreatedAt  func(childComplexity int) int
 		Geometry   func(childComplexity int) int
 		ID         func(childComplexity int) int
 		LevelID    func(childComplexity int) int
 		LevelIndex func(childComplexity int) int
 		LevelName  func(childComplexity int) int
 		Stops      func(childComplexity int) int
+		UpdatedAt  func(childComplexity int) int
 	}
 
 	Location struct {
@@ -889,6 +891,7 @@ type ComplexityRoot struct {
 	}
 
 	Pathway struct {
+		CreatedAt           func(childComplexity int) int
 		FromStop            func(childComplexity int) int
 		ID                  func(childComplexity int) int
 		IsBidirectional     func(childComplexity int) int
@@ -902,6 +905,7 @@ type ComplexityRoot struct {
 		StairCount          func(childComplexity int) int
 		ToStop              func(childComplexity int) int
 		TraversalTime       func(childComplexity int) int
+		UpdatedAt           func(childComplexity int) int
 	}
 
 	PermissionRef struct {
@@ -5359,6 +5363,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.LegTrip.TripShortName(childComplexity), true
 
+	case "Level.created_at":
+		if e.complexity.Level.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.Level.CreatedAt(childComplexity), true
+
 	case "Level.geometry":
 		if e.complexity.Level.Geometry == nil {
 			break
@@ -5400,6 +5411,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Level.Stops(childComplexity), true
+
+	case "Level.updated_at":
+		if e.complexity.Level.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.Level.UpdatedAt(childComplexity), true
 
 	case "Location.feed_onestop_id":
 		if e.complexity.Location.FeedOnestopID == nil {
@@ -5967,6 +5985,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.PageInfo.StartCursor(childComplexity), true
 
+	case "Pathway.created_at":
+		if e.complexity.Pathway.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.Pathway.CreatedAt(childComplexity), true
+
 	case "Pathway.from_stop":
 		if e.complexity.Pathway.FromStop == nil {
 			break
@@ -6057,6 +6082,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Pathway.TraversalTime(childComplexity), true
+
+	case "Pathway.updated_at":
+		if e.complexity.Pathway.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.Pathway.UpdatedAt(childComplexity), true
 
 	case "PermissionRef.id":
 		if e.complexity.PermissionRef.ID == nil {
@@ -9995,6 +10027,10 @@ type Pathway {
   from_stop: Stop!
   "Pathway ends at this stop"
   to_stop: Stop!
+  "Time this pathway record was created (typically the feed version import time)"
+  created_at: Time
+  "Time this pathway record was last updated (import time, or the last edit if edited since)"
+  updated_at: Time
 }
 
 """Record from a static GTFS [levels.txt](https://gtfs.org/reference/static/#levelstxt). Levels describes different levels of a station; used in conjunction with pathways."""
@@ -10011,6 +10047,10 @@ type Level {
   geometry: MultiPolygon!
   "Stops associated with this level"
   stops: [Stop!]
+  "Time this level record was created (typically the feed version import time)"
+  created_at: Time
+  "Time this level record was last updated (import time, or the last edit if edited since)"
+  updated_at: Time
 }
 
 """Record from a static GTFS [trips.txt](https://gtfs.org/schedule/reference/#tripstxt) file optionally enriched with by GTFS Realtime [TripUpdate](https://gtfs.org/reference/realtime/v2/#message-tripupdate) and [Alert](https://gtfs.org/reference/realtime/v2/#message-alert) messages."""
@@ -38215,6 +38255,88 @@ func (ec *executionContext) fieldContext_Level_stops(_ context.Context, field gr
 	return fc, nil
 }
 
+func (ec *executionContext) _Level_created_at(ctx context.Context, field graphql.CollectedField, obj *model.Level) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Level_created_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalOTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Level_created_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Level",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Level_updated_at(ctx context.Context, field graphql.CollectedField, obj *model.Level) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Level_updated_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalOTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Level_updated_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Level",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Location_id(ctx context.Context, field graphql.CollectedField, obj *model.Location) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Location_id(ctx, field)
 	if err != nil {
@@ -40611,6 +40733,10 @@ func (ec *executionContext) fieldContext_Mutation_level_create(ctx context.Conte
 				return ec.fieldContext_Level_geometry(ctx, field)
 			case "stops":
 				return ec.fieldContext_Level_stops(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Level_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Level_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Level", field.Name)
 		},
@@ -40680,6 +40806,10 @@ func (ec *executionContext) fieldContext_Mutation_level_update(ctx context.Conte
 				return ec.fieldContext_Level_geometry(ctx, field)
 			case "stops":
 				return ec.fieldContext_Level_stops(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Level_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Level_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Level", field.Name)
 		},
@@ -40822,6 +40952,10 @@ func (ec *executionContext) fieldContext_Mutation_pathway_create(ctx context.Con
 				return ec.fieldContext_Pathway_from_stop(ctx, field)
 			case "to_stop":
 				return ec.fieldContext_Pathway_to_stop(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Pathway_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Pathway_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Pathway", field.Name)
 		},
@@ -40905,6 +41039,10 @@ func (ec *executionContext) fieldContext_Mutation_pathway_update(ctx context.Con
 				return ec.fieldContext_Pathway_from_stop(ctx, field)
 			case "to_stop":
 				return ec.fieldContext_Pathway_to_stop(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Pathway_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Pathway_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Pathway", field.Name)
 		},
@@ -42766,6 +42904,88 @@ func (ec *executionContext) fieldContext_Pathway_to_stop(_ context.Context, fiel
 				return ec.fieldContext_Stop_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Stop", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Pathway_created_at(ctx context.Context, field graphql.CollectedField, obj *model.Pathway) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Pathway_created_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalOTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Pathway_created_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Pathway",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Pathway_updated_at(ctx context.Context, field graphql.CollectedField, obj *model.Pathway) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Pathway_updated_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalOTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Pathway_updated_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Pathway",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
 		},
 	}
 	return fc, nil
@@ -51048,6 +51268,10 @@ func (ec *executionContext) fieldContext_Stop_level(_ context.Context, field gra
 				return ec.fieldContext_Level_geometry(ctx, field)
 			case "stops":
 				return ec.fieldContext_Level_stops(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Level_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Level_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Level", field.Name)
 		},
@@ -51565,6 +51789,10 @@ func (ec *executionContext) fieldContext_Stop_child_levels(ctx context.Context, 
 				return ec.fieldContext_Level_geometry(ctx, field)
 			case "stops":
 				return ec.fieldContext_Level_stops(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Level_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Level_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Level", field.Name)
 		},
@@ -51648,6 +51876,10 @@ func (ec *executionContext) fieldContext_Stop_pathways_from_stop(ctx context.Con
 				return ec.fieldContext_Pathway_from_stop(ctx, field)
 			case "to_stop":
 				return ec.fieldContext_Pathway_to_stop(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Pathway_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Pathway_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Pathway", field.Name)
 		},
@@ -51731,6 +51963,10 @@ func (ec *executionContext) fieldContext_Stop_pathways_to_stop(ctx context.Conte
 				return ec.fieldContext_Pathway_from_stop(ctx, field)
 			case "to_stop":
 				return ec.fieldContext_Pathway_to_stop(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Pathway_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Pathway_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Pathway", field.Name)
 		},
@@ -71440,6 +71676,10 @@ func (ec *executionContext) _Level(ctx context.Context, sel ast.SelectionSet, ob
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "created_at":
+			out.Values[i] = ec._Level_created_at(ctx, field, obj)
+		case "updated_at":
+			out.Values[i] = ec._Level_updated_at(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -72396,6 +72636,10 @@ func (ec *executionContext) _Pathway(ctx context.Context, sel ast.SelectionSet, 
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "created_at":
+			out.Values[i] = ec._Pathway_created_at(ctx, field, obj)
+		case "updated_at":
+			out.Values[i] = ec._Pathway_updated_at(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/internal/generated/gqlout/generated.go
+++ b/internal/generated/gqlout/generated.go
@@ -1101,6 +1101,7 @@ type ComplexityRoot struct {
 		CensusGeographies  func(childComplexity int, limit *int, where *model.CensusGeographyFilter) int
 		ChildLevels        func(childComplexity int, limit *int) int
 		Children           func(childComplexity int, limit *int) int
+		CreatedAt          func(childComplexity int) int
 		Departures         func(childComplexity int, limit *int, where *model.StopTimeFilter) int
 		Directions         func(childComplexity int, to *model.WaypointInput, from *model.WaypointInput, mode *model.StepMode, departAt *time.Time) int
 		ExternalReference  func(childComplexity int) int
@@ -1130,6 +1131,7 @@ type ComplexityRoot struct {
 		StopTimezone       func(childComplexity int) int
 		StopURL            func(childComplexity int) int
 		TtsStopName        func(childComplexity int) int
+		UpdatedAt          func(childComplexity int) int
 		WheelchairBoarding func(childComplexity int) int
 		WithinFeatures     func(childComplexity int) int
 		ZoneID             func(childComplexity int) int
@@ -7163,6 +7165,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Stop.Children(childComplexity, args["limit"].(*int)), true
 
+	case "Stop.created_at":
+		if e.complexity.Stop.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.Stop.CreatedAt(childComplexity), true
+
 	case "Stop.departures":
 		if e.complexity.Stop.Departures == nil {
 			break
@@ -7410,6 +7419,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Stop.TtsStopName(childComplexity), true
+
+	case "Stop.updated_at":
+		if e.complexity.Stop.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.Stop.UpdatedAt(childComplexity), true
 
 	case "Stop.wheelchair_boarding":
 		if e.complexity.Stop.WheelchairBoarding == nil {
@@ -9945,6 +9961,10 @@ type Stop {
   alerts(active: Boolean, limit: Int): [Alert!]
   "Matching feature ids from polygon search"
   within_features: Strings
+  "Time this stop record was created (typically the feed version import time)"
+  created_at: Time
+  "Time this stop record was last updated (import time, or the last edit if edited since)"
+  updated_at: Time
 }
 
 """Record from a static GTFS [pathways.txt](https://gtfs.org/reference/static/#pathwaysstxt). Pathways are a graph representation of a subway or train station, with nodes (entrances, platforms, etc) and edges (the pathways). See https://gtfs.org/reference/static/#pathwaystxt"""
@@ -24252,6 +24272,10 @@ func (ec *executionContext) fieldContext_FeedVersion_stops(ctx context.Context, 
 				return ec.fieldContext_Stop_alerts(ctx, field)
 			case "within_features":
 				return ec.fieldContext_Stop_within_features(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Stop_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Stop_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Stop", field.Name)
 		},
@@ -38180,6 +38204,10 @@ func (ec *executionContext) fieldContext_Level_stops(_ context.Context, field gr
 				return ec.fieldContext_Stop_alerts(ctx, field)
 			case "within_features":
 				return ec.fieldContext_Stop_within_features(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Stop_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Stop_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Stop", field.Name)
 		},
@@ -39208,6 +39236,10 @@ func (ec *executionContext) fieldContext_LocationGroup_stops(ctx context.Context
 				return ec.fieldContext_Stop_alerts(ctx, field)
 			case "within_features":
 				return ec.fieldContext_Stop_within_features(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Stop_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Stop_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Stop", field.Name)
 		},
@@ -39548,6 +39580,10 @@ func (ec *executionContext) fieldContext_LocationGroupStop_stop(_ context.Contex
 				return ec.fieldContext_Stop_alerts(ctx, field)
 			case "within_features":
 				return ec.fieldContext_Stop_within_features(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Stop_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Stop_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Stop", field.Name)
 		},
@@ -40308,6 +40344,10 @@ func (ec *executionContext) fieldContext_Mutation_stop_create(ctx context.Contex
 				return ec.fieldContext_Stop_alerts(ctx, field)
 			case "within_features":
 				return ec.fieldContext_Stop_within_features(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Stop_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Stop_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Stop", field.Name)
 		},
@@ -40439,6 +40479,10 @@ func (ec *executionContext) fieldContext_Mutation_stop_update(ctx context.Contex
 				return ec.fieldContext_Stop_alerts(ctx, field)
 			case "within_features":
 				return ec.fieldContext_Stop_within_features(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Stop_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Stop_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Stop", field.Name)
 		},
@@ -42592,6 +42636,10 @@ func (ec *executionContext) fieldContext_Pathway_from_stop(_ context.Context, fi
 				return ec.fieldContext_Stop_alerts(ctx, field)
 			case "within_features":
 				return ec.fieldContext_Stop_within_features(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Stop_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Stop_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Stop", field.Name)
 		},
@@ -42712,6 +42760,10 @@ func (ec *executionContext) fieldContext_Pathway_to_stop(_ context.Context, fiel
 				return ec.fieldContext_Stop_alerts(ctx, field)
 			case "within_features":
 				return ec.fieldContext_Stop_within_features(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Stop_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Stop_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Stop", field.Name)
 		},
@@ -44068,6 +44120,10 @@ func (ec *executionContext) fieldContext_Query_stops(ctx context.Context, field 
 				return ec.fieldContext_Stop_alerts(ctx, field)
 			case "within_features":
 				return ec.fieldContext_Stop_within_features(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Stop_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Stop_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Stop", field.Name)
 		},
@@ -46647,6 +46703,10 @@ func (ec *executionContext) fieldContext_Route_stops(ctx context.Context, field 
 				return ec.fieldContext_Stop_alerts(ctx, field)
 			case "within_features":
 				return ec.fieldContext_Stop_within_features(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Stop_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Stop_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Stop", field.Name)
 		},
@@ -47773,6 +47833,10 @@ func (ec *executionContext) fieldContext_RouteHeadway_stop(_ context.Context, fi
 				return ec.fieldContext_Stop_alerts(ctx, field)
 			case "within_features":
 				return ec.fieldContext_Stop_within_features(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Stop_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Stop_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Stop", field.Name)
 		},
@@ -48423,6 +48487,10 @@ func (ec *executionContext) fieldContext_RouteStop_stop(_ context.Context, field
 				return ec.fieldContext_Stop_alerts(ctx, field)
 			case "within_features":
 				return ec.fieldContext_Stop_within_features(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Stop_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Stop_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Stop", field.Name)
 		},
@@ -51097,6 +51165,10 @@ func (ec *executionContext) fieldContext_Stop_parent(_ context.Context, field gr
 				return ec.fieldContext_Stop_alerts(ctx, field)
 			case "within_features":
 				return ec.fieldContext_Stop_within_features(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Stop_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Stop_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Stop", field.Name)
 		},
@@ -51349,6 +51421,10 @@ func (ec *executionContext) fieldContext_Stop_children(ctx context.Context, fiel
 				return ec.fieldContext_Stop_alerts(ctx, field)
 			case "within_features":
 				return ec.fieldContext_Stop_within_features(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Stop_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Stop_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Stop", field.Name)
 		},
@@ -52347,6 +52423,10 @@ func (ec *executionContext) fieldContext_Stop_nearby_stops(ctx context.Context, 
 				return ec.fieldContext_Stop_alerts(ctx, field)
 			case "within_features":
 				return ec.fieldContext_Stop_within_features(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Stop_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Stop_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Stop", field.Name)
 		},
@@ -52473,6 +52553,88 @@ func (ec *executionContext) fieldContext_Stop_within_features(_ context.Context,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Strings does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Stop_created_at(ctx context.Context, field graphql.CollectedField, obj *model.Stop) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Stop_created_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalOTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Stop_created_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Stop",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Stop_updated_at(ctx context.Context, field graphql.CollectedField, obj *model.Stop) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Stop_updated_at(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalOTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Stop_updated_at(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Stop",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
 		},
 	}
 	return fc, nil
@@ -52755,6 +52917,10 @@ func (ec *executionContext) fieldContext_StopExternalReference_target_active_sto
 				return ec.fieldContext_Stop_alerts(ctx, field)
 			case "within_features":
 				return ec.fieldContext_Stop_within_features(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Stop_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Stop_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Stop", field.Name)
 		},
@@ -54311,6 +54477,10 @@ func (ec *executionContext) fieldContext_StopTime_stop(_ context.Context, field 
 				return ec.fieldContext_Stop_alerts(ctx, field)
 			case "within_features":
 				return ec.fieldContext_Stop_within_features(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Stop_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Stop_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Stop", field.Name)
 		},
@@ -58029,6 +58199,10 @@ func (ec *executionContext) fieldContext_ValidationReportDetails_stops(ctx conte
 				return ec.fieldContext_Stop_alerts(ctx, field)
 			case "within_features":
 				return ec.fieldContext_Stop_within_features(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Stop_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Stop_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Stop", field.Name)
 		},
@@ -59236,6 +59410,10 @@ func (ec *executionContext) fieldContext_VehiclePosition_stop_id(_ context.Conte
 				return ec.fieldContext_Stop_alerts(ctx, field)
 			case "within_features":
 				return ec.fieldContext_Stop_within_features(ctx, field)
+			case "created_at":
+				return ec.fieldContext_Stop_created_at(ctx, field)
+			case "updated_at":
+				return ec.fieldContext_Stop_updated_at(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Stop", field.Name)
 		},
@@ -75240,6 +75418,10 @@ func (ec *executionContext) _Stop(ctx context.Context, sel ast.SelectionSet, obj
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "within_features":
 			out.Values[i] = ec._Stop_within_features(ctx, field, obj)
+		case "created_at":
+			out.Values[i] = ec._Stop_created_at(ctx, field, obj)
+		case "updated_at":
+			out.Values[i] = ec._Stop_updated_at(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/schema/graphql/schema.graphqls
+++ b/schema/graphql/schema.graphqls
@@ -646,6 +646,10 @@ type Stop {
   alerts(active: Boolean, limit: Int): [Alert!]
   "Matching feature ids from polygon search"
   within_features: Strings
+  "Time this stop record was created (typically the feed version import time)"
+  created_at: Time
+  "Time this stop record was last updated (import time, or the last edit if edited since)"
+  updated_at: Time
 }
 
 """Record from a static GTFS [pathways.txt](https://gtfs.org/reference/static/#pathwaysstxt). Pathways are a graph representation of a subway or train station, with nodes (entrances, platforms, etc) and edges (the pathways). See https://gtfs.org/reference/static/#pathwaystxt"""

--- a/schema/graphql/schema.graphqls
+++ b/schema/graphql/schema.graphqls
@@ -680,6 +680,10 @@ type Pathway {
   from_stop: Stop!
   "Pathway ends at this stop"
   to_stop: Stop!
+  "Time this pathway record was created (typically the feed version import time)"
+  created_at: Time
+  "Time this pathway record was last updated (import time, or the last edit if edited since)"
+  updated_at: Time
 }
 
 """Record from a static GTFS [levels.txt](https://gtfs.org/reference/static/#levelstxt). Levels describes different levels of a station; used in conjunction with pathways."""
@@ -696,6 +700,10 @@ type Level {
   geometry: MultiPolygon!
   "Stops associated with this level"
   stops: [Stop!]
+  "Time this level record was created (typically the feed version import time)"
+  created_at: Time
+  "Time this level record was last updated (import time, or the last edit if edited since)"
+  updated_at: Time
 }
 
 """Record from a static GTFS [trips.txt](https://gtfs.org/schedule/reference/#tripstxt) file optionally enriched with by GTFS Realtime [TripUpdate](https://gtfs.org/reference/realtime/v2/#message-tripupdate) and [Alert](https://gtfs.org/reference/realtime/v2/#message-alert) messages."""

--- a/server/finders/dbfinder/pathway.go
+++ b/server/finders/dbfinder/pathway.go
@@ -102,6 +102,8 @@ func pathwaySelect(limit *int, after *model.Cursor, ids []int, permFilter *model
 			"gtfs_pathways.min_width",
 			"gtfs_pathways.signposted_as",
 			"gtfs_pathways.reverse_signposted_as",
+			"gtfs_pathways.created_at",
+			"gtfs_pathways.updated_at",
 		).
 		From("gtfs_pathways").
 		Join("feed_versions on feed_versions.id = gtfs_pathways.feed_version_id").

--- a/server/finders/dbfinder/stop.go
+++ b/server/finders/dbfinder/stop.go
@@ -290,6 +290,8 @@ func stopSelect(limit *int, after *model.Cursor, ids []int, useActive *UseActive
 		"gtfs_stops.level_id",
 		"gtfs_stops.parent_station",
 		"gtfs_stops.area_id",
+		"gtfs_stops.created_at",
+		"gtfs_stops.updated_at",
 		"current_feeds.id AS feed_id",
 		"current_feeds.onestop_id AS feed_onestop_id",
 		"feed_versions.sha1 AS feed_version_sha1",

--- a/server/gql/entity_mutation_resolver_test.go
+++ b/server/gql/entity_mutation_resolver_test.go
@@ -6,13 +6,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/99designs/gqlgen/client"
 	"github.com/interline-io/transitland-lib/gtfs"
 	"github.com/interline-io/transitland-lib/internal/testconfig"
+	"github.com/interline-io/transitland-lib/server/auth/mw/usercheck"
 	"github.com/interline-io/transitland-lib/server/model"
 	"github.com/interline-io/transitland-lib/tldb/postgres"
 	"github.com/interline-io/transitland-lib/tt"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
 )
 
 // Entity mutation tests
@@ -120,6 +123,156 @@ func TestStopUpdate_BumpsUpdatedAt(t *testing.T) {
 			afterCreate.CreatedAt, afterUpdate.CreatedAt)
 		assert.True(t, afterUpdate.UpdatedAt.After(afterCreate.UpdatedAt),
 			"updated_at should advance on update (was %s, now %s)",
+			afterCreate.UpdatedAt, afterUpdate.UpdatedAt)
+	})
+}
+
+func TestStopUpdate_GraphQLBumpsUpdatedAt(t *testing.T) {
+	// End-to-end check that the stop_update GraphQL mutation
+	// (the one called by Station Editor) actually persists an
+	// advancing updated_at, observable via a follow-up GraphQL query.
+	testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
+		srv, _ := NewServer()
+		srv = model.AddConfigAndPerms(cfg, srv)
+		srv = usercheck.AdminDefaultMiddleware("test")(srv)
+		c := client.New(srv)
+		stopID := fmt.Sprintf("e2e-%d", time.Now().UnixNano())
+		createResp := make(map[string]interface{})
+		err := c.Post(
+			`mutation($set: StopSetInput!) { stop_create(set: $set) { id updated_at } }`,
+			&createResp,
+			client.Var("set", map[string]interface{}{
+				"feed_version": map[string]interface{}{"id": 1},
+				"stop_id":      stopID,
+				"stop_name":    "hello",
+				"geometry":     map[string]interface{}{"type": "Point", "coordinates": []float64{-122.27, 37.80}},
+			}),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		entID := int(gjson.Get(toJson(createResp), "stop_create.id").Int())
+		createdUpdatedAt := gjson.Get(toJson(createResp), "stop_create.updated_at").String()
+		assert.NotEmpty(t, createdUpdatedAt, "updated_at should be returned on create")
+		// Sleep so the bump is observably later (microsecond precision in pg).
+		time.Sleep(2 * time.Millisecond)
+		updateResp := make(map[string]interface{})
+		err = c.Post(
+			`mutation($set: StopSetInput!) { stop_update(set: $set) { id updated_at } }`,
+			&updateResp,
+			client.Var("set", map[string]interface{}{
+				"id":        entID,
+				"stop_name": "hello again",
+			}),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		updatedUpdatedAt := gjson.Get(toJson(updateResp), "stop_update.updated_at").String()
+		assert.NotEmpty(t, updatedUpdatedAt, "updated_at should be returned on update")
+		assert.NotEqual(t, createdUpdatedAt, updatedUpdatedAt,
+			"updated_at returned via GraphQL should advance after stop_update (was %s, now %s)",
+			createdUpdatedAt, updatedUpdatedAt)
+	})
+}
+
+func TestPathwayUpdate_BumpsUpdatedAt(t *testing.T) {
+	testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
+		finder := cfg.Finder
+		ctx := model.WithConfig(context.Background(), cfg)
+		atx := postgres.NewPostgresAdapterFromDBX(cfg.Finder.DBX())
+		fv := model.FeedVersionInput{ID: toPtr(1)}
+		// Create two stops to use as endpoints
+		fromStopID, err := finder.StopCreate(ctx, model.StopSetInput{
+			FeedVersion: &fv,
+			StopID:      toPtr(fmt.Sprintf("from-%d", time.Now().UnixNano())),
+			StopName:    toPtr("from"),
+			Geometry:    toPtr(tt.NewPoint(-122.271604, 37.803664)),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		toStopID, err := finder.StopCreate(ctx, model.StopSetInput{
+			FeedVersion: &fv,
+			StopID:      toPtr(fmt.Sprintf("to-%d", time.Now().UnixNano())),
+			StopName:    toPtr("to"),
+			Geometry:    toPtr(tt.NewPoint(-122.271, 37.803)),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		eid, err := finder.PathwayCreate(ctx, model.PathwaySetInput{
+			FeedVersion:     &fv,
+			PathwayID:       toPtr(fmt.Sprintf("pw-%d", time.Now().UnixNano())),
+			PathwayMode:     toPtr(1),
+			IsBidirectional: toPtr(0),
+			FromStop:        &model.StopSetInput{ID: &fromStopID},
+			ToStop:          &model.StopSetInput{ID: &toStopID},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		afterCreate := gtfs.Pathway{}
+		afterCreate.ID = eid
+		if err := atx.Find(ctx, &afterCreate); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(2 * time.Millisecond)
+		if _, err := finder.PathwayUpdate(ctx, model.PathwaySetInput{
+			ID:        toPtr(eid),
+			PathwayID: toPtr(fmt.Sprintf("pw-update-%d", time.Now().UnixNano())),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		afterUpdate := gtfs.Pathway{}
+		afterUpdate.ID = eid
+		if err := atx.Find(ctx, &afterUpdate); err != nil {
+			t.Fatal(err)
+		}
+		assert.True(t, afterUpdate.CreatedAt.Equal(afterCreate.CreatedAt),
+			"created_at should not change on pathway update")
+		assert.True(t, afterUpdate.UpdatedAt.After(afterCreate.UpdatedAt),
+			"updated_at should advance on pathway update (was %s, now %s)",
+			afterCreate.UpdatedAt, afterUpdate.UpdatedAt)
+	})
+}
+
+func TestLevelUpdate_BumpsUpdatedAt(t *testing.T) {
+	testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
+		finder := cfg.Finder
+		ctx := model.WithConfig(context.Background(), cfg)
+		atx := postgres.NewPostgresAdapterFromDBX(cfg.Finder.DBX())
+		fv := model.FeedVersionInput{ID: toPtr(1)}
+		eid, err := finder.LevelCreate(ctx, model.LevelSetInput{
+			FeedVersion: &fv,
+			LevelID:     toPtr(fmt.Sprintf("L-%d", time.Now().UnixNano())),
+			LevelIndex:  toPtr(0.0),
+			LevelName:   toPtr("ground"),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		afterCreate := gtfs.Level{}
+		afterCreate.ID = eid
+		if err := atx.Find(ctx, &afterCreate); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(2 * time.Millisecond)
+		if _, err := finder.LevelUpdate(ctx, model.LevelSetInput{
+			ID:        toPtr(eid),
+			LevelName: toPtr("ground floor"),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		afterUpdate := gtfs.Level{}
+		afterUpdate.ID = eid
+		if err := atx.Find(ctx, &afterUpdate); err != nil {
+			t.Fatal(err)
+		}
+		assert.True(t, afterUpdate.CreatedAt.Equal(afterCreate.CreatedAt),
+			"created_at should not change on level update")
+		assert.True(t, afterUpdate.UpdatedAt.After(afterCreate.UpdatedAt),
+			"updated_at should advance on level update (was %s, now %s)",
 			afterCreate.UpdatedAt, afterUpdate.UpdatedAt)
 	})
 }

--- a/server/gql/entity_mutation_resolver_test.go
+++ b/server/gql/entity_mutation_resolver_test.go
@@ -78,6 +78,52 @@ func TestStopUpdate(t *testing.T) {
 	})
 }
 
+func TestStopUpdate_BumpsUpdatedAt(t *testing.T) {
+	testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
+		finder := cfg.Finder
+		ctx := model.WithConfig(context.Background(), cfg)
+		atx := postgres.NewPostgresAdapterFromDBX(cfg.Finder.DBX())
+		fv := model.FeedVersionInput{ID: toPtr(1)}
+		stopInput := model.StopSetInput{
+			FeedVersion: &fv,
+			StopID:      toPtr(fmt.Sprintf("%d", time.Now().UnixNano())),
+			StopName:    toPtr("hello"),
+			Geometry:    toPtr(tt.NewPoint(-122.271604, 37.803664)),
+		}
+		eid, err := finder.StopCreate(ctx, stopInput)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Capture timestamps right after create
+		afterCreate := gtfs.Stop{}
+		afterCreate.ID = eid
+		if err := atx.Find(ctx, &afterCreate); err != nil {
+			t.Fatal(err)
+		}
+		// Sleep so the updated_at bump is observably later than created_at
+		// even on fast machines. Postgres timestamps have microsecond precision.
+		time.Sleep(2 * time.Millisecond)
+		stopUpdate := model.StopSetInput{
+			ID:       toPtr(eid),
+			StopName: toPtr("hello again"),
+		}
+		if _, err := finder.StopUpdate(ctx, stopUpdate); err != nil {
+			t.Fatal(err)
+		}
+		afterUpdate := gtfs.Stop{}
+		afterUpdate.ID = eid
+		if err := atx.Find(ctx, &afterUpdate); err != nil {
+			t.Fatal(err)
+		}
+		assert.True(t, afterUpdate.CreatedAt.Equal(afterCreate.CreatedAt),
+			"created_at should not change on update (was %s, now %s)",
+			afterCreate.CreatedAt, afterUpdate.CreatedAt)
+		assert.True(t, afterUpdate.UpdatedAt.After(afterCreate.UpdatedAt),
+			"updated_at should advance on update (was %s, now %s)",
+			afterCreate.UpdatedAt, afterUpdate.UpdatedAt)
+	})
+}
+
 func TestStopReference(t *testing.T) {
 	testStr := func(t *testing.T) string { return fmt.Sprintf("%s-%d", t.Name(), time.Now().UnixNano()) }
 	type stopExternalReference struct {

--- a/server/gql/stop_resolver_test.go
+++ b/server/gql/stop_resolver_test.go
@@ -244,6 +244,17 @@ func stopResolverTestcases(t testing.TB, cfg model.Config) []testcase {
 			selector:     "stops.0.route_stops.#.route.route_id",
 			selectExpect: []string{"01", "03", "07"},
 		},
+		{
+			name:  "timestamps",
+			query: `query($stop_id: String!) { stops(where:{stop_id:$stop_id}) { created_at updated_at } }`,
+			vars:  vars,
+			f: func(t *testing.T, jj string) {
+				createdAt := gjson.Get(jj, "stops.0.created_at").String()
+				updatedAt := gjson.Get(jj, "stops.0.updated_at").String()
+				assert.NotEmpty(t, createdAt, "created_at should be exposed and non-empty")
+				assert.NotEmpty(t, updatedAt, "updated_at should be exposed and non-empty")
+			},
+		},
 
 		{
 			name:         "where onestop_id",

--- a/tldb/common.go
+++ b/tldb/common.go
@@ -100,6 +100,13 @@ func Update(ctx context.Context, adapter Adapter, ent interface{}, columns ...st
 	if err != nil {
 		return err
 	}
+	// When the entity carries timestamps, always persist updated_at so
+	// the in-memory bump from UpdateTimestamps() (called by the adapter
+	// before this point) actually reaches SQL. Otherwise the explicit
+	// columns list would filter it out.
+	if _, ok := ent.(CanUpdateTimestamps); ok && len(columns) > 0 && !Contains("updated_at", columns) {
+		columns = append(columns, "updated_at")
+	}
 	colmap := make(map[string]interface{})
 	for i, col := range header {
 		if len(columns) > 0 && !Contains(col, columns) {


### PR DESCRIPTION
## Summary

Adds `created_at: Time` and `updated_at: Time` to the GraphQL `Stop`, `Pathway`, and `Level` types, and fixes a latent bug where `updated_at` was not actually persisted on entity updates. Motivation: lets editor clients show when a station or any of its constituent records was last edited.

The Go models for all three (`gtfs.Stop`, `gtfs.Pathway`, `gtfs.Level`) already embed `tt.BaseEntity` → `tt.Timestamps`, so gqlgen auto-resolves the new fields with no resolver methods.

### Persistence fix in `tldb.Update`

While wiring this up I found that `updated_at` was not actually being persisted on entity edits. The adapter `Update` methods call `ent.UpdateTimestamps()` to bump the timestamp in memory, but `tldb.Update` filters the SQL by the explicit `columns` list, and the mutation callers (`StopUpdate`, `PathwayUpdate`, `LevelUpdate`, etc.) only list the user-changed columns. Net effect: `updated_at` stayed at the original import time on every edited record.

Fix is in `tldb/common.go`: when the entity implements `CanUpdateTimestamps` and the caller passed an explicit column list, append `"updated_at"` to that list. This restores the behavior implied by the existing (otherwise-dead) `UpdateTimestamps()` call. Affects all entity update paths via `createUpdateEnt` — which is the intent.

### SELECT-side fixes

- `stopSelect` and `pathwaySelect` build explicit column lists; both omitted the timestamp columns. Added them so the resolver returns non-null values.
- Level reads via `quickSelect("gtfs_levels", ...)` which uses `SELECT *`, so no change needed.

### Tests

- `stopResolverTestcases.timestamps` — GraphQL query for `created_at`/`updated_at` returns non-empty values.
- `TestStopUpdate_BumpsUpdatedAt`, `TestPathwayUpdate_BumpsUpdatedAt`, `TestLevelUpdate_BumpsUpdatedAt` — confirm the `tldb.Update` fix is generic across entity types (created_at unchanged, updated_at advanced after a mutation).
- `TestStopUpdate_GraphQLBumpsUpdatedAt` — end-to-end GraphQL test using the gqlgen client. Issues `stop_update` (the same mutation editor clients use) and asserts the returned `updated_at` advances after the mutation. Locks in the editor wire format.

All five tests verified passing locally against `tlv2_test_server`.

## Test plan

- [x] CI runs the new and existing entity-mutation and stop-resolver tests.
- [x] Manually query `{ stops { id stop_id created_at updated_at } pathways { id pathway_id created_at updated_at } levels { id level_id created_at updated_at } }` against a server built from this branch and confirm values come through.
- [ ] Manually edit a stop, pathway, or level via the corresponding `*_update` mutation and confirm `updated_at` advances while `created_at` stays fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)