### PR TITLE
Move dbmigrate commands into the packages that own their embedded data

### DIFF
--- a/cmd/transitland/main.go
+++ b/cmd/transitland/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/interline-io/log"
 	tl "github.com/interline-io/transitland-lib"
 	"github.com/interline-io/transitland-lib/cmds"
+	"github.com/interline-io/transitland-lib/cmds/dbmigratene"
 	"github.com/interline-io/transitland-lib/diff"
 	"github.com/interline-io/transitland-lib/tlcli"
 	"github.com/interline-io/transitland-lib/tlxy"
@@ -59,6 +60,7 @@ func init() {
 		tlcli.CobraHelper(&cmds.ServerCommand{}, pc, "server"),
 		tlcli.CobraHelper(&versionCommand{}, pc, "version"),
 		tlcli.CobraHelper(&cmds.DBMigrateCommand{}, pc, "dbmigrate"),
+		tlcli.CobraHelper(&dbmigratene.Command{}, pc, "dbmigrate-natural-earth"),
 		tlcli.CobraHelper(&cmds.FeedStateManagerCommand{}, pc, "feed-state"),
 		cmds.NewDmfrCommand(pc),
 		dmfrFormatCommand,

--- a/cmd/transitland/main.go
+++ b/cmd/transitland/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/interline-io/transitland-lib/cmds"
 	"github.com/interline-io/transitland-lib/cmds/dbmigratene"
 	"github.com/interline-io/transitland-lib/diff"
+	postgresSchema "github.com/interline-io/transitland-lib/schema/postgres"
 	"github.com/interline-io/transitland-lib/tlcli"
 	"github.com/interline-io/transitland-lib/tlxy"
 
@@ -59,7 +60,7 @@ func init() {
 		tlcli.CobraHelper(&tlxy.PolylinesCommand{}, pc, "polylines-create"),
 		tlcli.CobraHelper(&cmds.ServerCommand{}, pc, "server"),
 		tlcli.CobraHelper(&versionCommand{}, pc, "version"),
-		tlcli.CobraHelper(&cmds.DBMigrateCommand{}, pc, "dbmigrate"),
+		tlcli.CobraHelper(&postgresSchema.Command{}, pc, "dbmigrate"),
 		tlcli.CobraHelper(&dbmigratene.Command{}, pc, "dbmigrate-natural-earth"),
 		tlcli.CobraHelper(&cmds.FeedStateManagerCommand{}, pc, "feed-state"),
 		cmds.NewDmfrCommand(pc),

--- a/cmd/transitland/main.go
+++ b/cmd/transitland/main.go
@@ -8,8 +8,8 @@ import (
 	"github.com/interline-io/log"
 	tl "github.com/interline-io/transitland-lib"
 	"github.com/interline-io/transitland-lib/cmds"
-	"github.com/interline-io/transitland-lib/cmds/dbmigratene"
 	"github.com/interline-io/transitland-lib/diff"
+	neSchema "github.com/interline-io/transitland-lib/schema/ne"
 	postgresSchema "github.com/interline-io/transitland-lib/schema/postgres"
 	"github.com/interline-io/transitland-lib/tlcli"
 	"github.com/interline-io/transitland-lib/tlxy"
@@ -61,7 +61,7 @@ func init() {
 		tlcli.CobraHelper(&cmds.ServerCommand{}, pc, "server"),
 		tlcli.CobraHelper(&versionCommand{}, pc, "version"),
 		tlcli.CobraHelper(&postgresSchema.Command{}, pc, "dbmigrate"),
-		tlcli.CobraHelper(&dbmigratene.Command{}, pc, "dbmigrate-natural-earth"),
+		tlcli.CobraHelper(&neSchema.Command{}, pc, "dbmigrate-natural-earth"),
 		tlcli.CobraHelper(&cmds.FeedStateManagerCommand{}, pc, "feed-state"),
 		cmds.NewDmfrCommand(pc),
 		dmfrFormatCommand,

--- a/cmds/dbmigrate_cmd.go
+++ b/cmds/dbmigrate_cmd.go
@@ -1,12 +1,9 @@
 package cmds
 
 import (
-	"archive/zip"
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"strings"
 
@@ -16,16 +13,12 @@ import (
 	"github.com/golang-migrate/migrate/v4/source/iofs"
 	_ "github.com/golang-migrate/migrate/v4/source/iofs"
 	"github.com/rs/zerolog"
-	"github.com/twpayne/go-geom"
-	"github.com/twpayne/go-shapefile"
 
 	"github.com/interline-io/log"
-	"github.com/interline-io/transitland-lib/schema/ne"
 	postgressMigrations "github.com/interline-io/transitland-lib/schema/postgres"
 	"github.com/interline-io/transitland-lib/tlcli"
 	"github.com/interline-io/transitland-lib/tldb"
 	postgressAdapter "github.com/interline-io/transitland-lib/tldb/postgres"
-	"github.com/interline-io/transitland-lib/tt"
 
 	"github.com/spf13/pflag"
 )
@@ -37,7 +30,7 @@ type DBMigrateCommand struct {
 }
 
 func (cmd *DBMigrateCommand) HelpDesc() (string, string) {
-	return "Perform database migrations and load Natural Earth geographies", ""
+	return "Perform database migrations", ""
 }
 
 func (cmd *DBMigrateCommand) HelpArgs() string {
@@ -100,158 +93,12 @@ func (cmd *DBMigrateCommand) Run(ctx context.Context) error {
 		}
 		return err
 	case "natural-earth":
-		return cmd.neLoad(ctx)
+		return errors.New("natural-earth has moved to its own command; use 'transitland dbmigrate-natural-earth' instead")
 	case "down":
 		return errors.New("unsupported command")
 	}
 	return fmt.Errorf("unknown subcommand: %s", cmd.Subcommand)
 }
-
-func (cmd *DBMigrateCommand) neLoad(ctx context.Context) error {
-	var err error
-	err = fs.WalkDir(ne.EmbeddedNaturalEarthData, ".", func(path string, info fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if !strings.HasSuffix(path, ".zip") {
-			return nil
-		}
-		neZipData, err := ne.EmbeddedNaturalEarthData.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		switch path {
-		case "ne_10m_admin_1_states_provinces.zip":
-			return cmd.neProcess(ctx, neZipData, cmd.neLoadAdmins)
-		case "ne_10m_populated_places_simple.zip":
-			return cmd.neProcess(ctx, neZipData, cmd.neLoadPlaces)
-		}
-		return nil
-	})
-	return err
-}
-
-func (cmd *DBMigrateCommand) neProcess(ctx context.Context, neZipFile []byte, cb shpFileHandler) error {
-	ret := []neShape{}
-	zipReader, err := zip.NewReader(bytes.NewReader(neZipFile), int64(len(neZipFile)))
-	if err != nil {
-		return err
-	}
-	scanner, err := shapefile.NewScannerFromZipReader(zipReader, &shapefile.ReadShapefileOptions{
-		DBF: &shapefile.ReadDBFOptions{
-			SkipBrokenFields: true,
-		},
-	})
-	if err != nil {
-		return err
-	}
-	shapeFields := scanner.DBFFieldDescriptors()
-	for scanner.Next() {
-		shpGeom, _, shpRec := scanner.Scan()
-		if shpGeom == nil {
-			continue
-		}
-		t := neShape{}
-		t.attrs = map[string]string{}
-		for i, fieldDesc := range shapeFields {
-			fieldName := fieldDesc.Name
-			fieldValue := shpRec[i]
-			t.attrs[fieldName] = fmt.Sprintf("%v", fieldValue)
-		}
-		t.geometry = shpGeom.Geom
-		ret = append(ret, t)
-	}
-	return cb(ctx, cmd.Adapter, ret)
-}
-
-type shpFileHandler = func(context.Context, tldb.Adapter, []neShape) error
-
-type neShape struct {
-	geometry geom.T
-	attrs    map[string]string
-}
-
-//////////////////
-
-type neAdmin struct {
-	Name     tt.String   `db:"name"`
-	Admin    tt.String   `db:"admin"`
-	IsoName  tt.String   `db:"iso_3166_2"`
-	IsoA2    tt.String   `db:"iso_a2"`
-	Geometry tt.Geometry `db:"geometry"`
-}
-
-func (ent *neAdmin) TableName() string {
-	return "ne_10m_admin_1_states_provinces"
-}
-
-func (cmd *DBMigrateCommand) neLoadAdmins(ctx context.Context, atx tldb.Adapter, shapes []neShape) error {
-	var ents []any
-	for _, nes := range shapes {
-		ent := neAdmin{}
-		ent.Geometry = tt.NewGeometry(nes.geometry)
-		for k, val := range nes.attrs {
-			switch k {
-			case "admin":
-				ent.Admin.Set(val)
-			case "name":
-				ent.Name.Set(val)
-			case "iso_3166_2":
-				ent.IsoName.Set(val)
-			case "iso_a2":
-				ent.IsoA2.Set(val)
-			}
-		}
-		ents = append(ents, &ent)
-	}
-	log.Info().Msgf("Inserting %d admin boundaries", len(ents))
-	if _, err := cmd.Adapter.MultiInsert(ctx, ents); err != nil {
-		return err
-	}
-	return nil
-}
-
-//////////////////
-
-type nePlace struct {
-	Name     tt.String   `db:"name"`
-	Adm0Name tt.String   `db:"adm0name"`
-	Adm1Name tt.String   `db:"adm1name"`
-	IsoA2    tt.String   `db:"iso_a2"`
-	Geometry tt.Geometry `db:"geometry"`
-}
-
-func (ent *nePlace) TableName() string {
-	return "ne_10m_populated_places"
-}
-
-func (cmd *DBMigrateCommand) neLoadPlaces(ctx context.Context, atx tldb.Adapter, shapes []neShape) error {
-	var ents []any
-	for _, nes := range shapes {
-		ent := nePlace{}
-		ent.Geometry = tt.NewGeometry(nes.geometry)
-		for k, val := range nes.attrs {
-			switch k {
-			case "name":
-				ent.Name.Set(val)
-			case "adm0name":
-				ent.Adm0Name.Set(val)
-			case "adm1name":
-				ent.Adm1Name.Set(val)
-			case "iso_a2":
-				ent.IsoA2.Set(val)
-			}
-		}
-		ents = append(ents, &ent)
-	}
-	log.Info().Msgf("Inserting %d populated places", len(ents))
-	if _, err := cmd.Adapter.MultiInsert(ctx, ents); err != nil {
-		return err
-	}
-	return nil
-}
-
-/////////
 
 type migrationLogger struct {
 	log zerolog.Logger

--- a/cmds/dbmigratene/dbmigratene_cmd.go
+++ b/cmds/dbmigratene/dbmigratene_cmd.go
@@ -1,0 +1,191 @@
+// Package dbmigratene loads Natural Earth admin boundary and populated place
+// data into the transitland database. The Natural Earth shapefile data is
+// embedded via transitland-lib/schema/ne (~15MB), so this package is kept
+// separate from transitland-lib/cmds to keep that data out of consumer
+// binaries that only need the rest of cmds.
+package dbmigratene
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+
+	"github.com/interline-io/log"
+	"github.com/interline-io/transitland-lib/schema/ne"
+	"github.com/interline-io/transitland-lib/tldb"
+	postgresAdapter "github.com/interline-io/transitland-lib/tldb/postgres"
+	"github.com/interline-io/transitland-lib/tt"
+	"github.com/spf13/pflag"
+	"github.com/twpayne/go-geom"
+	"github.com/twpayne/go-shapefile"
+)
+
+type Command struct {
+	DBURL   string
+	Adapter tldb.Adapter
+}
+
+func (cmd *Command) HelpDesc() (string, string) {
+	return "Load Natural Earth admin boundaries and populated places into the database", ""
+}
+
+func (cmd *Command) AddFlags(fl *pflag.FlagSet) {
+	fl.StringVar(&cmd.DBURL, "dburl", "", "Database URL (default: $TL_DATABASE_URL)")
+}
+
+func (cmd *Command) Parse(args []string) error {
+	if cmd.DBURL == "" {
+		cmd.DBURL = os.Getenv("TL_DATABASE_URL")
+	}
+	return nil
+}
+
+func (cmd *Command) Run(ctx context.Context) error {
+	atx := postgresAdapter.PostgresAdapter{DBURL: cmd.DBURL}
+	db, err := atx.OpenDB()
+	if err != nil {
+		return err
+	}
+	defer atx.Close()
+	cmd.Adapter = postgresAdapter.NewPostgresAdapterFromDBX(db)
+
+	return fs.WalkDir(ne.EmbeddedNaturalEarthData, ".", func(path string, info fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !strings.HasSuffix(path, ".zip") {
+			return nil
+		}
+		neZipData, err := ne.EmbeddedNaturalEarthData.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		switch path {
+		case "ne_10m_admin_1_states_provinces.zip":
+			return cmd.processShapes(ctx, neZipData, cmd.loadAdmins)
+		case "ne_10m_populated_places_simple.zip":
+			return cmd.processShapes(ctx, neZipData, cmd.loadPlaces)
+		}
+		return nil
+	})
+}
+
+type shapeHandler = func(context.Context, tldb.Adapter, []neShape) error
+
+type neShape struct {
+	geometry geom.T
+	attrs    map[string]string
+}
+
+func (cmd *Command) processShapes(ctx context.Context, neZipFile []byte, cb shapeHandler) error {
+	ret := []neShape{}
+	zipReader, err := zip.NewReader(bytes.NewReader(neZipFile), int64(len(neZipFile)))
+	if err != nil {
+		return err
+	}
+	scanner, err := shapefile.NewScannerFromZipReader(zipReader, &shapefile.ReadShapefileOptions{
+		DBF: &shapefile.ReadDBFOptions{
+			SkipBrokenFields: true,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	shapeFields := scanner.DBFFieldDescriptors()
+	for scanner.Next() {
+		shpGeom, _, shpRec := scanner.Scan()
+		if shpGeom == nil {
+			continue
+		}
+		t := neShape{}
+		t.attrs = map[string]string{}
+		for i, fieldDesc := range shapeFields {
+			fieldName := fieldDesc.Name
+			fieldValue := shpRec[i]
+			t.attrs[fieldName] = fmt.Sprintf("%v", fieldValue)
+		}
+		t.geometry = shpGeom.Geom
+		ret = append(ret, t)
+	}
+	return cb(ctx, cmd.Adapter, ret)
+}
+
+type neAdmin struct {
+	Name     tt.String   `db:"name"`
+	Admin    tt.String   `db:"admin"`
+	IsoName  tt.String   `db:"iso_3166_2"`
+	IsoA2    tt.String   `db:"iso_a2"`
+	Geometry tt.Geometry `db:"geometry"`
+}
+
+func (ent *neAdmin) TableName() string {
+	return "ne_10m_admin_1_states_provinces"
+}
+
+func (cmd *Command) loadAdmins(ctx context.Context, atx tldb.Adapter, shapes []neShape) error {
+	var ents []any
+	for _, nes := range shapes {
+		ent := neAdmin{}
+		ent.Geometry = tt.NewGeometry(nes.geometry)
+		for k, val := range nes.attrs {
+			switch k {
+			case "admin":
+				ent.Admin.Set(val)
+			case "name":
+				ent.Name.Set(val)
+			case "iso_3166_2":
+				ent.IsoName.Set(val)
+			case "iso_a2":
+				ent.IsoA2.Set(val)
+			}
+		}
+		ents = append(ents, &ent)
+	}
+	log.Info().Msgf("Inserting %d admin boundaries", len(ents))
+	if _, err := cmd.Adapter.MultiInsert(ctx, ents); err != nil {
+		return err
+	}
+	return nil
+}
+
+type nePlace struct {
+	Name     tt.String   `db:"name"`
+	Adm0Name tt.String   `db:"adm0name"`
+	Adm1Name tt.String   `db:"adm1name"`
+	IsoA2    tt.String   `db:"iso_a2"`
+	Geometry tt.Geometry `db:"geometry"`
+}
+
+func (ent *nePlace) TableName() string {
+	return "ne_10m_populated_places"
+}
+
+func (cmd *Command) loadPlaces(ctx context.Context, atx tldb.Adapter, shapes []neShape) error {
+	var ents []any
+	for _, nes := range shapes {
+		ent := nePlace{}
+		ent.Geometry = tt.NewGeometry(nes.geometry)
+		for k, val := range nes.attrs {
+			switch k {
+			case "name":
+				ent.Name.Set(val)
+			case "adm0name":
+				ent.Adm0Name.Set(val)
+			case "adm1name":
+				ent.Adm1Name.Set(val)
+			case "iso_a2":
+				ent.IsoA2.Set(val)
+			}
+		}
+		ents = append(ents, &ent)
+	}
+	log.Info().Msgf("Inserting %d populated places", len(ents))
+	if _, err := cmd.Adapter.MultiInsert(ctx, ents); err != nil {
+		return err
+	}
+	return nil
+}

--- a/doc/cli/transitland.md
+++ b/doc/cli/transitland.md
@@ -13,7 +13,8 @@ transitland-lib utilities
 * [transitland checksum](transitland_checksum.md)	 - Calculate the SHA1 checksum of a static GTFS feed
 * [transitland completion](transitland_completion.md)	 - Generate the autocompletion script for the specified shell
 * [transitland copy](transitland_copy.md)	 - Copy performs a basic copy from a reader to a writer.
-* [transitland dbmigrate](transitland_dbmigrate.md)	 - Perform database migrations and load Natural Earth geographies
+* [transitland dbmigrate](transitland_dbmigrate.md)	 - Perform database migrations
+* [transitland dbmigrate-natural-earth](transitland_dbmigrate-natural-earth.md)	 - Load Natural Earth admin boundaries and populated places into the database
 * [transitland delete](transitland_delete.md)	 - Delete feed versions
 * [transitland diff](transitland_diff.md)	 - Calculate difference between two feeds, writing output in a GTFS-like format
 * [transitland dmfr](transitland_dmfr.md)	 - DMFR commands

--- a/doc/cli/transitland_dbmigrate-natural-earth.md
+++ b/doc/cli/transitland_dbmigrate-natural-earth.md
@@ -1,0 +1,25 @@
+## transitland dbmigrate-natural-earth
+
+Load Natural Earth admin boundaries and populated places into the database
+
+### Synopsis
+
+Load Natural Earth admin boundaries and populated places into the database
+
+
+
+```
+transitland dbmigrate-natural-earth [flags]
+```
+
+### Options
+
+```
+      --dburl string   Database URL (default: $TL_DATABASE_URL)
+  -h, --help           help for dbmigrate-natural-earth
+```
+
+### SEE ALSO
+
+* [transitland](transitland.md)	 - transitland-lib utilities
+

--- a/doc/cli/transitland_dbmigrate.md
+++ b/doc/cli/transitland_dbmigrate.md
@@ -1,10 +1,10 @@
 ## transitland dbmigrate
 
-Perform database migrations and load Natural Earth geographies
+Perform database migrations
 
 ### Synopsis
 
-Perform database migrations and load Natural Earth geographies
+Perform database migrations
 
 
 

--- a/schema/ne/dbmigrate_cmd.go
+++ b/schema/ne/dbmigrate_cmd.go
@@ -1,9 +1,4 @@
-// Package dbmigratene loads Natural Earth admin boundary and populated place
-// data into the transitland database. The Natural Earth shapefile data is
-// embedded via transitland-lib/schema/ne (~15MB), so this package is kept
-// separate from transitland-lib/cmds to keep that data out of consumer
-// binaries that only need the rest of cmds.
-package dbmigratene
+package ne
 
 import (
 	"archive/zip"
@@ -15,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/interline-io/log"
-	"github.com/interline-io/transitland-lib/schema/ne"
 	"github.com/interline-io/transitland-lib/tldb"
 	postgresAdapter "github.com/interline-io/transitland-lib/tldb/postgres"
 	"github.com/interline-io/transitland-lib/tt"
@@ -23,6 +17,11 @@ import (
 	"github.com/twpayne/go-geom"
 	"github.com/twpayne/go-shapefile"
 )
+
+// Command loads Natural Earth admin boundaries and populated places into a
+// Postgres database. Lives next to the embedded shapefile data so consumers
+// that don't need to run this loader don't transitively pull the ~15MB of
+// zip files in by importing transitland-lib/cmds.
 
 type Command struct {
 	DBURL   string
@@ -53,14 +52,14 @@ func (cmd *Command) Run(ctx context.Context) error {
 	defer atx.Close()
 	cmd.Adapter = postgresAdapter.NewPostgresAdapterFromDBX(db)
 
-	return fs.WalkDir(ne.EmbeddedNaturalEarthData, ".", func(path string, info fs.DirEntry, err error) error {
+	return fs.WalkDir(EmbeddedNaturalEarthData, ".", func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if !strings.HasSuffix(path, ".zip") {
 			return nil
 		}
-		neZipData, err := ne.EmbeddedNaturalEarthData.ReadFile(path)
+		neZipData, err := EmbeddedNaturalEarthData.ReadFile(path)
 		if err != nil {
 			return err
 		}

--- a/schema/postgres/bootstrap.sh
+++ b/schema/postgres/bootstrap.sh
@@ -20,7 +20,7 @@ createdb "${PGDATABASE}"
 transitland dbmigrate up
 
 # Load Natural Earth - ogr2ogr is required for this.
-transitland dbmigrate natural-earth
+transitland dbmigrate-natural-earth
 
 # Import GTFS feeds from directories or DMFR files
 for arg in "$@"; do

--- a/schema/postgres/dbmigrate_cmd.go
+++ b/schema/postgres/dbmigrate_cmd.go
@@ -1,4 +1,4 @@
-package cmds
+package postgres
 
 import (
 	"context"
@@ -8,41 +8,41 @@ import (
 	"strings"
 
 	"github.com/golang-migrate/migrate/v4"
-	"github.com/golang-migrate/migrate/v4/database/postgres"
-	_ "github.com/golang-migrate/migrate/v4/database/postgres"
+	migratepg "github.com/golang-migrate/migrate/v4/database/postgres"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
-	_ "github.com/golang-migrate/migrate/v4/source/iofs"
 	"github.com/rs/zerolog"
 
 	"github.com/interline-io/log"
-	postgressMigrations "github.com/interline-io/transitland-lib/schema/postgres"
 	"github.com/interline-io/transitland-lib/tlcli"
 	"github.com/interline-io/transitland-lib/tldb"
-	postgressAdapter "github.com/interline-io/transitland-lib/tldb/postgres"
+	postgresAdapter "github.com/interline-io/transitland-lib/tldb/postgres"
 
 	"github.com/spf13/pflag"
 )
 
-type DBMigrateCommand struct {
+// Command runs schema migrations against a Postgres database using the
+// migrations embedded in this package. Lives next to the embedded migrations
+// so consumers that don't need to run dbmigrate don't transitively pull them
+// in by importing transitland-lib/cmds.
+type Command struct {
 	DBURL      string
 	Subcommand string
 	Adapter    tldb.Adapter
 }
 
-func (cmd *DBMigrateCommand) HelpDesc() (string, string) {
+func (cmd *Command) HelpDesc() (string, string) {
 	return "Perform database migrations", ""
 }
 
-func (cmd *DBMigrateCommand) HelpArgs() string {
+func (cmd *Command) HelpArgs() string {
 	return "[flags] <subcommand>"
 }
 
-func (cmd *DBMigrateCommand) AddFlags(fl *pflag.FlagSet) {
+func (cmd *Command) AddFlags(fl *pflag.FlagSet) {
 	fl.StringVar(&cmd.DBURL, "dburl", "", "Database URL (default: $TL_DATABASE_URL)")
 }
 
-// Parse command line options.
-func (cmd *DBMigrateCommand) Parse(args []string) error {
+func (cmd *Command) Parse(args []string) error {
 	fl := tlcli.NewNArgs(args)
 	if fl.NArg() == 0 {
 		return errors.New("subcommand required")
@@ -54,31 +54,29 @@ func (cmd *DBMigrateCommand) Parse(args []string) error {
 	return nil
 }
 
-// Run this command.
-func (cmd *DBMigrateCommand) Run(ctx context.Context) error {
-	atx := postgressAdapter.PostgresAdapter{DBURL: cmd.DBURL}
+func (cmd *Command) Run(ctx context.Context) error {
+	atx := postgresAdapter.PostgresAdapter{DBURL: cmd.DBURL}
 	db, err := atx.OpenDB()
 	if err != nil {
 		return err
 	}
 	defer atx.Close()
-	cmd.Adapter = postgressAdapter.NewPostgresAdapterFromDBX(db)
+	cmd.Adapter = postgresAdapter.NewPostgresAdapterFromDBX(db)
 
-	_ = postgressMigrations.EmbeddedMigrations
-	driver, err := postgres.WithInstance(db.DB, &postgres.Config{})
+	driver, err := migratepg.WithInstance(db.DB, &migratepg.Config{})
 	if err != nil {
 		return err
 	}
-	_ = driver
-	source, err := iofs.New(postgressMigrations.EmbeddedMigrations, "migrations")
+	source, err := iofs.New(EmbeddedMigrations, "migrations")
 	if err != nil {
 		return err
 	}
 	m, err := migrate.NewWithInstance("iofs", source, "postgres", driver)
-	m.Log = &migrationLogger{log: log.Logger.With().Logger()}
 	if err != nil {
 		return err
 	}
+	m.Log = &migrationLogger{log: log.Logger.With().Logger()}
+
 	switch cmd.Subcommand {
 	case "up":
 		log.Info().Msg("Running migrations...")

--- a/testdata/test_setup.sh
+++ b/testdata/test_setup.sh
@@ -63,7 +63,7 @@ createdb "$PGDATABASE"
 
 # Run migrations
 transitland dbmigrate --dburl="$TL_TEST_DATABASE_URL" up
-transitland dbmigrate --dburl="$TL_TEST_DATABASE_URL" natural-earth
+transitland dbmigrate-natural-earth --dburl="$TL_TEST_DATABASE_URL"
 
 #########################
 # Migrate and init server database
@@ -79,7 +79,7 @@ createdb "$PGDATABASE"
 
 # Run migrations
 transitland dbmigrate --dburl="$TL_TEST_SERVER_DATABASE_URL" up
-transitland dbmigrate --dburl="$TL_TEST_SERVER_DATABASE_URL" natural-earth
+transitland dbmigrate-natural-earth --dburl="$TL_TEST_SERVER_DATABASE_URL"
 
 # Remove import files
 transitland sync --dburl="$TL_TEST_SERVER_DATABASE_URL" "$SCRIPTDIR/server/server-test.dmfr.json"


### PR DESCRIPTION
## Summary
Move both the schema migration loader and the Natural Earth shapefile loader out of `transitland-lib/cmds` and into the packages that own the embedded data, in mirrored locations: `schema/postgres/` (migrations + `dbmigrate`) and `schema/ne/` (Natural Earth shapefiles + `dbmigrate-natural-earth`). Anything importing `transitland-lib/cmds` no longer transitively embeds the ~424KB of `schema/postgres/migrations/*.pgsql` files or the ~15MB of `schema/ne/*.zip` shapefiles. CLI surface preserved: `transitland dbmigrate` still applies schema migrations, and `transitland dbmigrate-natural-earth` is a new sibling command for the one-shot Natural Earth load.

### Postgres migrations
- `cmds/dbmigrate_cmd.go` moved to `schema/postgres/dbmigrate_cmd.go` (now in `package postgres`, next to the existing `EmbeddedMigrations` `embed.FS`)
- `DBMigrateCommand` renamed to `Command`; uses the package-local `EmbeddedMigrations` directly instead of importing its own package via alias
- `migrate/v4/database/postgres` aliased as `migratepg` to avoid the new package-name collision; redundant `_` blank imports of the named `migrate/v4/database/postgres` and `migrate/v4/source/iofs` packages removed
- `cmd/transitland/main.go` registers `postgresSchema.Command{}` as `dbmigrate` — no CLI surface change

### Natural Earth loader
- Natural Earth loader moved to `schema/ne/dbmigrate_cmd.go` (in `package ne`, next to the existing `EmbeddedNaturalEarthData` `embed.FS`); uses the package-local var directly
- Defines `Command` plus the `neShape`/`neAdmin`/`nePlace` types and the `processShapes`/`loadAdmins`/`loadPlaces` methods
- `schema/ne` is now the only package in transitland-lib that references the embedded shapefile zips
- `cmd/transitland/main.go` registers `neSchema.Command{}` as `dbmigrate-natural-earth`
- The legacy `transitland dbmigrate natural-earth` invocation returns an error pointing users to the new command:
  > `natural-earth has moved to its own command; use 'transitland dbmigrate-natural-earth' instead`

### Internal scripts and docs updated
- `schema/postgres/bootstrap.sh` and `testdata/test_setup.sh` use the new `transitland dbmigrate-natural-earth` invocation
- `doc/cli/*.md` regenerated via `transitland gendoc`

### Bonus: latent nil-deref fix
The pre-refactor `cmds/dbmigrate_cmd.go` set `m.Log = ...` before checking the `err` returned by `migrate.NewWithInstance(...)`. That constructor returns `(nil, err)` on failure, so any failure would have panicked on the assignment. The refactored `schema/postgres/dbmigrate_cmd.go` reorders the `if err != nil { return err }` check to run before the `m.Log` assignment.

### Result for consumer binaries
A throwaway module importing only `transitland-lib/cmds` confirms via `go list -deps` that `schema/postgres`, `schema/ne`, and the `golang-migrate/migrate/v4/*` packages are all gone from its dependency graph.

## Test plan
- `go build ./...` and `go vet ./...`
- `transitland dbmigrate --help` shows the same flags and description as before
- `transitland dbmigrate-natural-earth --help` shows the new subcommand and its `--dburl` flag
- Against a fresh database: `transitland dbmigrate up && transitland dbmigrate-natural-earth --dburl=...` populates the schema and the `ne_10m_admin_1_states_provinces` / `ne_10m_populated_places` tables
- `transitland dbmigrate natural-earth` (legacy form) exits non-zero with the migration-path error message
- `./testdata/test_setup.sh` completes end-to-end against `$TL_TEST_DATABASE_URL` / `$TL_TEST_SERVER_DATABASE_URL`