### PR TITLE
Back out GraphQL mutations for permissions

### DIFF
--- a/internal/generated/gqlout/generated.go
+++ b/internal/generated/gqlout/generated.go
@@ -851,21 +851,15 @@ type ComplexityRoot struct {
 		FeedVersionImport   func(childComplexity int, id int) int
 		FeedVersionUnimport func(childComplexity int, id int) int
 		FeedVersionUpdate   func(childComplexity int, set model.FeedVersionSetInput) int
-		GroupSave           func(childComplexity int, id int, input model.GroupInput) int
 		LevelCreate         func(childComplexity int, set model.LevelSetInput) int
 		LevelDelete         func(childComplexity int, id int) int
 		LevelUpdate         func(childComplexity int, set model.LevelSetInput) int
 		PathwayCreate       func(childComplexity int, set model.PathwaySetInput) int
 		PathwayDelete       func(childComplexity int, id int) int
 		PathwayUpdate       func(childComplexity int, set model.PathwaySetInput) int
-		PermissionAdd       func(childComplexity int, typeArg string, id int, input model.PermissionInput) int
-		PermissionRemove    func(childComplexity int, typeArg string, id int, input model.PermissionInput) int
-		PermissionSetParent func(childComplexity int, typeArg string, id int, input model.SetParentInput) int
 		StopCreate          func(childComplexity int, set model.StopSetInput) int
 		StopDelete          func(childComplexity int, id int) int
 		StopUpdate          func(childComplexity int, set model.StopSetInput) int
-		TenantCreateGroup   func(childComplexity int, id int, input model.GroupInput) int
-		TenantSave          func(childComplexity int, id int, input model.TenantInput) int
 		ValidateGtfs        func(childComplexity int, file *graphql.Upload, url *string, realtimeUrls []string) int
 	}
 
@@ -1484,12 +1478,6 @@ type MutationResolver interface {
 	PathwayCreate(ctx context.Context, set model.PathwaySetInput) (*model.Pathway, error)
 	PathwayUpdate(ctx context.Context, set model.PathwaySetInput) (*model.Pathway, error)
 	PathwayDelete(ctx context.Context, id int) (*model.EntityDeleteResult, error)
-	PermissionAdd(ctx context.Context, typeArg string, id int, input model.PermissionInput) (bool, error)
-	PermissionRemove(ctx context.Context, typeArg string, id int, input model.PermissionInput) (bool, error)
-	PermissionSetParent(ctx context.Context, typeArg string, id int, input model.SetParentInput) (bool, error)
-	TenantSave(ctx context.Context, id int, input model.TenantInput) (*model.Tenant, error)
-	TenantCreateGroup(ctx context.Context, id int, input model.GroupInput) (*model.Group, error)
-	GroupSave(ctx context.Context, id int, input model.GroupInput) (*model.Group, error)
 }
 type OperatorResolver interface {
 	Agencies(ctx context.Context, obj *model.Operator) ([]*model.Agency, error)
@@ -5683,18 +5671,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.FeedVersionUpdate(childComplexity, args["set"].(model.FeedVersionSetInput)), true
 
-	case "Mutation.group_save":
-		if e.complexity.Mutation.GroupSave == nil {
-			break
-		}
-
-		args, err := ec.field_Mutation_group_save_args(ctx, rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Mutation.GroupSave(childComplexity, args["id"].(int), args["input"].(model.GroupInput)), true
-
 	case "Mutation.level_create":
 		if e.complexity.Mutation.LevelCreate == nil {
 			break
@@ -5767,42 +5743,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.PathwayUpdate(childComplexity, args["set"].(model.PathwaySetInput)), true
 
-	case "Mutation.permission_add":
-		if e.complexity.Mutation.PermissionAdd == nil {
-			break
-		}
-
-		args, err := ec.field_Mutation_permission_add_args(ctx, rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Mutation.PermissionAdd(childComplexity, args["type"].(string), args["id"].(int), args["input"].(model.PermissionInput)), true
-
-	case "Mutation.permission_remove":
-		if e.complexity.Mutation.PermissionRemove == nil {
-			break
-		}
-
-		args, err := ec.field_Mutation_permission_remove_args(ctx, rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Mutation.PermissionRemove(childComplexity, args["type"].(string), args["id"].(int), args["input"].(model.PermissionInput)), true
-
-	case "Mutation.permission_set_parent":
-		if e.complexity.Mutation.PermissionSetParent == nil {
-			break
-		}
-
-		args, err := ec.field_Mutation_permission_set_parent_args(ctx, rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Mutation.PermissionSetParent(childComplexity, args["type"].(string), args["id"].(int), args["input"].(model.SetParentInput)), true
-
 	case "Mutation.stop_create":
 		if e.complexity.Mutation.StopCreate == nil {
 			break
@@ -5838,30 +5778,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Mutation.StopUpdate(childComplexity, args["set"].(model.StopSetInput)), true
-
-	case "Mutation.tenant_create_group":
-		if e.complexity.Mutation.TenantCreateGroup == nil {
-			break
-		}
-
-		args, err := ec.field_Mutation_tenant_create_group_args(ctx, rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Mutation.TenantCreateGroup(childComplexity, args["id"].(int), args["input"].(model.GroupInput)), true
-
-	case "Mutation.tenant_save":
-		if e.complexity.Mutation.TenantSave == nil {
-			break
-		}
-
-		args, err := ec.field_Mutation_tenant_save_args(ctx, rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Mutation.TenantSave(childComplexity, args["id"].(int), args["input"].(model.TenantInput)), true
 
 	case "Mutation.validate_gtfs":
 		if e.complexity.Mutation.ValidateGtfs == nil {
@@ -8664,7 +8580,6 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputFocusPoint,
 		ec.unmarshalInputGbfsBikeRequest,
 		ec.unmarshalInputGbfsDockRequest,
-		ec.unmarshalInputGroupInput,
 		ec.unmarshalInputLevelSetInput,
 		ec.unmarshalInputLicenseFilter,
 		ec.unmarshalInputLocationFilter,
@@ -8672,7 +8587,6 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputOperatorFilter,
 		ec.unmarshalInputPathwayFilter,
 		ec.unmarshalInputPathwaySetInput,
-		ec.unmarshalInputPermissionInput,
 		ec.unmarshalInputPlaceFilter,
 		ec.unmarshalInputPointRadius,
 		ec.unmarshalInputRouteFilter,
@@ -8680,7 +8594,6 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputSegmentFilter,
 		ec.unmarshalInputSegmentPatternFilter,
 		ec.unmarshalInputServiceCoversFilter,
-		ec.unmarshalInputSetParentInput,
 		ec.unmarshalInputStopBuffer,
 		ec.unmarshalInputStopExternalReferenceSetInput,
 		ec.unmarshalInputStopFilter,
@@ -8688,7 +8601,6 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputStopObservationFilter,
 		ec.unmarshalInputStopSetInput,
 		ec.unmarshalInputStopTimeFilter,
-		ec.unmarshalInputTenantInput,
 		ec.unmarshalInputTripFilter,
 		ec.unmarshalInputTripStopTimeFilter,
 		ec.unmarshalInputUserFilter,
@@ -9664,36 +9576,6 @@ type Group {
   permissions: Permissions
 }
 
-"""Input for adding or removing a permission"""
-input PermissionInput {
-  "Subject type (e.g. user, tenant, group)"
-  subject_type: String!
-  "Subject identifier"
-  subject_id: String!
-  "Relationship to grant (e.g. viewer, editor, manager, admin, member)"
-  relation: String!
-}
-
-"""Input for setting an entity's parent"""
-input SetParentInput {
-  "Parent entity type"
-  parent_type: String!
-  "Parent entity ID"
-  parent_id: Int!
-}
-
-"""Input for saving a tenant"""
-input TenantInput {
-  "Tenant name"
-  name: String!
-}
-
-"""Input for saving a group"""
-input GroupInput {
-  "Group name"
-  name: String!
-}
-
 """A user in the authorization system"""
 type User {
   "User identifier"
@@ -9719,21 +9601,6 @@ extend type Query {
   groups(limit: Int, ids: [Int!]): [Group!]!
   "Search for users"
   users(limit: Int, where: UserFilter): [User!]!
-}
-
-extend type Mutation {
-  "Add a permission to an entity"
-  permission_add(type: String!, id: Int!, input: PermissionInput!): Boolean!
-  "Remove a permission from an entity"
-  permission_remove(type: String!, id: Int!, input: PermissionInput!): Boolean!
-  "Set an entity's parent in the authorization hierarchy"
-  permission_set_parent(type: String!, id: Int!, input: SetParentInput!): Boolean!
-  "Update a tenant's name"
-  tenant_save(id: Int!, input: TenantInput!): Tenant!
-  "Create a group within a tenant"
-  tenant_create_group(id: Int!, input: GroupInput!): Group!
-  "Update a group's name"
-  group_save(id: Int!, input: GroupInput!): Group!
 }
 
 extend type Feed {
@@ -13484,22 +13351,6 @@ func (ec *executionContext) field_Mutation_feed_version_update_args(ctx context.
 	return args, nil
 }
 
-func (ec *executionContext) field_Mutation_group_save_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
-	var err error
-	args := map[string]any{}
-	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "id", ec.unmarshalNInt2int)
-	if err != nil {
-		return nil, err
-	}
-	args["id"] = arg0
-	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNGroupInput2githubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐGroupInput)
-	if err != nil {
-		return nil, err
-	}
-	args["input"] = arg1
-	return args, nil
-}
-
 func (ec *executionContext) field_Mutation_level_create_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -13566,69 +13417,6 @@ func (ec *executionContext) field_Mutation_pathway_update_args(ctx context.Conte
 	return args, nil
 }
 
-func (ec *executionContext) field_Mutation_permission_add_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
-	var err error
-	args := map[string]any{}
-	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "type", ec.unmarshalNString2string)
-	if err != nil {
-		return nil, err
-	}
-	args["type"] = arg0
-	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "id", ec.unmarshalNInt2int)
-	if err != nil {
-		return nil, err
-	}
-	args["id"] = arg1
-	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNPermissionInput2githubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐPermissionInput)
-	if err != nil {
-		return nil, err
-	}
-	args["input"] = arg2
-	return args, nil
-}
-
-func (ec *executionContext) field_Mutation_permission_remove_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
-	var err error
-	args := map[string]any{}
-	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "type", ec.unmarshalNString2string)
-	if err != nil {
-		return nil, err
-	}
-	args["type"] = arg0
-	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "id", ec.unmarshalNInt2int)
-	if err != nil {
-		return nil, err
-	}
-	args["id"] = arg1
-	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNPermissionInput2githubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐPermissionInput)
-	if err != nil {
-		return nil, err
-	}
-	args["input"] = arg2
-	return args, nil
-}
-
-func (ec *executionContext) field_Mutation_permission_set_parent_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
-	var err error
-	args := map[string]any{}
-	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "type", ec.unmarshalNString2string)
-	if err != nil {
-		return nil, err
-	}
-	args["type"] = arg0
-	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "id", ec.unmarshalNInt2int)
-	if err != nil {
-		return nil, err
-	}
-	args["id"] = arg1
-	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNSetParentInput2githubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐSetParentInput)
-	if err != nil {
-		return nil, err
-	}
-	args["input"] = arg2
-	return args, nil
-}
-
 func (ec *executionContext) field_Mutation_stop_create_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -13659,38 +13447,6 @@ func (ec *executionContext) field_Mutation_stop_update_args(ctx context.Context,
 		return nil, err
 	}
 	args["set"] = arg0
-	return args, nil
-}
-
-func (ec *executionContext) field_Mutation_tenant_create_group_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
-	var err error
-	args := map[string]any{}
-	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "id", ec.unmarshalNInt2int)
-	if err != nil {
-		return nil, err
-	}
-	args["id"] = arg0
-	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNGroupInput2githubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐGroupInput)
-	if err != nil {
-		return nil, err
-	}
-	args["input"] = arg1
-	return args, nil
-}
-
-func (ec *executionContext) field_Mutation_tenant_save_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
-	var err error
-	args := map[string]any{}
-	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "id", ec.unmarshalNInt2int)
-	if err != nil {
-		return nil, err
-	}
-	args["id"] = arg0
-	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "input", ec.unmarshalNTenantInput2githubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐTenantInput)
-	if err != nil {
-		return nil, err
-	}
-	args["input"] = arg1
 	return args, nil
 }
 
@@ -42196,370 +41952,6 @@ func (ec *executionContext) fieldContext_Mutation_pathway_delete(ctx context.Con
 	return fc, nil
 }
 
-func (ec *executionContext) _Mutation_permission_add(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mutation_permission_add(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().PermissionAdd(rctx, fc.Args["type"].(string), fc.Args["id"].(int), fc.Args["input"].(model.PermissionInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(bool)
-	fc.Result = res
-	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Mutation_permission_add(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Mutation",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Boolean does not have child fields")
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_permission_add_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Mutation_permission_remove(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mutation_permission_remove(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().PermissionRemove(rctx, fc.Args["type"].(string), fc.Args["id"].(int), fc.Args["input"].(model.PermissionInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(bool)
-	fc.Result = res
-	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Mutation_permission_remove(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Mutation",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Boolean does not have child fields")
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_permission_remove_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Mutation_permission_set_parent(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mutation_permission_set_parent(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().PermissionSetParent(rctx, fc.Args["type"].(string), fc.Args["id"].(int), fc.Args["input"].(model.SetParentInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(bool)
-	fc.Result = res
-	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Mutation_permission_set_parent(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Mutation",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Boolean does not have child fields")
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_permission_set_parent_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Mutation_tenant_save(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mutation_tenant_save(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().TenantSave(rctx, fc.Args["id"].(int), fc.Args["input"].(model.TenantInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*model.Tenant)
-	fc.Result = res
-	return ec.marshalNTenant2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐTenant(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Mutation_tenant_save(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Mutation",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Tenant_id(ctx, field)
-			case "name":
-				return ec.fieldContext_Tenant_name(ctx, field)
-			case "groups":
-				return ec.fieldContext_Tenant_groups(ctx, field)
-			case "permissions":
-				return ec.fieldContext_Tenant_permissions(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Tenant", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_tenant_save_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Mutation_tenant_create_group(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mutation_tenant_create_group(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().TenantCreateGroup(rctx, fc.Args["id"].(int), fc.Args["input"].(model.GroupInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*model.Group)
-	fc.Result = res
-	return ec.marshalNGroup2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐGroup(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Mutation_tenant_create_group(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Mutation",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Group_id(ctx, field)
-			case "name":
-				return ec.fieldContext_Group_name(ctx, field)
-			case "tenant":
-				return ec.fieldContext_Group_tenant(ctx, field)
-			case "feeds":
-				return ec.fieldContext_Group_feeds(ctx, field)
-			case "permissions":
-				return ec.fieldContext_Group_permissions(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Group", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_tenant_create_group_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Mutation_group_save(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Mutation_group_save(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().GroupSave(rctx, fc.Args["id"].(int), fc.Args["input"].(model.GroupInput))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*model.Group)
-	fc.Result = res
-	return ec.marshalNGroup2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐGroup(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Mutation_group_save(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Mutation",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Group_id(ctx, field)
-			case "name":
-				return ec.fieldContext_Group_name(ctx, field)
-			case "tenant":
-				return ec.fieldContext_Group_tenant(ctx, field)
-			case "feeds":
-				return ec.fieldContext_Group_feeds(ctx, field)
-			case "permissions":
-				return ec.fieldContext_Group_permissions(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Group", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_group_save_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _Operator_id(ctx context.Context, field graphql.CollectedField, obj *model.Operator) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Operator_id(ctx, field)
 	if err != nil {
@@ -64904,33 +64296,6 @@ func (ec *executionContext) unmarshalInputGbfsDockRequest(ctx context.Context, o
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputGroupInput(ctx context.Context, obj any) (model.GroupInput, error) {
-	var it model.GroupInput
-	asMap := map[string]any{}
-	for k, v := range obj.(map[string]any) {
-		asMap[k] = v
-	}
-
-	fieldsInOrder := [...]string{"name"}
-	for _, k := range fieldsInOrder {
-		v, ok := asMap[k]
-		if !ok {
-			continue
-		}
-		switch k {
-		case "name":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Name = data
-		}
-	}
-
-	return it, nil
-}
-
 func (ec *executionContext) unmarshalInputLevelSetInput(ctx context.Context, obj any) (model.LevelSetInput, error) {
 	var it model.LevelSetInput
 	asMap := map[string]any{}
@@ -65393,47 +64758,6 @@ func (ec *executionContext) unmarshalInputPathwaySetInput(ctx context.Context, o
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputPermissionInput(ctx context.Context, obj any) (model.PermissionInput, error) {
-	var it model.PermissionInput
-	asMap := map[string]any{}
-	for k, v := range obj.(map[string]any) {
-		asMap[k] = v
-	}
-
-	fieldsInOrder := [...]string{"subject_type", "subject_id", "relation"}
-	for _, k := range fieldsInOrder {
-		v, ok := asMap[k]
-		if !ok {
-			continue
-		}
-		switch k {
-		case "subject_type":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("subject_type"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.SubjectType = data
-		case "subject_id":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("subject_id"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.SubjectID = data
-		case "relation":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("relation"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Relation = data
-		}
-	}
-
-	return it, nil
-}
-
 func (ec *executionContext) unmarshalInputPlaceFilter(ctx context.Context, obj any) (model.PlaceFilter, error) {
 	var it model.PlaceFilter
 	asMap := map[string]any{}
@@ -65841,40 +65165,6 @@ func (ec *executionContext) unmarshalInputServiceCoversFilter(ctx context.Contex
 				return it, err
 			}
 			it.LatestCalendarDate = data
-		}
-	}
-
-	return it, nil
-}
-
-func (ec *executionContext) unmarshalInputSetParentInput(ctx context.Context, obj any) (model.SetParentInput, error) {
-	var it model.SetParentInput
-	asMap := map[string]any{}
-	for k, v := range obj.(map[string]any) {
-		asMap[k] = v
-	}
-
-	fieldsInOrder := [...]string{"parent_type", "parent_id"}
-	for _, k := range fieldsInOrder {
-		v, ok := asMap[k]
-		if !ok {
-			continue
-		}
-		switch k {
-		case "parent_type":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("parent_type"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ParentType = data
-		case "parent_id":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("parent_id"))
-			data, err := ec.unmarshalNInt2int(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ParentID = data
 		}
 	}
 
@@ -66449,33 +65739,6 @@ func (ec *executionContext) unmarshalInputStopTimeFilter(ctx context.Context, ob
 				return it, err
 			}
 			it.ExcludeLast = data
-		}
-	}
-
-	return it, nil
-}
-
-func (ec *executionContext) unmarshalInputTenantInput(ctx context.Context, obj any) (model.TenantInput, error) {
-	var it model.TenantInput
-	asMap := map[string]any{}
-	for k, v := range obj.(map[string]any) {
-		asMap[k] = v
-	}
-
-	fieldsInOrder := [...]string{"name"}
-	for _, k := range fieldsInOrder {
-		v, ok := asMap[k]
-		if !ok {
-			continue
-		}
-		switch k {
-		case "name":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Name = data
 		}
 	}
 
@@ -73365,48 +72628,6 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "permission_add":
-			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_permission_add(ctx, field)
-			})
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "permission_remove":
-			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_permission_remove(ctx, field)
-			})
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "permission_set_parent":
-			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_permission_set_parent(ctx, field)
-			})
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "tenant_save":
-			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_tenant_save(ctx, field)
-			})
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "tenant_create_group":
-			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_tenant_create_group(ctx, field)
-			})
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "group_save":
-			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
-				return ec._Mutation_group_save(ctx, field)
-			})
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -80069,10 +79290,6 @@ func (ec *executionContext) marshalNGeometry2githubᚗcomᚋinterlineᚑioᚋtra
 	return v
 }
 
-func (ec *executionContext) marshalNGroup2githubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐGroup(ctx context.Context, sel ast.SelectionSet, v model.Group) graphql.Marshaler {
-	return ec._Group(ctx, sel, &v)
-}
-
 func (ec *executionContext) marshalNGroup2ᚕᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐGroupᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Group) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
@@ -80125,11 +79342,6 @@ func (ec *executionContext) marshalNGroup2ᚖgithubᚗcomᚋinterlineᚑioᚋtra
 		return graphql.Null
 	}
 	return ec._Group(ctx, sel, v)
-}
-
-func (ec *executionContext) unmarshalNGroupInput2githubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐGroupInput(ctx context.Context, v any) (model.GroupInput, error) {
-	res, err := ec.unmarshalInputGroupInput(ctx, v)
-	return res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalNInt2githubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐInt(ctx context.Context, v any) (tt.Int, error) {
@@ -80567,11 +79779,6 @@ func (ec *executionContext) marshalNPathway2ᚖgithubᚗcomᚋinterlineᚑioᚋt
 
 func (ec *executionContext) unmarshalNPathwaySetInput2githubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐPathwaySetInput(ctx context.Context, v any) (model.PathwaySetInput, error) {
 	res, err := ec.unmarshalInputPathwaySetInput(ctx, v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) unmarshalNPermissionInput2githubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐPermissionInput(ctx context.Context, v any) (model.PermissionInput, error) {
-	res, err := ec.unmarshalInputPermissionInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
@@ -81061,11 +80268,6 @@ func (ec *executionContext) marshalNSegmentPattern2ᚖgithubᚗcomᚋinterline�
 	return ec._SegmentPattern(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalNSetParentInput2githubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐSetParentInput(ctx context.Context, v any) (model.SetParentInput, error) {
-	res, err := ec.unmarshalInputSetParentInput(ctx, v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
 func (ec *executionContext) marshalNShape2githubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐShape(ctx context.Context, sel ast.SelectionSet, v model.Shape) graphql.Marshaler {
 	return ec._Shape(ctx, sel, &v)
 }
@@ -81357,10 +80559,6 @@ func (ec *executionContext) marshalNString2ᚖstring(ctx context.Context, sel as
 	return res
 }
 
-func (ec *executionContext) marshalNTenant2githubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐTenant(ctx context.Context, sel ast.SelectionSet, v model.Tenant) graphql.Marshaler {
-	return ec._Tenant(ctx, sel, &v)
-}
-
 func (ec *executionContext) marshalNTenant2ᚕᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐTenantᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.Tenant) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
@@ -81413,11 +80611,6 @@ func (ec *executionContext) marshalNTenant2ᚖgithubᚗcomᚋinterlineᚑioᚋtr
 		return graphql.Null
 	}
 	return ec._Tenant(ctx, sel, v)
-}
-
-func (ec *executionContext) unmarshalNTenantInput2githubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐTenantInput(ctx context.Context, v any) (model.TenantInput, error) {
-	res, err := ec.unmarshalInputTenantInput(ctx, v)
-	return res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalNTime2timeᚐTime(ctx context.Context, v any) (time.Time, error) {

--- a/schema/graphql/permissions.graphqls
+++ b/schema/graphql/permissions.graphqls
@@ -58,36 +58,6 @@ type Group {
   permissions: Permissions
 }
 
-"""Input for adding or removing a permission"""
-input PermissionInput {
-  "Subject type (e.g. user, tenant, group)"
-  subject_type: String!
-  "Subject identifier"
-  subject_id: String!
-  "Relationship to grant (e.g. viewer, editor, manager, admin, member)"
-  relation: String!
-}
-
-"""Input for setting an entity's parent"""
-input SetParentInput {
-  "Parent entity type"
-  parent_type: String!
-  "Parent entity ID"
-  parent_id: Int!
-}
-
-"""Input for saving a tenant"""
-input TenantInput {
-  "Tenant name"
-  name: String!
-}
-
-"""Input for saving a group"""
-input GroupInput {
-  "Group name"
-  name: String!
-}
-
 """A user in the authorization system"""
 type User {
   "User identifier"
@@ -113,21 +83,6 @@ extend type Query {
   groups(limit: Int, ids: [Int!]): [Group!]!
   "Search for users"
   users(limit: Int, where: UserFilter): [User!]!
-}
-
-extend type Mutation {
-  "Add a permission to an entity"
-  permission_add(type: String!, id: Int!, input: PermissionInput!): Boolean!
-  "Remove a permission from an entity"
-  permission_remove(type: String!, id: Int!, input: PermissionInput!): Boolean!
-  "Set an entity's parent in the authorization hierarchy"
-  permission_set_parent(type: String!, id: Int!, input: SetParentInput!): Boolean!
-  "Update a tenant's name"
-  tenant_save(id: Int!, input: TenantInput!): Tenant!
-  "Create a group within a tenant"
-  tenant_create_group(id: Int!, input: GroupInput!): Group!
-  "Update a group's name"
-  group_save(id: Int!, input: GroupInput!): Group!
 }
 
 extend type Feed {

--- a/server/gql/permission_resolver.go
+++ b/server/gql/permission_resolver.go
@@ -234,94 +234,6 @@ func (r *queryResolver) Users(ctx context.Context, limit *int, where *model.User
 	return users, nil
 }
 
-// Mutation resolvers
-
-func (r *mutationResolver) PermissionAdd(ctx context.Context, typeArg string, id int, input model.PermissionInput) (bool, error) {
-	pm, ref, subject, rel, err := parsePermissionArgs(ctx, typeArg, id, input)
-	if err != nil {
-		return false, err
-	}
-	if err := pm.AddPermission(ctx, ref, subject, rel); err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-func (r *mutationResolver) PermissionRemove(ctx context.Context, typeArg string, id int, input model.PermissionInput) (bool, error) {
-	pm, ref, subject, rel, err := parsePermissionArgs(ctx, typeArg, id, input)
-	if err != nil {
-		return false, err
-	}
-	if err := pm.RemovePermission(ctx, ref, subject, rel); err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-func (r *mutationResolver) PermissionSetParent(ctx context.Context, typeArg string, id int, input model.SetParentInput) (bool, error) {
-	pm, err := getPermissionManager(ctx)
-	if pm == nil || err != nil {
-		return false, errors.New("permission management not configured")
-	}
-	childType, err := authz.ObjectTypeString(typeArg)
-	if err != nil {
-		return false, err
-	}
-	parentType, err := authz.ObjectTypeString(input.ParentType)
-	if err != nil {
-		return false, err
-	}
-	child := authz.ObjectRef{Type: childType, ID: int64(id)}
-	parent := authz.ObjectRef{Type: parentType, ID: int64(input.ParentID)}
-	if err := pm.SetParent(ctx, child, parent); err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-func (r *mutationResolver) TenantSave(ctx context.Context, id int, input model.TenantInput) (*model.Tenant, error) {
-	am, err := getAdminManager(ctx)
-	if err != nil {
-		return nil, err
-	}
-	_, err = am.TenantSave(ctx, &authz.TenantSaveRequest{
-		Tenant: &authz.Tenant{Id: int64(id), Name: input.Name},
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &model.Tenant{ID: id, Name: input.Name}, nil
-}
-
-func (r *mutationResolver) TenantCreateGroup(ctx context.Context, id int, input model.GroupInput) (*model.Group, error) {
-	am, err := getAdminManager(ctx)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := am.TenantCreateGroup(ctx, &authz.TenantCreateGroupRequest{
-		Id:    int64(id),
-		Group: &authz.Group{Name: input.Name},
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &model.Group{ID: int(resp.Group.Id), Name: input.Name}, nil
-}
-
-func (r *mutationResolver) GroupSave(ctx context.Context, id int, input model.GroupInput) (*model.Group, error) {
-	am, err := getAdminManager(ctx)
-	if err != nil {
-		return nil, err
-	}
-	_, err = am.GroupSave(ctx, &authz.GroupSaveRequest{
-		Group: &authz.Group{Id: int64(id), Name: input.Name},
-	})
-	if err != nil {
-		return nil, err
-	}
-	return &model.Group{ID: id, Name: input.Name}, nil
-}
-
 // Helpers
 
 func getPermissionManager(ctx context.Context) (authz.PermissionManager, error) {
@@ -338,30 +250,6 @@ func getAdminManager(ctx context.Context) (authz.AdminManager, error) {
 		return am, nil
 	}
 	return nil, errors.New("admin operations not configured")
-}
-
-// parsePermissionArgs validates and converts the string arguments for
-// permission add/remove mutations into typed authz values.
-func parsePermissionArgs(ctx context.Context, typeArg string, id int, input model.PermissionInput) (authz.PermissionManager, authz.ObjectRef, authz.EntityKey, authz.Relation, error) {
-	pm, err := getPermissionManager(ctx)
-	if pm == nil || err != nil {
-		return nil, authz.ObjectRef{}, authz.EntityKey{}, 0, errors.New("permission management not configured")
-	}
-	objType, err := authz.ObjectTypeString(typeArg)
-	if err != nil {
-		return nil, authz.ObjectRef{}, authz.EntityKey{}, 0, err
-	}
-	subjectType, err := authz.ObjectTypeString(input.SubjectType)
-	if err != nil {
-		return nil, authz.ObjectRef{}, authz.EntityKey{}, 0, err
-	}
-	rel, err := authz.RelationString(input.Relation)
-	if err != nil {
-		return nil, authz.ObjectRef{}, authz.EntityKey{}, 0, err
-	}
-	ref := authz.ObjectRef{Type: objType, ID: int64(id)}
-	subject := authz.NewEntityKey(subjectType, input.SubjectID)
-	return pm, ref, subject, rel, nil
 }
 
 func resolvePermissions(ctx context.Context, objType authz.ObjectType, id int64) (*model.Permissions, error) {

--- a/server/gql/permission_resolver_test.go
+++ b/server/gql/permission_resolver_test.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 	"testing"
 
-	"fmt"
-
 	"github.com/99designs/gqlgen/client"
 	"github.com/interline-io/transitland-lib/internal/testconfig"
 	"github.com/interline-io/transitland-lib/server/auth/authn"
@@ -76,13 +74,6 @@ func postQuery(t testing.TB, c *client.Client, query string, vars map[string]int
 		t.Fatal(err)
 	}
 	return toJson(resp)
-}
-
-func postQueryExpectError(t testing.TB, c *client.Client, query string) {
-	t.Helper()
-	var resp map[string]interface{}
-	err := c.Post(query, &resp)
-	assert.Error(t, err)
 }
 
 // Tests
@@ -316,117 +307,6 @@ func TestPermissionResolver_FeedVersionPermissions(t *testing.T) {
 		assert.GreaterOrEqual(t, len(fvs), 1)
 		p := fvs[0].Get("permissions")
 		assert.True(t, p.Type == gjson.Null || !p.Exists(), "expected permissions to be null")
-	})
-}
-
-func TestPermissionResolver_Mutations(t *testing.T) {
-	c := newPermTestClient(t, "tl-tenant-admin")
-
-	// Look up the tl-tenant ID for use in mutations
-	jj := postQuery(t, c, `{ tenants { id name } }`, nil)
-	var tenantID int64
-	for _, tenant := range gjson.Get(jj, "tenants").Array() {
-		if tenant.Get("name").Str == "tl-tenant" {
-			tenantID = tenant.Get("id").Int()
-		}
-	}
-	assert.Greater(t, tenantID, int64(0), "expected to find tl-tenant ID")
-
-	t.Run("permission_add", func(t *testing.T) {
-		jj := postQuery(t, c, `mutation($id: Int!) {
-			permission_add(type: "tenant", id: $id, input: {subject_type: "user", subject_id: "newuser", relation: "member"})
-		}`, map[string]interface{}{"id": tenantID})
-		assert.Equal(t, true, gjson.Get(jj, "permission_add").Bool())
-	})
-
-	t.Run("permission_remove", func(t *testing.T) {
-		postQuery(t, c, `mutation($id: Int!) {
-			permission_add(type: "tenant", id: $id, input: {subject_type: "user", subject_id: "tempuser", relation: "member"})
-		}`, map[string]interface{}{"id": tenantID})
-
-		jj := postQuery(t, c, `mutation($id: Int!) {
-			permission_remove(type: "tenant", id: $id, input: {subject_type: "user", subject_id: "tempuser", relation: "member"})
-		}`, map[string]interface{}{"id": tenantID})
-		assert.Equal(t, true, gjson.Get(jj, "permission_remove").Bool())
-	})
-
-	t.Run("permission_set_parent", func(t *testing.T) {
-		jj := postQuery(t, c, `{ groups { id name } }`, nil)
-		var groupID int64
-		for _, g := range gjson.Get(jj, "groups").Array() {
-			if g.Get("name").Str == "CT-group" {
-				groupID = g.Get("id").Int()
-			}
-		}
-		assert.Greater(t, groupID, int64(0))
-
-		// Use "group" (the display alias) instead of "org" to verify the alias works
-		jj = postQuery(t, c, `mutation($groupId: Int!, $tenantId: Int!) {
-			permission_set_parent(type: "group", id: $groupId, input: {parent_type: "tenant", parent_id: $tenantId})
-		}`, map[string]interface{}{"groupId": groupID, "tenantId": tenantID})
-		assert.Equal(t, true, gjson.Get(jj, "permission_set_parent").Bool())
-	})
-
-	t.Run("invalid type", func(t *testing.T) {
-		postQueryExpectError(t, c, `mutation {
-			permission_add(type: "bogus", id: 1, input: {subject_type: "user", subject_id: "ian", relation: "admin"})
-		}`)
-	})
-
-	t.Run("invalid relation", func(t *testing.T) {
-		postQueryExpectError(t, c, `mutation {
-			permission_add(type: "tenant", id: 1, input: {subject_type: "user", subject_id: "ian", relation: "bogus"})
-		}`)
-	})
-}
-
-func TestPermissionResolver_AdminMutations(t *testing.T) {
-	// Admin mutations modify DB rows, so run inside a rollback transaction
-	testconfig.ConfigTxRollback(t, fgaTestOpts(t), func(cfg model.Config) {
-		c := newPermTestClientFromConfig(cfg, "tl-tenant-admin")
-
-		// Look up the tl-tenant ID
-		jj := postQuery(t, c, `{ tenants { id name } }`, nil)
-		var tenantID int64
-		for _, tenant := range gjson.Get(jj, "tenants").Array() {
-			if tenant.Get("name").Str == "tl-tenant" {
-				tenantID = tenant.Get("id").Int()
-			}
-		}
-		assert.Greater(t, tenantID, int64(0))
-
-		t.Run("tenant_save", func(t *testing.T) {
-			jj := postQuery(t, c, `mutation($id: Int!) {
-				tenant_save(id: $id, input: {name: "tl-tenant-renamed"}) { id name }
-			}`, map[string]interface{}{"id": tenantID})
-			assert.Equal(t, tenantID, gjson.Get(jj, "tenant_save.id").Int())
-			assert.Equal(t, "tl-tenant-renamed", gjson.Get(jj, "tenant_save.name").Str)
-		})
-
-		t.Run("tenant_create_group", func(t *testing.T) {
-			jj := postQuery(t, c, `mutation($id: Int!) {
-				tenant_create_group(id: $id, input: {name: "new-test-group"}) { id name }
-			}`, map[string]interface{}{"id": tenantID})
-			assert.Greater(t, gjson.Get(jj, "tenant_create_group.id").Int(), int64(0))
-			assert.Equal(t, "new-test-group", gjson.Get(jj, "tenant_create_group.name").Str)
-		})
-
-		t.Run("group_save", func(t *testing.T) {
-			jj := postQuery(t, c, `{ groups { id name } }`, nil)
-			var groupID int64
-			for _, g := range gjson.Get(jj, "groups").Array() {
-				if g.Get("name").Str == "CT-group" {
-					groupID = g.Get("id").Int()
-				}
-			}
-			assert.Greater(t, groupID, int64(0))
-
-			jj = postQuery(t, c, `mutation($id: Int!) {
-				group_save(id: $id, input: {name: "CT-group-renamed"}) { id name }
-			}`, map[string]interface{}{"id": groupID})
-			assert.Equal(t, groupID, gjson.Get(jj, "group_save.id").Int())
-			assert.Equal(t, "CT-group-renamed", gjson.Get(jj, "group_save.name").Str)
-		})
 	})
 }
 
@@ -705,7 +585,6 @@ func TestPermissionResolver_UnauthorizedUser(t *testing.T) {
 	// Both clients share the same config (same FGA store and DB) so authorization
 	// tuples are visible across users. Only the authn user identity differs.
 	cfg := testconfig.Config(t, fgaTestOpts(t))
-	adminClient := newPermTestClientFromConfig(cfg, "tl-tenant-admin")
 	nobodyClient := newPermTestClientFromConfig(cfg, "nobody", "testrole")
 
 	t.Run("tenants returns empty", func(t *testing.T) {
@@ -719,115 +598,4 @@ func TestPermissionResolver_UnauthorizedUser(t *testing.T) {
 		groups := gjson.Get(jj, "groups").Array()
 		assert.Equal(t, 0, len(groups))
 	})
-
-	// Look up real IDs via the admin client for use in mutation tests
-	jj := postQuery(t, adminClient, `{ tenants { id name } }`, nil)
-	var tenantID int64
-	for _, tenant := range gjson.Get(jj, "tenants").Array() {
-		if tenant.Get("name").Str == "tl-tenant" {
-			tenantID = tenant.Get("id").Int()
-		}
-	}
-	assert.Greater(t, tenantID, int64(0))
-
-	jj = postQuery(t, adminClient, `{ groups { id name } }`, nil)
-	var groupID int64
-	for _, g := range gjson.Get(jj, "groups").Array() {
-		if g.Get("name").Str == "CT-group" {
-			groupID = g.Get("id").Int()
-		}
-	}
-	assert.Greater(t, groupID, int64(0))
-
-	t.Run("permission_add unauthorized", func(t *testing.T) {
-		postQueryExpectError(t, nobodyClient, fmt.Sprintf(`mutation {
-			permission_add(type: "tenant", id: %d, input: {subject_type: "user", subject_id: "someone", relation: "member"})
-		}`, tenantID))
-	})
-
-	t.Run("tenant_save unauthorized", func(t *testing.T) {
-		postQueryExpectError(t, nobodyClient, fmt.Sprintf(`mutation {
-			tenant_save(id: %d, input: {name: "hacked"}) { id }
-		}`, tenantID))
-	})
-
-	t.Run("tenant_create_group unauthorized", func(t *testing.T) {
-		postQueryExpectError(t, nobodyClient, fmt.Sprintf(`mutation {
-			tenant_create_group(id: %d, input: {name: "hacked-group"}) { id }
-		}`, tenantID))
-	})
-
-	t.Run("group_save unauthorized", func(t *testing.T) {
-		postQueryExpectError(t, nobodyClient, fmt.Sprintf(`mutation {
-			group_save(id: %d, input: {name: "hacked-group"}) { id }
-		}`, groupID))
-	})
-}
-
-func TestPermissionResolver_MutationRoundTrip(t *testing.T) {
-	// Verify that permission_add actually creates a visible permission,
-	// and permission_remove actually deletes it.
-	cfg := testconfig.Config(t, fgaTestOpts(t))
-	c := newPermTestClientFromConfig(cfg, "tl-tenant-admin", "admin")
-
-	// Look up tenant ID
-	jj := postQuery(t, c, `{ tenants { id name } }`, nil)
-	var tenantID int64
-	for _, tenant := range gjson.Get(jj, "tenants").Array() {
-		if tenant.Get("name").Str == "tl-tenant" {
-			tenantID = tenant.Get("id").Int()
-		}
-	}
-	assert.Greater(t, tenantID, int64(0))
-
-	// Verify "roundtrip-user" is not a subject before we add them
-	jj = postQuery(t, c, `{ tenants { id name permissions { subjects { id relation } } } }`, nil)
-	for _, tenant := range gjson.Get(jj, "tenants").Array() {
-		if tenant.Get("name").Str != "tl-tenant" {
-			continue
-		}
-		for _, s := range tenant.Get("permissions.subjects").Array() {
-			assert.NotEqual(t, "roundtrip-user", s.Get("id").Str, "roundtrip-user should not exist before add")
-		}
-	}
-
-	// Add the permission
-	postQuery(t, c, fmt.Sprintf(`mutation {
-		permission_add(type: "tenant", id: %d, input: {subject_type: "user", subject_id: "roundtrip-user", relation: "member"})
-	}`, tenantID), nil)
-
-	// Verify "roundtrip-user" now appears as a subject
-	jj = postQuery(t, c, `{ tenants { name permissions { subjects { id relation } } } }`, nil)
-	var foundAfterAdd bool
-	for _, tenant := range gjson.Get(jj, "tenants").Array() {
-		if tenant.Get("name").Str != "tl-tenant" {
-			continue
-		}
-		for _, s := range tenant.Get("permissions.subjects").Array() {
-			if s.Get("id").Str == "roundtrip-user" && s.Get("relation").Str == "member" {
-				foundAfterAdd = true
-			}
-		}
-	}
-	assert.True(t, foundAfterAdd, "roundtrip-user should appear as member after permission_add")
-
-	// Remove the permission
-	postQuery(t, c, fmt.Sprintf(`mutation {
-		permission_remove(type: "tenant", id: %d, input: {subject_type: "user", subject_id: "roundtrip-user", relation: "member"})
-	}`, tenantID), nil)
-
-	// Verify "roundtrip-user" is gone
-	jj = postQuery(t, c, `{ tenants { name permissions { subjects { id relation } } } }`, nil)
-	var foundAfterRemove bool
-	for _, tenant := range gjson.Get(jj, "tenants").Array() {
-		if tenant.Get("name").Str != "tl-tenant" {
-			continue
-		}
-		for _, s := range tenant.Get("permissions.subjects").Array() {
-			if s.Get("id").Str == "roundtrip-user" {
-				foundAfterRemove = true
-			}
-		}
-	}
-	assert.False(t, foundAfterRemove, "roundtrip-user should be gone after permission_remove")
 }

--- a/server/model/config.go
+++ b/server/model/config.go
@@ -10,13 +10,13 @@ import (
 )
 
 type Config struct {
-	Finder                   Finder
-	RTFinder                 RTFinder
-	GbfsFinder               GbfsFinder
-	Checker                  Checker
-	Actions                  Actions
-	Jobs                     jobs.Backend
-	JobRunner                *jobs.Runner
+	Finder     Finder
+	RTFinder   RTFinder
+	GbfsFinder GbfsFinder
+	Checker    Checker
+	Actions    Actions
+	Jobs       jobs.Backend
+	JobRunner  *jobs.Runner
 	// JobPolicy gates the synchronous /run endpoint (which doesn't go
 	// through a Queue). Nil means no kind-level RBAC on /run.
 	JobPolicy                jobs.AccessPolicy

--- a/server/model/models_gen.go
+++ b/server/model/models_gen.go
@@ -660,12 +660,6 @@ type Group struct {
 	Permissions *Permissions `json:"permissions,omitempty"`
 }
 
-// Input for saving a group
-type GroupInput struct {
-	// Group name
-	Name string `json:"name"`
-}
-
 // A single trip option from origin to destination, composed of one or more `Leg`s.
 type Itinerary struct {
 	// Total duration of this itinerary
@@ -896,16 +890,6 @@ type PathwaySetInput struct {
 	FromStop *StopSetInput `json:"from_stop,omitempty"`
 	// Reference to an existing destination stop; only the `id` is used (the stop must already exist)
 	ToStop *StopSetInput `json:"to_stop,omitempty"`
-}
-
-// Input for adding or removing a permission
-type PermissionInput struct {
-	// Subject type (e.g. user, tenant, group)
-	SubjectType string `json:"subject_type"`
-	// Subject identifier
-	SubjectID string `json:"subject_id"`
-	// Relationship to grant (e.g. viewer, editor, manager, admin, member)
-	Relation string `json:"relation"`
 }
 
 // Reference to a related entity in the authorization hierarchy
@@ -1241,14 +1225,6 @@ type ServiceCoversFilter struct {
 	LatestCalendarDate *tt.Date `json:"latest_calendar_date,omitempty"`
 }
 
-// Input for setting an entity's parent
-type SetParentInput struct {
-	// Parent entity type
-	ParentType string `json:"parent_type"`
-	// Parent entity ID
-	ParentID int `json:"parent_id"`
-}
-
 // A single turn-by-turn navigation instruction within a walking or cycling leg.
 type Step struct {
 	// Duration of this step
@@ -1518,12 +1494,6 @@ type Tenant struct {
 	Groups []*Group `json:"groups"`
 	// Authorization permissions for this tenant
 	Permissions *Permissions `json:"permissions,omitempty"`
-}
-
-// Input for saving a tenant
-type TenantInput struct {
-	// Tenant name
-	Name string `json:"name"`
 }
 
 // Search options for trips


### PR DESCRIPTION
## Summary
Removes the GraphQL mutation surface for permission and tenant/group management that was added in #581/#590. The mutations exposed too much write surface for the API to comfortably support; permission reads (Tenant/Group/Feed/FeedVersion `permissions`, plus `tenants`/`groups`/`users` queries) are retained unchanged. The underlying Checker/AdminManager methods (`AddPermission`, `RemovePermission`, `SetParent`, `TenantSave`, `TenantCreateGroup`, `GroupSave`) are left intact so other callers can continue to use them directly.

### Schema
- Removed 6 mutations from `permissions.graphqls`: `permission_add`, `permission_remove`, `permission_set_parent`, `tenant_save`, `tenant_create_group`, `group_save`
- Removed 4 mutation-only input types: `PermissionInput`, `SetParentInput`, `TenantInput`, `GroupInput`
- Regenerated `internal/generated/gqlout/generated.go` and `server/model/models_gen.go`

### Resolver code
- Deleted the 6 mutation resolver functions and the `parsePermissionArgs` helper from `permission_resolver.go`
- Kept `getPermissionManager`, `getAdminManager`, `resolvePermissions`, and the FGA→GraphQL type-name alias — all still used by read paths

### Tests
- Removed `TestPermissionResolver_Mutations`, `TestPermissionResolver_AdminMutations`, and `TestPermissionResolver_MutationRoundTrip`
- Trimmed mutation-only subtests from `TestPermissionResolver_UnauthorizedUser`, leaving the read-side empty-result checks

## Test plan
- Run the resolver tests: `go test -count=1 -run TestPermissionResolver ./server/gql/`
- Confirm reads still work end-to-end against a server: query `{ tenants { id name permissions { actions subjects { id relation } children { name } } } }` and `{ feeds(where:{onestop_id:"CT"}) { permissions { actions parent { type name } } } }`
- Issue any of the removed mutations against the schema and confirm a `Cannot query field` / `Unknown field` error
