### PR TITLE
Remove aws sdk go v1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.0.0
 	github.com/MicahParks/keyfunc/v3 v3.8.0
 	github.com/auth0/go-auth0 v0.17.2
-	github.com/aws/aws-sdk-go v1.49.6
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.29.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.67

--- a/go.sum
+++ b/go.sum
@@ -51,8 +51,6 @@ github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/auth0/go-auth0 v0.17.2 h1:qEttAY4yYeEJl6wu0iOwlet26wUKA2G5YOUomfuxcy4=
 github.com/auth0/go-auth0 v0.17.2/go.mod h1:Hlp4kYcvn2JSD1tAmPQ8DD7MMoiO0bwVJwTHXqJbDDE=
-github.com/aws/aws-sdk-go v1.49.6 h1:yNldzF5kzLBRvKlKz1S0bkvc2+04R1kt13KfBWQBfFA=
-github.com/aws/aws-sdk-go v1.49.6/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
 github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=
@@ -258,8 +256,6 @@ github.com/jellydator/ttlcache/v2 v2.11.1/go.mod h1:RtE5Snf0/57e+2cLWFYWCCsLas2H
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jlaffaye/ftp v0.0.0-20220524001917-dfa1e758f3af h1:sh8vAWJ+vr9izhkDAMS3JRGDIjj0tNVwxfwd+2U2xMo=
 github.com/jlaffaye/ftp v0.0.0-20220524001917-dfa1e758f3af/go.mod h1:oZaomI+9/et52UBjvNU9LCIqmgt816+7ljXCx0EIPzo=
-github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
-github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
 github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
 github.com/joeshaw/gengen v0.0.0-20190604015154-c77d87825f5a/go.mod h1:v2qvRL8Xwk4OlARK6gPlf2JreZXzv0dYp/8+kUJ0y7Q=

--- a/server/directions/valhalla/valhalla.go
+++ b/server/directions/valhalla/valhalla.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/interline-io/log"
 	"github.com/interline-io/transitland-lib/internal/clock"
 	"github.com/interline-io/transitland-lib/server/caches/httpcache"
@@ -59,7 +58,7 @@ func NewRouter(client *http.Client, endpoint string, apikey string) *Router {
 
 func (h *Router) Request(ctx context.Context, req model.DirectionRequest) (*model.Directions, error) {
 	if err := directions.ValidateDirectionRequest(req); err != nil {
-		return &model.Directions{Success: false, Exception: aws.String("invalid input")}, nil
+		return &model.Directions{Success: false, Exception: strPtr("invalid input")}, nil
 	}
 
 	// Prepare request
@@ -74,7 +73,7 @@ func (h *Router) Request(ctx context.Context, req model.DirectionRequest) (*mode
 	case model.StepModeWalk, model.StepModeTransit:
 		input.Costing = "pedestrian"
 	default:
-		return &model.Directions{Success: false, Exception: aws.String("unsupported travel mode")}, nil
+		return &model.Directions{Success: false, Exception: strPtr("unsupported travel mode")}, nil
 	}
 
 	// Prepare time
@@ -94,7 +93,7 @@ func (h *Router) Request(ctx context.Context, req model.DirectionRequest) (*mode
 	res, err := makeRequest(ctx, input, h.client, h.endpoint, h.apikey)
 	if err != nil || len(res.Trip.Legs) == 0 {
 		log.For(ctx).Error().Err(err).Msg("valhalla router failed to calculate route")
-		return &model.Directions{Success: false, Exception: aws.String("could not calculate route")}, nil
+		return &model.Directions{Success: false, Exception: strPtr("could not calculate route")}, nil
 	}
 	// Prepare response
 	ret := makeDirections(res, departAt)
@@ -144,7 +143,7 @@ func makeDirections(res *Response, departAt time.Time) *model.Directions {
 	ret.Distance = itin.Distance
 	ret.StartTime = &itin.StartTime
 	ret.EndTime = &itin.EndTime
-	ret.DataSource = aws.String("OSM")
+	ret.DataSource = strPtr("OSM")
 
 	// Create legs for itinerary
 	prevLegDepartAt := departAt
@@ -222,7 +221,7 @@ func makeDirections(res *Response, departAt time.Time) *model.Directions {
 		itin.Legs = append(itin.Legs, &leg)
 	}
 	if len(itin.Legs) == 0 {
-		return &model.Directions{Success: false, Exception: aws.String("no legs in response")}
+		return &model.Directions{Success: false, Exception: strPtr("no legs in response")}
 	}
 
 	// Add summary
@@ -297,4 +296,8 @@ func wpiWaypoint(w *model.WaypointInput) *model.Waypoint {
 		Lat:  w.Lat,
 		Name: w.Name,
 	}
+}
+
+func strPtr(s string) *string {
+	return &s
 }


### PR DESCRIPTION
## Summary
Remove the `aws-sdk-go` v1 dependency from transitland-lib. The SDK was pulled in solely for `aws.String()` in the Valhalla directions provider, but importing it dragged the v1 SDK's full endpoints registry (~1.9MB) and its `jmespath/go-jmespath` transitive into every binary built against transitland-lib.

### Dependency cleanup
- Drop `github.com/aws/aws-sdk-go` v1.49.6 from `go.mod`
- `go mod tidy` removes the transitively-pulled `github.com/jmespath/go-jmespath` v0.4.0
- AWS SDK v2 dependencies are unaffected

### Valhalla directions provider
- Replace 5 `aws.String(...)` call sites in `server/directions/valhalla/valhalla.go` with a local `strPtr(s string) *string` helper
- No behavior change — both return a pointer to the same string value
