### PR TITLE
Context enrichers

### DIFF
--- a/server/auth/mw/enrich/enrich.go
+++ b/server/auth/mw/enrich/enrich.go
@@ -1,0 +1,48 @@
+// Package enrich provides an HTTP middleware that runs a context-enriching
+// step after the bare user has been stamped in (by JWT/header/etc.) and
+// before downstream handlers run. Typical enrichers inflate roles from an
+// upstream service, attach private-feed access lists, or stash a
+// permissions/rate-limit struct on the context.
+//
+// The Enricher interface is declared here at the consumer; the same shape
+// is re-declared in the jobs package for the worker-side adapter. Concrete
+// enrichers satisfy both via structural typing.
+package enrich
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// Enricher returns a new context derived from the input, or an error if a
+// required lookup fails. Implementations should return (ctx, nil) when
+// there is nothing to enrich (for example, no user in context); only return
+// a non-nil error when an enrichment lookup itself failed.
+type Enricher interface {
+	EnrichContext(ctx context.Context) (context.Context, error)
+}
+
+// NewMiddleware adapts an Enricher to a chi/net-http middleware. On success
+// the downstream handler sees the enriched context. On error the middleware
+// writes a JSON 401 and the downstream handler is not called.
+func NewMiddleware(e Enricher) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx, err := e.EnrichContext(r.Context())
+			if err != nil {
+				writeJsonError(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+				return
+			}
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+func writeJsonError(w http.ResponseWriter, msg string, statusCode int) {
+	a := map[string]string{"error": msg}
+	jj, _ := json.Marshal(&a)
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	w.Write(jj)
+}

--- a/server/auth/mw/enrich/enrich_test.go
+++ b/server/auth/mw/enrich/enrich_test.go
@@ -1,0 +1,61 @@
+package enrich
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type ctxKey string
+
+const tagKey ctxKey = "enrich-test-tag"
+
+// stubEnricher stamps tag onto ctx unless err is set, in which case it
+// returns the error and the original context.
+type stubEnricher struct {
+	tag string
+	err error
+}
+
+func (s stubEnricher) EnrichContext(ctx context.Context) (context.Context, error) {
+	if s.err != nil {
+		return ctx, s.err
+	}
+	return context.WithValue(ctx, tagKey, s.tag), nil
+}
+
+func TestMiddleware_Success(t *testing.T) {
+	var gotTag string
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		gotTag, _ = r.Context().Value(tagKey).(string)
+	})
+
+	mw := NewMiddleware(stubEnricher{tag: "enriched"})
+	rr := httptest.NewRecorder()
+	mw(next).ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	assert.True(t, called, "downstream handler should be called on success")
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "enriched", gotTag)
+}
+
+func TestMiddleware_ErrorReturns401(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	mw := NewMiddleware(stubEnricher{err: errors.New("lookup failed")})
+	rr := httptest.NewRecorder()
+	mw(next).ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	assert.False(t, called, "downstream handler must not run on enrichment error")
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+}

--- a/server/jobs/enrich.go
+++ b/server/jobs/enrich.go
@@ -1,0 +1,36 @@
+package jobs
+
+import "context"
+
+// Enricher returns a new context derived from the input, or an error if a
+// required lookup fails. Implementations should return (ctx, nil) when
+// there is nothing to enrich; only return a non-nil error when an
+// enrichment lookup itself failed.
+//
+// The same shape is declared in server/auth/mw/enrich for the HTTP-side
+// adapter; concrete enrichers satisfy both via structural typing.
+type Enricher interface {
+	EnrichContext(ctx context.Context) (context.Context, error)
+}
+
+// NewEnrichMiddleware adapts an Enricher to a Runner Middleware. On success
+// the wrapped Worker.Run sees the enriched context. On error the wrapped
+// Worker.Run is not called and the error is returned as the job result.
+func NewEnrichMiddleware(e Enricher) Middleware {
+	return func(next Worker, _ Job) Worker {
+		return &enrichWorker{enricher: e, Worker: next}
+	}
+}
+
+type enrichWorker struct {
+	enricher Enricher
+	Worker
+}
+
+func (w *enrichWorker) Run(ctx context.Context) error {
+	ctx, err := w.enricher.EnrichContext(ctx)
+	if err != nil {
+		return err
+	}
+	return w.Worker.Run(ctx)
+}

--- a/server/jobs/enrich_test.go
+++ b/server/jobs/enrich_test.go
@@ -1,0 +1,68 @@
+package jobs
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type ctxKey string
+
+const tagKey ctxKey = "enrich-test-tag"
+
+type stubEnricher struct {
+	tag string
+	err error
+}
+
+func (s stubEnricher) EnrichContext(ctx context.Context) (context.Context, error) {
+	if s.err != nil {
+		return ctx, s.err
+	}
+	return context.WithValue(ctx, tagKey, s.tag), nil
+}
+
+type stubWorker struct {
+	called bool
+	gotTag string
+	retErr error
+}
+
+func (s *stubWorker) Kind() string { return "stub" }
+
+func (s *stubWorker) Run(ctx context.Context) error {
+	s.called = true
+	s.gotTag, _ = ctx.Value(tagKey).(string)
+	return s.retErr
+}
+
+func TestEnrichMiddleware_Success(t *testing.T) {
+	worker := &stubWorker{}
+	mw := NewEnrichMiddleware(stubEnricher{tag: "enriched"})
+	wrapped := mw(worker, Job{})
+
+	err := wrapped.Run(context.Background())
+	assert.NoError(t, err)
+	assert.True(t, worker.called, "wrapped worker should run on success")
+	assert.Equal(t, "enriched", worker.gotTag)
+}
+
+func TestEnrichMiddleware_ErrorBlocksWorker(t *testing.T) {
+	worker := &stubWorker{}
+	enrichErr := errors.New("lookup failed")
+	mw := NewEnrichMiddleware(stubEnricher{err: enrichErr})
+	wrapped := mw(worker, Job{})
+
+	err := wrapped.Run(context.Background())
+	assert.ErrorIs(t, err, enrichErr)
+	assert.False(t, worker.called, "wrapped worker must not run on enrichment error")
+}
+
+func TestEnrichMiddleware_PreservesKind(t *testing.T) {
+	worker := &stubWorker{}
+	mw := NewEnrichMiddleware(stubEnricher{tag: "enriched"})
+	wrapped := mw(worker, Job{})
+	assert.Equal(t, "stub", wrapped.Kind(), "Kind should pass through to the wrapped worker")
+}


### PR DESCRIPTION
## Summary

Adds a small `Enricher` abstraction for running context-enriching steps after a bare user is stamped into context but before downstream code runs. Two thin shells — an HTTP middleware in `server/auth/mw/enrich` and a worker middleware in `server/jobs` — let the same concrete enricher (for example, an upstream-service user inflater or a private-feed allowlist resolver) drive both transports without duplicating its body. No call sites yet; downstream binaries compose the wiring.

### HTTP enricher
- New `server/auth/mw/enrich` package with `Enricher` interface (`EnrichContext(ctx) (context.Context, error)`) and `NewMiddleware` adapter for chi / `net/http`.
- On success the downstream handler sees the enriched context; on a non-nil error the middleware writes a JSON 401 and stops the chain.

### Worker enricher
- `server/jobs/enrich.go` declares the same `Enricher` interface at the consumer (per Go's "consumer defines the interface" idiom) so the lib does not introduce a shared package just to host the type.
- `NewEnrichMiddleware` adapts an `Enricher` to a `Runner` `Middleware`; on success the wrapped `Worker.Run` sees the enriched context, on error the wrapped worker is not invoked and the error becomes the job result. `Kind()` passes through.

### Design
- The two `Enricher` interfaces are structurally identical and declared independently in each consumer package; concrete enrichers satisfy both via Go's structural typing, with no third "shared interface" package.
- Lib stays generic — there are no concrete enrichers in this PR. Downstream binaries compose their own (role inflation, permission allowlists, rate-limit struct attachment) and wire one instance into both transports.

## Test plan
- Build a downstream binary that wraps a stub `Enricher` (writes a sentinel to ctx) with `enrich.NewMiddleware`, hit any chi route, and confirm a handler reads the sentinel back from the request context.
- Make the same stub return an error and confirm the response is `401 application/json` and the handler is skipped.
- In a `jobs.Runner`, register the same enricher via `jobs.NewEnrichMiddleware(...)`, dispatch a job whose `Worker.Run` reads the sentinel, and confirm it sees the enriched value.
- Make the enricher return an error in the worker path and confirm `Worker.Run` is not called and the runner surfaces the error as the job's failure.
