### PR TITLE
Checker fails closed

### DIFF
--- a/cmds/server_cmd.go
+++ b/cmds/server_cmd.go
@@ -52,7 +52,6 @@ type ServerCommand struct {
 	LoadAdmins              bool
 	ValidateLargeFiles      bool
 	UseMaterialized         bool
-	DisableAuth             bool
 	LoaderBatchSize         int
 	LoaderStopTimeBatchSize int
 	SecretsFile             string
@@ -88,7 +87,6 @@ func (cmd *ServerCommand) AddFlags(fl *pflag.FlagSet) {
 	fl.IntVar(&cmd.LoaderStopTimeBatchSize, "loader-stop-time-batch-size", 1, "GraphQL Loader batch size for StopTimes")
 	fl.Float64Var(&cmd.MaxRadius, "max-radius", 100_000, "Maximum radius for nearby stops")
 	fl.BoolVar(&cmd.UseMaterialized, "use-materialized", false, "Use materialized views for active entities")
-	fl.BoolVar(&cmd.DisableAuth, "disable-auth", false, "Disable feed authorization checks (treat all feeds as public)")
 }
 
 func (cmd *ServerCommand) Parse(args []string) error {
@@ -156,11 +154,14 @@ func (cmd *ServerCommand) Run(ctx context.Context) error {
 
 	var actionFinder model.Actions = &actions.Actions{}
 
-	// Setup config
+	// Demo binary: authorization disabled. Production deployments should
+	// compose their own binary with a real Checker.
+	log.For(ctx).Warn().Msg("authorization disabled: demo mode")
 	cfg := model.Config{
 		Finder:                  dbFinder,
 		RTFinder:                rtFinder,
 		GbfsFinder:              gbfsFinder,
+		Checker:                 allowAllCheckerInstance,
 		Actions:                 actionFinder,
 		Secrets:                 cmd.secrets,
 		Storage:                 cmd.Storage,
@@ -171,11 +172,6 @@ func (cmd *ServerCommand) Run(ctx context.Context) error {
 		LoaderBatchSize:         cmd.LoaderBatchSize,
 		LoaderStopTimeBatchSize: cmd.LoaderStopTimeBatchSize,
 		MaxRadius:               cmd.MaxRadius,
-	}
-
-	// Disable auth if requested
-	if cmd.DisableAuth {
-		cfg.Checker = globalAdminCheckerInstance
 	}
 
 	// Setup router
@@ -253,5 +249,4 @@ func (cmd *ServerCommand) Run(ctx context.Context) error {
 	return srv.ListenAndServe()
 }
 
-// globalAdminChecker disables all feed authorization checks.
-var globalAdminCheckerInstance = &authz.GlobalAdminChecker{}
+var allowAllCheckerInstance = &authz.AllowAllChecker{}

--- a/doc/cli/transitland_server.md
+++ b/doc/cli/transitland_server.md
@@ -16,7 +16,6 @@ transitland server [flags]
 
 ```
       --dburl string                      Database URL (default: $TL_DATABASE_URL)
-      --disable-auth                      Disable feed authorization checks (treat all feeds as public)
   -h, --help                              help for server
       --load-admins                       Load admin polygons from database into memory
       --loader-batch-size int             GraphQL Loader batch size (default 100)

--- a/internal/testconfig/testconfig.go
+++ b/internal/testconfig/testconfig.go
@@ -36,6 +36,9 @@ type Options struct {
 	FGAEndpoint    string
 	FGAModelFile   string
 	FGAModelTuples []authz.TupleKey
+	// AllowAll installs an AllowAllChecker. Required for tests that exercise
+	// mutations. Ignored when FGAEndpoint is set.
+	AllowAll bool
 }
 
 func Config(t testing.TB, opts Options) model.Config {
@@ -97,8 +100,12 @@ func newTestConfig(t testing.TB, ctx context.Context, db tldb.Ext, opts Options)
 	}
 	cl := &clock.Mock{T: when}
 
-	// Setup Checker
-	var checker model.Checker
+	// model.Config requires a non-nil Checker. Default to deny-all; tests that
+	// exercise mutations must opt in via Options.AllowAll.
+	var checker model.Checker = &authz.DenyAllChecker{}
+	if opts.AllowAll {
+		checker = &authz.AllowAllChecker{}
+	}
 	if opts.FGAEndpoint != "" {
 		fgaClient, fgaErr := fga.NewFGAClient(opts.FGAEndpoint, "", "")
 		if fgaErr != nil {

--- a/server/auth/authz/checker.go
+++ b/server/auth/authz/checker.go
@@ -98,7 +98,9 @@ func userInfoFromAuthn(user authn.User) *UserInfo {
 // AllowAllChecker is the explicit "allow all" Checker — install it when a
 // deployment wants to opt out of authorization. Pairs with DenyAllChecker.
 // Use only in demo binaries or tests; never in a deployment that enforces
-// per-feed permissions.
+// per-feed permissions. When no authn user is present, Me() returns a
+// synthetic identity with the "admin" role, so anonymous callers also pass
+// any handler gated on RoleRequired("admin").
 type AllowAllChecker struct{}
 
 func (c *AllowAllChecker) Me(ctx context.Context) (*UserInfo, error) {

--- a/server/auth/authz/checker.go
+++ b/server/auth/authz/checker.go
@@ -1,6 +1,10 @@
 package authz
 
-import "context"
+import (
+	"context"
+
+	"github.com/interline-io/transitland-lib/server/auth/authn"
+)
 
 // ObjectRef identifies an entity in the authorization system.
 type ObjectRef struct {
@@ -80,22 +84,63 @@ type AdminManager interface {
 	GroupSave(ctx context.Context, req *GroupSaveRequest) (*GroupSaveResponse, error)
 }
 
-// GlobalAdminChecker implements Checker and always grants access.
-// Used when auth is disabled (e.g., --disable-auth flag).
-type GlobalAdminChecker struct{}
-
-func (c *GlobalAdminChecker) Me(ctx context.Context) (*UserInfo, error) {
-	return &UserInfo{}, nil
+// userInfoFromAuthn projects the authn identity into UserInfo for convenience
+// checkers. Caller must ensure user is non-nil.
+func userInfoFromAuthn(user authn.User) *UserInfo {
+	return &UserInfo{
+		ID:    user.ID(),
+		Name:  user.Name(),
+		Email: user.Email(),
+		Roles: user.Roles(),
+	}
 }
 
-func (c *GlobalAdminChecker) IsGlobalAdmin(ctx context.Context) (bool, error) {
+// AllowAllChecker is the explicit "allow all" Checker — install it when a
+// deployment wants to opt out of authorization. Pairs with DenyAllChecker.
+// Use only in demo binaries or tests; never in a deployment that enforces
+// per-feed permissions.
+type AllowAllChecker struct{}
+
+func (c *AllowAllChecker) Me(ctx context.Context) (*UserInfo, error) {
+	if user := authn.ForContext(ctx); user != nil {
+		return userInfoFromAuthn(user), nil
+	}
+	return &UserInfo{ID: "admin", Name: "admin", Roles: []string{"admin"}}, nil
+}
+
+func (c *AllowAllChecker) IsGlobalAdmin(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-func (c *GlobalAdminChecker) ListObjects(ctx context.Context, objType ObjectType) ([]ObjectRef, error) {
+func (c *AllowAllChecker) ListObjects(ctx context.Context, objType ObjectType) ([]ObjectRef, error) {
 	return nil, nil
 }
 
-func (c *GlobalAdminChecker) Check(ctx context.Context, obj ObjectRef, action Action) (bool, error) {
+func (c *AllowAllChecker) Check(ctx context.Context, obj ObjectRef, action Action) (bool, error) {
 	return true, nil
+}
+
+// DenyAllChecker is the explicit "deny all" Checker — install it when
+// callers should have no per-feed access. Read paths still see public feeds
+// via the unconditional public clause in pfJoinCheck.
+type DenyAllChecker struct{}
+
+func (c *DenyAllChecker) Me(ctx context.Context) (*UserInfo, error) {
+	user := authn.ForContext(ctx)
+	if user == nil {
+		return nil, ErrUnauthorized
+	}
+	return userInfoFromAuthn(user), nil
+}
+
+func (c *DenyAllChecker) IsGlobalAdmin(ctx context.Context) (bool, error) {
+	return false, nil
+}
+
+func (c *DenyAllChecker) ListObjects(ctx context.Context, objType ObjectType) ([]ObjectRef, error) {
+	return nil, nil
+}
+
+func (c *DenyAllChecker) Check(ctx context.Context, obj ObjectRef, action Action) (bool, error) {
+	return false, nil
 }

--- a/server/auth/azchecker/mock.go
+++ b/server/auth/azchecker/mock.go
@@ -2,10 +2,10 @@ package azchecker
 
 import (
 	"context"
-	"errors"
 	"strings"
 
 	"github.com/interline-io/transitland-lib/server/auth/authn"
+	"github.com/interline-io/transitland-lib/server/auth/authz"
 )
 
 type MockUserProvider struct {
@@ -26,7 +26,7 @@ func (c *MockUserProvider) UserByID(ctx context.Context, id string) (authn.User,
 	if user, ok := c.users[id]; ok {
 		return user, nil
 	}
-	return nil, errors.New("unauthorized")
+	return nil, authz.ErrUnauthorized
 }
 
 func (c *MockUserProvider) Users(ctx context.Context, userQuery string) ([]authn.User, error) {

--- a/server/finders/actions/feed_fetch.go
+++ b/server/finders/actions/feed_fetch.go
@@ -185,26 +185,31 @@ func GbfsFetch(ctx context.Context, feedId string, feedUrl string) error {
 }
 
 func fetchCheckFeed(ctx context.Context, feedId string) (*model.Feed, error) {
-	// Check feed exists
 	cfg := model.ForContext(ctx)
+
+	// Both not-found and not-authorized return ErrUnauthorized — distinguishing
+	// them would let unauthorized callers probe feed existence.
 	feeds, err := cfg.Finder.FindFeeds(ctx, nil, nil, nil, &model.FeedFilter{OnestopID: &feedId})
 	if err != nil {
 		return nil, err
 	}
 	if len(feeds) == 0 {
-		return nil, errors.New("feed not found")
+		log.For(ctx).Debug().Str("feed_id", feedId).Msg("fetchCheckFeed: feed not found")
+		return nil, authz.ErrUnauthorized
 	}
 	feed := feeds[0]
 
-	// Check feed permissions
-	if checker := cfg.Checker; checker != nil {
-		ok, err := checker.Check(ctx, authz.ObjectRef{Type: authz.FeedType, ID: int64(feed.ID)}, authz.CanCreateFeedVersion)
-		if err != nil {
-			return nil, err
-		}
-		if !ok {
-			return nil, errors.New("unauthorized")
-		}
+	if cfg.Checker == nil {
+		log.For(ctx).Debug().Str("feed_id", feedId).Msg("fetchCheckFeed: no Checker configured")
+		return nil, authz.ErrUnauthorized
+	}
+	ok, err := cfg.Checker.Check(ctx, authz.ObjectRef{Type: authz.FeedType, ID: int64(feed.ID)}, authz.CanCreateFeedVersion)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		log.For(ctx).Debug().Str("feed_id", feedId).Int("feed_db_id", feed.ID).Msg("fetchCheckFeed: caller not authorized")
+		return nil, authz.ErrUnauthorized
 	}
 	return feed, nil
 }

--- a/server/finders/actions/feed_fetch.go
+++ b/server/finders/actions/feed_fetch.go
@@ -187,6 +187,11 @@ func GbfsFetch(ctx context.Context, feedId string, feedUrl string) error {
 func fetchCheckFeed(ctx context.Context, feedId string) (*model.Feed, error) {
 	cfg := model.ForContext(ctx)
 
+	if cfg.Checker == nil {
+		log.For(ctx).Debug().Str("feed_id", feedId).Msg("fetchCheckFeed: no Checker configured")
+		return nil, authz.ErrUnauthorized
+	}
+
 	// Both not-found and not-authorized return ErrUnauthorized — distinguishing
 	// them would let unauthorized callers probe feed existence.
 	feeds, err := cfg.Finder.FindFeeds(ctx, nil, nil, nil, &model.FeedFilter{OnestopID: &feedId})
@@ -199,10 +204,6 @@ func fetchCheckFeed(ctx context.Context, feedId string) (*model.Feed, error) {
 	}
 	feed := feeds[0]
 
-	if cfg.Checker == nil {
-		log.For(ctx).Debug().Str("feed_id", feedId).Msg("fetchCheckFeed: no Checker configured")
-		return nil, authz.ErrUnauthorized
-	}
 	ok, err := cfg.Checker.Check(ctx, authz.ObjectRef{Type: authz.FeedType, ID: int64(feed.ID)}, authz.CanCreateFeedVersion)
 	if err != nil {
 		return nil, err

--- a/server/finders/actions/fv.go
+++ b/server/finders/actions/fv.go
@@ -310,11 +310,10 @@ func checkFeedEdit(ctx context.Context, fvid int) error {
 		return errors.New("invalid feed version id")
 	}
 	cfg := model.ForContext(ctx)
-	checker := cfg.Checker
-	if checker == nil {
-		return nil
+	if cfg.Checker == nil {
+		return authz.ErrUnauthorized
 	}
-	ok, err := checker.Check(ctx, authz.ObjectRef{Type: authz.FeedVersionType, ID: int64(fvid)}, authz.CanEdit)
+	ok, err := cfg.Checker.Check(ctx, authz.ObjectRef{Type: authz.FeedVersionType, ID: int64(fvid)}, authz.CanEdit)
 	if err != nil {
 		return err
 	}

--- a/server/finders/actions/test/actions_test.go
+++ b/server/finders/actions/test/actions_test.go
@@ -42,7 +42,7 @@ func (t *testWorker) Run(ctx context.Context) error {
 func TestGbfsFetch(t *testing.T) {
 	ts := httptest.NewServer(gbfs.NewTestGbfsServer("en", testdata.Path("server/gbfs")))
 	defer ts.Close()
-	testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
+	testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
 		ctx := model.WithConfig(context.Background(), cfg)
 		if err := actions.GbfsFetch(ctx, "test-gbfs", ts.URL+"/gbfs.json"); err != nil {
 			t.Fatal(err)
@@ -164,8 +164,7 @@ func TestStaticFetchWorker(t *testing.T) {
 
 			// Setup job
 			feedUrl := ts.URL + "/" + tc.serveFile
-			testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
-				cfg.Checker = nil // disable checker for this test
+			testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
 				ctx := model.WithConfig(context.Background(), cfg)
 				// Run job
 				if result, err := actions.StaticFetch(ctx, tc.feedId, nil, feedUrl); err != nil && !tc.expectError {
@@ -242,9 +241,8 @@ func TestValidateUpload(t *testing.T) {
 			ts := testutil.NewTestServer(testdata.Path())
 			defer ts.Close()
 
-			// Setup job
-			testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
-				cfg.Checker = nil // disable checker for this test
+			// AllowAll for setup-consistency; ValidateUpload doesn't consult Checker.
+			testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
 				ctx := model.WithConfig(context.Background(), cfg)
 				// Run job
 				feedUrl := ts.URL + "/" + tc.serveFile

--- a/server/finders/dbfinder/mutations.go
+++ b/server/finders/dbfinder/mutations.go
@@ -358,11 +358,10 @@ func checkFeedEdit(ctx context.Context, fvid int) error {
 		return errors.New("invalid feed version id")
 	}
 	cfg := model.ForContext(ctx)
-	checker := cfg.Checker
-	if checker == nil {
-		return nil
+	if cfg.Checker == nil {
+		return authz.ErrUnauthorized
 	}
-	ok, err := checker.Check(ctx, authz.ObjectRef{Type: authz.FeedVersionType, ID: int64(fvid)}, authz.CanEdit)
+	ok, err := cfg.Checker.Check(ctx, authz.ObjectRef{Type: authz.FeedVersionType, ID: int64(fvid)}, authz.CanEdit)
 	if err != nil {
 		return err
 	}

--- a/server/gql/entity_mutation_resolver_test.go
+++ b/server/gql/entity_mutation_resolver_test.go
@@ -21,7 +21,7 @@ import (
 // Entity mutation tests
 
 func TestStopCreate(t *testing.T) {
-	testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
+	testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
 		finder := cfg.Finder
 		ctx := model.WithConfig(context.Background(), cfg)
 		fv := model.FeedVersionInput{ID: toPtr(1)}
@@ -48,7 +48,7 @@ func TestStopCreate(t *testing.T) {
 }
 
 func TestStopUpdate(t *testing.T) {
-	testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
+	testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
 		finder := cfg.Finder
 		ctx := model.WithConfig(context.Background(), cfg)
 		fv := model.FeedVersionInput{ID: toPtr(1)}
@@ -82,7 +82,7 @@ func TestStopUpdate(t *testing.T) {
 }
 
 func TestStopUpdate_BumpsUpdatedAt(t *testing.T) {
-	testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
+	testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
 		finder := cfg.Finder
 		ctx := model.WithConfig(context.Background(), cfg)
 		atx := postgres.NewPostgresAdapterFromDBX(cfg.Finder.DBX())
@@ -131,7 +131,7 @@ func TestStopUpdate_GraphQLBumpsUpdatedAt(t *testing.T) {
 	// End-to-end check that the stop_update GraphQL mutation
 	// (the one called by Station Editor) actually persists an
 	// advancing updated_at, observable via a follow-up GraphQL query.
-	testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
+	testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
 		srv, _ := NewServer()
 		srv = model.AddConfigAndPerms(cfg, srv)
 		srv = usercheck.AdminDefaultMiddleware("test")(srv)
@@ -177,7 +177,7 @@ func TestStopUpdate_GraphQLBumpsUpdatedAt(t *testing.T) {
 }
 
 func TestPathwayUpdate_BumpsUpdatedAt(t *testing.T) {
-	testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
+	testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
 		finder := cfg.Finder
 		ctx := model.WithConfig(context.Background(), cfg)
 		atx := postgres.NewPostgresAdapterFromDBX(cfg.Finder.DBX())
@@ -238,7 +238,7 @@ func TestPathwayUpdate_BumpsUpdatedAt(t *testing.T) {
 }
 
 func TestLevelUpdate_BumpsUpdatedAt(t *testing.T) {
-	testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
+	testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
 		finder := cfg.Finder
 		ctx := model.WithConfig(context.Background(), cfg)
 		atx := postgres.NewPostgresAdapterFromDBX(cfg.Finder.DBX())
@@ -285,7 +285,7 @@ func TestStopReference(t *testing.T) {
 		TargetFeedOnestopID tt.String `db:"target_feed_onestop_id"`
 		TargetStopID        tt.String `db:"target_stop_id"`
 	}
-	testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
+	testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
 		finder := cfg.Finder
 		ctx := model.WithConfig(context.Background(), cfg)
 		fv := model.FeedVersionInput{ID: toPtr(1)}

--- a/server/gql/fv_mutation_resolver_test.go
+++ b/server/gql/fv_mutation_resolver_test.go
@@ -25,7 +25,7 @@ func TestFeedVersionFetchResolver(t *testing.T) {
 		w.Write(buf)
 	}))
 	t.Run("found sha1", func(t *testing.T) {
-		testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
+		testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
 			srv, _ := NewServer()
 			srv = model.AddConfigAndPerms(cfg, srv)
 			srv = usercheck.AdminDefaultMiddleware("test")(srv) // Run all requests as admin

--- a/server/gql/query_resolver.go
+++ b/server/gql/query_resolver.go
@@ -2,9 +2,7 @@ package gql
 
 import (
 	"context"
-	"errors"
 
-	"github.com/interline-io/transitland-lib/server/auth/authn"
 	"github.com/interline-io/transitland-lib/server/model"
 	"github.com/interline-io/transitland-lib/tt"
 )
@@ -17,29 +15,16 @@ func (r *queryResolver) Me(ctx context.Context) (*model.Me, error) {
 	cfg := model.ForContext(ctx)
 	me := model.Me{}
 	me.ExternalData = tt.NewMap(map[string]any{})
-	if checker := cfg.Checker; checker != nil {
-		// Use checker if available
-		cm, err := checker.Me(ctx)
-		if err != nil {
-			return nil, err
-		}
-		me.ID = cm.ID
-		me.Email = &cm.Email
-		me.Name = &cm.Name
-		me.Roles = cm.Roles
-		for k, v := range cm.ExternalData {
-			me.ExternalData.Val[k] = v
-		}
-	} else if user := authn.ForContext(ctx); user != nil {
-		// Fallback to user context
-		um := user.Email()
-		un := user.Name()
-		me.ID = user.ID()
-		me.Name = &un
-		me.Email = &um
-		me.Roles = user.Roles()
-	} else {
-		return nil, errors.New("no user")
+	cm, err := cfg.Checker.Me(ctx)
+	if err != nil {
+		return nil, err
+	}
+	me.ID = cm.ID
+	me.Email = &cm.Email
+	me.Name = &cm.Name
+	me.Roles = cm.Roles
+	for k, v := range cm.ExternalData {
+		me.ExternalData.Val[k] = v
 	}
 	return &me, nil
 }

--- a/server/model/config.go
+++ b/server/model/config.go
@@ -50,6 +50,9 @@ func WithConfig(ctx context.Context, cfg Config) context.Context {
 }
 
 func AddConfig(cfg Config) func(http.Handler) http.Handler {
+	if cfg.Checker == nil {
+		panic("model.AddConfig: Config.Checker must be set; install authz.AllowAllChecker or authz.DenyAllChecker for demo/test, or a real Checker for production")
+	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()

--- a/server/model/config.go
+++ b/server/model/config.go
@@ -44,6 +44,9 @@ func ForContext(ctx context.Context) Config {
 	return raw
 }
 
+// WithConfig stores cfg in ctx for non-HTTP entry points (background jobs,
+// tests). Unlike AddConfig, this does not enforce a non-nil Checker — test
+// scaffolding (testconfig) is responsible for providing one.
 func WithConfig(ctx context.Context, cfg Config) context.Context {
 	r := context.WithValue(ctx, finderCtxKey, cfg)
 	return r

--- a/server/model/config_test.go
+++ b/server/model/config_test.go
@@ -1,0 +1,34 @@
+package model
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/interline-io/transitland-lib/server/auth/authz"
+)
+
+func TestAddConfig_PanicsOnNilChecker(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic when Config.Checker is nil")
+		}
+	}()
+	_ = AddConfig(Config{})
+}
+
+func TestAddConfig_NoPanicWithChecker(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("unexpected panic: %v", r)
+		}
+	}()
+	mw := AddConfig(Config{Checker: &authz.DenyAllChecker{}})
+	srv := httptest.NewServer(mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})))
+	defer srv.Close()
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+}

--- a/server/model/perm_filter.go
+++ b/server/model/perm_filter.go
@@ -127,10 +127,10 @@ func refsToInts(refs []authz.ObjectRef) []int {
 }
 
 func checkActive(ctx context.Context, checker Checker) (*PermFilter, error) {
-	active := &PermFilter{}
 	if checker == nil {
-		return active, nil
+		panic("model.checkActive: Checker must be non-nil; install authz.DenyAllChecker for the deny-all default")
 	}
+	active := &PermFilter{}
 
 	if ok, err := checker.IsGlobalAdmin(ctx); err != nil {
 		return nil, err

--- a/server/model/perm_filter_test.go
+++ b/server/model/perm_filter_test.go
@@ -332,31 +332,13 @@ func TestWithPerms(t *testing.T) {
 		}
 	})
 
-	t.Run("nil checker - returns empty filter", func(t *testing.T) {
-		ctx := context.Background()
-		ctx = WithPerms(ctx, nil)
-
-		pf := PermsForContext(ctx)
-		if pf == nil {
-			t.Error("expected non-nil PermFilter")
-		}
-		if len(pf.AllowedFeeds) != 0 || len(pf.AllowedFeedVersions) != 0 {
-			t.Error("expected empty PermFilter")
-		}
-	})
-
-	t.Run("nil checker with existing filter - merges empty", func(t *testing.T) {
-		ctx := context.Background()
-		existing := &PermFilter{AllowedFeeds: []int{1, 2}, AllowedFeedVersions: []int{10}}
-		ctx = WithPermFilter(ctx, existing)
-
-		ctx = WithPerms(ctx, nil)
-
-		pf := PermsForContext(ctx)
-		// Should merge existing with empty checker result
-		if !reflect.DeepEqual(sortedInts(pf.AllowedFeeds), []int{1, 2}) {
-			t.Errorf("expected feeds [1, 2], got %v", pf.AllowedFeeds)
-		}
+	t.Run("nil checker panics", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("expected panic on nil checker")
+			}
+		}()
+		WithPerms(context.Background(), nil)
 	})
 
 	t.Run("existing admin + non-admin checker preserves admin", func(t *testing.T) {
@@ -403,18 +385,13 @@ func TestWithPerms_ThreadSafety(t *testing.T) {
 }
 
 func TestCheckActive(t *testing.T) {
-	t.Run("nil checker returns empty filter", func(t *testing.T) {
-		ctx := context.Background()
-		pf, err := checkActive(ctx, nil)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if pf == nil {
-			t.Error("expected non-nil PermFilter")
-		}
-		if len(pf.AllowedFeeds) != 0 {
-			t.Error("expected empty AllowedFeeds")
-		}
+	t.Run("nil checker panics", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("expected panic on nil checker")
+			}
+		}()
+		_, _ = checkActive(context.Background(), nil)
 	})
 
 	t.Run("checker returns feeds and versions", func(t *testing.T) {


### PR DESCRIPTION
## Summary
Make permission checks in the server fail closed. Previously, several mutation paths (feed fetch, feed-edit checks used by GraphQL mutations) silently granted access when no `Checker` was configured. Library callers that did not wire up a Checker were therefore running with no enforcement, which is unsafe as a default. This PR flips those paths to return `authz.ErrUnauthorized` when `Checker` is nil, makes a non-nil Checker a hard requirement of `model.AddConfig` (panics at startup otherwise), and renames the existing `GlobalAdminChecker` to `AllowAllChecker` with a sibling `DenyAllChecker` so deployments can express intent explicitly. Read-path behavior is unchanged: anonymous reads still see public feeds via the existing unconditional public clause in `pfJoinCheck`.

### Fail-closed authorization
- `server/finders/actions/feed_fetch.go`: `fetchCheckFeed` now returns `authz.ErrUnauthorized` when no Checker is configured, instead of skipping the check. Both not-found and not-authorized return the same sentinel so unauthorized callers cannot probe feed existence. Replaces the ad-hoc `errors.New("unauthorized")` with the shared sentinel.
- `server/finders/actions/fv.go` and `server/finders/dbfinder/mutations.go`: `checkFeedEdit` returns `authz.ErrUnauthorized` instead of `nil` when Checker is nil.
- `server/model/config.go`: `model.AddConfig` panics when `Config.Checker` is nil. Loud failure at startup rather than silent fail-open at request time.
- `server/model/perm_filter.go`: `checkActive` panics on nil checker for the same reason. `WithPerms` no longer needs to handle the nil-checker fallback.

### Convenience checkers
- `server/auth/authz/checker.go`: renames `GlobalAdminChecker` to `AllowAllChecker` and adds a sibling `DenyAllChecker`. The pair makes intent self-documenting and gives tests a non-nil deny-all default to install when they do not need to exercise mutation paths.
- `AllowAllChecker.Me` returns the authn identity if present, or a synthetic `{ID: "admin", Name: "admin", Roles: ["admin"]}` when no user is in context.
- `DenyAllChecker.Me` returns the authn identity if present, or `ErrUnauthorized` when no user is in context.

### Demo binary
- `cmds/server_cmd.go`: removes the `--disable-auth` flag. The demo binary now always installs `AllowAllChecker` and logs `authorization disabled: demo mode` at startup. Production deployments are expected to compose their own binary with a real Checker.

### Test scaffolding
- `internal/testconfig/testconfig.go`: adds an `AllowAll` option that installs `AllowAllChecker`. Required for tests that exercise mutation paths now that the library fails closed when Checker is nil. Tests that do not opt in get a `DenyAllChecker` so `model.Config.Checker` is non-nil but per-feed mutations are denied; reads still see public feeds via the unconditional public clause.
- `server/gql/entity_mutation_resolver_test.go`, `server/gql/fv_mutation_resolver_test.go`, `server/finders/actions/test/actions_test.go`: pass `AllowAll: true` for tests that previously relied on the implicit allow-all behavior, and remove the now-unnecessary `cfg.Checker = nil` lines.
- `server/model/perm_filter_test.go`: replaces "nil checker returns empty filter" cases with panic assertions matching the new contract.

### Me() resolver cleanup
- `server/gql/query_resolver.go`: drops the dead `if checker != nil` fallback and the secondary `authn.ForContext` fallback. With Checker now required, the resolver delegates directly to `cfg.Checker.Me(ctx)`.

## Test plan
- `go test ./server/...` with `TL_TEST_DATABASE_URL` and `TL_TEST_SERVER_DATABASE_URL` set; in particular confirm `TestStopCreate`, `TestStopUpdate`, `TestStopReference`, `TestFeedVersionFetchResolver`, `TestStaticFetchWorker`, and `TestValidateUpload` pass.
- Run `transitland server` locally and confirm the startup warning `authorization disabled: demo mode` is logged and that `--disable-auth` is no longer accepted.
- Spot-check that a downstream binary which does not configure a Checker now panics at startup from `model.AddConfig`, and that mutation paths return `authz.ErrUnauthorized` rather than succeeding.
