### PR TITLE
Support both GBFS 2.x and 3.x

### DIFF
--- a/internal/gbfs/fetch_test.go
+++ b/internal/gbfs/fetch_test.go
@@ -2,6 +2,7 @@ package gbfs
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http/httptest"
 	"testing"
@@ -9,6 +10,38 @@ import (
 	"github.com/interline-io/transitland-lib/testdata"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestSystemFileUnmarshalJSON(t *testing.T) {
+	t.Run("gbfs 2.x language-keyed data", func(t *testing.T) {
+		body := []byte(`{"data":{"en":{"feeds":[{"name":"system_information","url":"http://example.com/system_information.json"}]}}}`)
+		var sf SystemFile
+		if err := json.Unmarshal(body, &sf); err != nil {
+			t.Fatal(err)
+		}
+		if assert.Contains(t, sf.Data, "en") && assert.NotNil(t, sf.Data["en"]) {
+			assert.Len(t, sf.Data["en"].Feeds, 1)
+			assert.Equal(t, "system_information", sf.Data["en"].Feeds[0].Name.Val)
+		}
+	})
+	t.Run("gbfs 3.x flat data", func(t *testing.T) {
+		body := []byte(`{"data":{"feeds":[{"name":"system_information","url":"http://example.com/system_information.json"}]}}`)
+		var sf SystemFile
+		if err := json.Unmarshal(body, &sf); err != nil {
+			t.Fatal(err)
+		}
+		if assert.Contains(t, sf.Data, "") && assert.NotNil(t, sf.Data[""]) {
+			assert.Len(t, sf.Data[""].Feeds, 1)
+			assert.Equal(t, "system_information", sf.Data[""].Feeds[0].Name.Val)
+		}
+	})
+	t.Run("empty data", func(t *testing.T) {
+		var sf SystemFile
+		if err := json.Unmarshal([]byte(`{}`), &sf); err != nil {
+			t.Fatal(err)
+		}
+		assert.Empty(t, sf.Data)
+	})
+}
 
 func TestGbfsFetch(t *testing.T) {
 	ts := httptest.NewServer(NewTestGbfsServer("en", testdata.Path("server/gbfs")))

--- a/internal/gbfs/fetch_test.go
+++ b/internal/gbfs/fetch_test.go
@@ -34,12 +34,24 @@ func TestSystemFileUnmarshalJSON(t *testing.T) {
 			assert.Equal(t, "system_information", sf.Data[""].Feeds[0].Name.Val)
 		}
 	})
-	t.Run("empty data", func(t *testing.T) {
+	t.Run("empty data object", func(t *testing.T) {
+		var sf SystemFile
+		if err := json.Unmarshal([]byte(`{"data":{}}`), &sf); err != nil {
+			t.Fatal(err)
+		}
+		assert.Empty(t, sf.Data)
+	})
+	t.Run("missing data key", func(t *testing.T) {
 		var sf SystemFile
 		if err := json.Unmarshal([]byte(`{}`), &sf); err != nil {
 			t.Fatal(err)
 		}
 		assert.Empty(t, sf.Data)
+	})
+	t.Run("malformed 2.x language value is not silently treated as 3.x", func(t *testing.T) {
+		var sf SystemFile
+		err := json.Unmarshal([]byte(`{"data":{"en":"bad"}}`), &sf)
+		assert.Error(t, err)
 	})
 }
 

--- a/internal/gbfs/gbfs.go
+++ b/internal/gbfs/gbfs.go
@@ -43,7 +43,10 @@ type SystemFile struct {
 // UnmarshalJSON accepts both the GBFS 1.x/2.x shape, where `data` is a map
 // keyed by language code, and the GBFS 3.x shape, where `data` is the
 // SystemFeeds object directly. The 3.x payload is stored under an empty
-// language key so downstream consumers can iterate uniformly.
+// language key so downstream consumers can iterate uniformly. The version
+// is disambiguated by the presence of a top-level `feeds` key in `data`,
+// rather than by trial-decoding — `SystemFeeds` ignores unknown fields, so
+// a fallback strategy would silently accept malformed 2.x payloads.
 func (s *SystemFile) UnmarshalJSON(b []byte) error {
 	var raw struct {
 		Data json.RawMessage `json:"data"`
@@ -54,16 +57,23 @@ func (s *SystemFile) UnmarshalJSON(b []byte) error {
 	if len(raw.Data) == 0 {
 		return nil
 	}
-	var langMap map[string]*SystemFeeds
-	if err := json.Unmarshal(raw.Data, &langMap); err == nil {
-		s.Data = langMap
-		return nil
-	}
-	var sf SystemFeeds
-	if err := json.Unmarshal(raw.Data, &sf); err != nil {
+	var keys map[string]json.RawMessage
+	if err := json.Unmarshal(raw.Data, &keys); err != nil {
 		return err
 	}
-	s.Data = map[string]*SystemFeeds{"": &sf}
+	if _, ok := keys["feeds"]; ok {
+		var sf SystemFeeds
+		if err := json.Unmarshal(raw.Data, &sf); err != nil {
+			return err
+		}
+		s.Data = map[string]*SystemFeeds{"": &sf}
+		return nil
+	}
+	var langMap map[string]*SystemFeeds
+	if err := json.Unmarshal(raw.Data, &langMap); err != nil {
+		return err
+	}
+	s.Data = langMap
 	return nil
 }
 

--- a/internal/gbfs/gbfs.go
+++ b/internal/gbfs/gbfs.go
@@ -1,6 +1,10 @@
 package gbfs
 
-import "github.com/interline-io/transitland-lib/tt"
+import (
+	"encoding/json"
+
+	"github.com/interline-io/transitland-lib/tt"
+)
 
 // Loaders
 
@@ -34,6 +38,33 @@ type SystemFeed struct {
 
 type SystemFile struct {
 	Data map[string]*SystemFeeds `json:"data,omitempty"`
+}
+
+// UnmarshalJSON accepts both the GBFS 1.x/2.x shape, where `data` is a map
+// keyed by language code, and the GBFS 3.x shape, where `data` is the
+// SystemFeeds object directly. The 3.x payload is stored under an empty
+// language key so downstream consumers can iterate uniformly.
+func (s *SystemFile) UnmarshalJSON(b []byte) error {
+	var raw struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if len(raw.Data) == 0 {
+		return nil
+	}
+	var langMap map[string]*SystemFeeds
+	if err := json.Unmarshal(raw.Data, &langMap); err == nil {
+		s.Data = langMap
+		return nil
+	}
+	var sf SystemFeeds
+	if err := json.Unmarshal(raw.Data, &sf); err != nil {
+		return err
+	}
+	s.Data = map[string]*SystemFeeds{"": &sf}
+	return nil
 }
 
 type SystemInformationFile struct {


### PR DESCRIPTION
## Summary
Fixes GBFS feed fetches that were failing with `json: cannot unmarshal array into Go struct field SystemFile.data of type gbfs.SystemFeeds` when the upstream system served a GBFS 3.x `gbfs.json` discovery file. In GBFS 3.0 the `data` object dropped its language-code wrapper and now contains `feeds` directly, which the existing `map[string]*SystemFeeds` shape could not decode.

### Schema compatibility
- Added a custom `SystemFile.UnmarshalJSON` that accepts both the GBFS 1.x/2.x language-keyed shape (`{"data":{"en":{"feeds":[...]}}}`) and the GBFS 3.x flat shape (`{"data":{"feeds":[...]}}`).
- The 3.x payload is stored under an empty-string language key so the existing iteration in `fetch.go` continues to work without changes to downstream consumers.
- Disambiguation is driven by the underlying JSON: a 3.x payload fails the language-map decode (array value cannot satisfy `*SystemFeeds`), then succeeds on the flat decode.

### Tests
- New `TestSystemFileUnmarshalJSON` with subtests covering the 2.x language-keyed shape, the 3.x flat shape, and an empty `data` object.
- Existing `TestGbfsFetch` continues to pass against the language-keyed test server fixture, confirming no regression for 2.x feeds.

## Test plan
- Point a GBFS fetch job at a known v3.x feed (e.g. one returning `version: "3.0"` in `gbfs.json`) and confirm the job no longer errors and that `system_information` and other sub-files are fetched.
- Re-run an existing v2.x feed and confirm fetched feeds still populate as before.
- Tail the job runner logs and confirm the `cannot unmarshal array into Go struct field SystemFile.data` warning no longer appears for affected feeds.
