### PR TITLE
Additional PermFilter checking

### DIFF
--- a/server/finders/dbfinder/feed_version.go
+++ b/server/finders/dbfinder/feed_version.go
@@ -335,7 +335,7 @@ func feedVersionSelect(ctx context.Context, limit *int, after *model.Cursor, ids
 	return q
 }
 
-func feedVersionServiceLevelSelect(limit *int, after *model.Cursor, ids []int, _ *model.PermFilter, where *model.FeedVersionServiceLevelFilter) sq.SelectBuilder {
+func feedVersionServiceLevelSelect(limit *int, after *model.Cursor, ids []int, permFilter *model.PermFilter, where *model.FeedVersionServiceLevelFilter) sq.SelectBuilder {
 	q := sq.StatementBuilder.
 		Select(
 			"feed_version_service_levels.id",
@@ -352,16 +352,18 @@ func feedVersionServiceLevelSelect(limit *int, after *model.Cursor, ids []int, _
 			"feed_version_service_levels.sunday",
 		).
 		From("feed_version_service_levels").
+		Join("feed_versions on feed_versions.id = feed_version_service_levels.feed_version_id").
+		Join("current_feeds on current_feeds.id = feed_versions.feed_id").
 		Limit(finderCheckLimit(limit)).
 		OrderBy("feed_version_service_levels.id")
 
-	q = q.Where(sq.Eq{"route_id": nil})
+	q = q.Where(sq.Eq{"feed_version_service_levels.route_id": nil})
 	if where != nil {
 		if where.StartDate != nil {
-			q = q.Where(sq.LtOrEq{"start_date": where.StartDate})
+			q = q.Where(sq.LtOrEq{"feed_version_service_levels.start_date": where.StartDate})
 		}
 		if where.EndDate != nil {
-			q = q.Where(sq.GtOrEq{"end_date": where.EndDate})
+			q = q.Where(sq.GtOrEq{"feed_version_service_levels.end_date": where.EndDate})
 		}
 	}
 	if len(ids) > 0 {
@@ -370,6 +372,7 @@ func feedVersionServiceLevelSelect(limit *int, after *model.Cursor, ids []int, _
 	if after != nil && after.Valid && after.ID > 0 {
 		q = q.Where(sq.Gt{"feed_version_service_levels.id": after.ID})
 	}
+	q = pfJoinCheckFv(q, permFilter)
 	return q
 }
 

--- a/server/finders/dbfinder/segment.go
+++ b/server/finders/dbfinder/segment.go
@@ -65,7 +65,7 @@ func (f *Finder) SegmentsByRouteIDs(ctx context.Context, limit *int, where *mode
 		Join("tl_segment_patterns on tl_segment_patterns.segment_id = tl_segments.id").
 		Join("feed_versions on feed_versions.id = tl_segments.feed_version_id").
 		Join("current_feeds on current_feeds.id = feed_versions.feed_id").
-		Where("tl_segment_patterns.route_id = gtfs_routes.id").
+		Where(sq.Expr("tl_segment_patterns.route_id = gtfs_routes.id")).
 		Limit(finderCheckLimit(limit))
 	inner = pfJoinCheckFv(inner, f.PermFilter(ctx))
 	q := sq.StatementBuilder.
@@ -140,7 +140,16 @@ func segmentSelect(limit *int, after *model.Cursor, ids []int, permFilter *model
 
 func segmentPatternSelect(limit *int, after *model.Cursor, ids []int, permFilter *model.PermFilter) sq.SelectBuilder {
 	q := sq.StatementBuilder.
-		Select("tl_segment_patterns.*").
+		Select(
+			"tl_segment_patterns.id",
+			"tl_segment_patterns.route_id",
+			"tl_segment_patterns.segment_id",
+			"tl_segment_patterns.shape_id",
+			"tl_segment_patterns.stop_pattern_id",
+			"tl_segment_patterns.direction_id",
+			"tl_segment_patterns.sequence_idx",
+			"tl_segment_patterns.way_id",
+		).
 		From("tl_segment_patterns").
 		Join("feed_versions on feed_versions.id = tl_segment_patterns.feed_version_id").
 		Join("current_feeds on current_feeds.id = feed_versions.feed_id").

--- a/server/finders/dbfinder/segment.go
+++ b/server/finders/dbfinder/segment.go
@@ -10,24 +10,16 @@ import (
 
 func (f *Finder) SegmentsByFeedVersionIDs(ctx context.Context, limit *int, where *model.SegmentFilter, keys []int) ([][]*model.Segment, error) {
 	var ents []*model.Segment
-	// Use a subquery with row_number to get limit per feed_version_id
-	subq := sq.StatementBuilder.
-		Select(
-			"tl_segments.id",
-			"tl_segments.feed_version_id",
-			"tl_segments.way_id",
-			"tl_segments.geometry",
-			"row_number() over (partition by tl_segments.feed_version_id order by tl_segments.id) as rn",
-		).
-		From("tl_segments").
-		Where(In("tl_segments.feed_version_id", keys))
-	q := sq.StatementBuilder.
-		Select("id", "feed_version_id", "way_id", "geometry").
-		FromSelect(subq, "t").
-		Where(sq.LtOrEq{"rn": finderCheckLimit(limit)})
 	err := dbutil.Select(ctx,
 		f.db,
-		q,
+		lateralWrap(
+			segmentSelect(limit, nil, nil, f.PermFilter(ctx)),
+			"feed_versions",
+			"id",
+			"tl_segments",
+			"feed_version_id",
+			keys,
+		),
 		&ents,
 	)
 	return arrangeGroup(keys, ents, func(ent *model.Segment) int { return ent.FeedVersionID }), err
@@ -37,7 +29,7 @@ func (f *Finder) SegmentsByIDs(ctx context.Context, ids []int) ([]*model.Segment
 	var ents []*model.Segment
 	err := dbutil.Select(ctx,
 		f.db,
-		segmentSelect(nil, nil, ids),
+		segmentSelect(nil, nil, ids, f.PermFilter(ctx)),
 		&ents,
 	)
 	if err != nil {
@@ -48,18 +40,25 @@ func (f *Finder) SegmentsByIDs(ctx context.Context, ids []int) ([]*model.Segment
 
 func (f *Finder) SegmentsByRouteIDs(ctx context.Context, limit *int, where *model.SegmentFilter, keys []int) ([][]*model.Segment, error) {
 	var ents []*model.Segment
-	q := sq.Select(
-		"s.id",
-		"s.way_id",
-		"s.geometry",
-		"s.route_id",
-		"s.route_id with_route_id",
-	).
-		From("gtfs_routes").
-		JoinClause(
-			`join lateral (select distinct on (tl_segments.id, tl_segment_patterns.route_id) tl_segments.id, tl_segments.way_id, tl_segments.geometry, tl_segment_patterns.route_id from tl_segments join tl_segment_patterns on tl_segment_patterns.segment_id = tl_segments.id where tl_segment_patterns.route_id = gtfs_routes.id limit ?) s on true`,
-			finderCheckLimit(limit),
+	inner := sq.StatementBuilder.
+		Select(
+			"tl_segments.id",
+			"tl_segments.way_id",
+			"tl_segments.geometry",
+			"tl_segment_patterns.route_id",
 		).
+		Distinct().Options("on (tl_segments.id, tl_segment_patterns.route_id)").
+		From("tl_segments").
+		Join("tl_segment_patterns on tl_segment_patterns.segment_id = tl_segments.id").
+		Join("feed_versions on feed_versions.id = tl_segments.feed_version_id").
+		Join("current_feeds on current_feeds.id = feed_versions.feed_id").
+		Where("tl_segment_patterns.route_id = gtfs_routes.id").
+		Limit(finderCheckLimit(limit))
+	inner = pfJoinCheckFv(inner, f.PermFilter(ctx))
+	q := sq.StatementBuilder.
+		Select("s.id", "s.way_id", "s.geometry", "s.route_id", "s.route_id as with_route_id").
+		From("gtfs_routes").
+		JoinClause(inner.Prefix("JOIN LATERAL (").Suffix(") s on true")).
 		Where(In("gtfs_routes.id", keys))
 	err := dbutil.Select(ctx,
 		f.db,
@@ -74,7 +73,7 @@ func (f *Finder) SegmentPatternsByRouteIDs(ctx context.Context, limit *int, wher
 	err := dbutil.Select(ctx,
 		f.db,
 		lateralWrap(
-			quickSelect("tl_segment_patterns", limit, nil, nil),
+			segmentPatternSelect(limit, nil, nil, f.PermFilter(ctx)),
 			"gtfs_routes",
 			"id",
 			"tl_segment_patterns",
@@ -91,7 +90,7 @@ func (f *Finder) SegmentPatternsBySegmentIDs(ctx context.Context, limit *int, wh
 	err := dbutil.Select(ctx,
 		f.db,
 		lateralWrap(
-			quickSelect("tl_segment_patterns", limit, nil, nil),
+			segmentPatternSelect(limit, nil, nil, f.PermFilter(ctx)),
 			"tl_segments",
 			"id",
 			"tl_segment_patterns",
@@ -103,7 +102,7 @@ func (f *Finder) SegmentPatternsBySegmentIDs(ctx context.Context, limit *int, wh
 	return arrangeGroup(keys, ents, func(ent *model.SegmentPattern) int { return ent.SegmentID }), err
 }
 
-func segmentSelect(limit *int, after *model.Cursor, ids []int) sq.SelectBuilder {
+func segmentSelect(limit *int, after *model.Cursor, ids []int, permFilter *model.PermFilter) sq.SelectBuilder {
 	q := sq.StatementBuilder.
 		Select(
 			"tl_segments.id",
@@ -112,6 +111,8 @@ func segmentSelect(limit *int, after *model.Cursor, ids []int) sq.SelectBuilder 
 			"tl_segments.geometry",
 		).
 		From("tl_segments").
+		Join("feed_versions on feed_versions.id = tl_segments.feed_version_id").
+		Join("current_feeds on current_feeds.id = feed_versions.feed_id").
 		OrderBy("tl_segments.id").
 		Limit(finderCheckLimit(limit))
 	if len(ids) > 0 {
@@ -120,5 +121,24 @@ func segmentSelect(limit *int, after *model.Cursor, ids []int) sq.SelectBuilder 
 	if after != nil && after.Valid && after.ID > 0 {
 		q = q.Where(sq.Gt{"tl_segments.id": after.ID})
 	}
+	q = pfJoinCheckFv(q, permFilter)
+	return q
+}
+
+func segmentPatternSelect(limit *int, after *model.Cursor, ids []int, permFilter *model.PermFilter) sq.SelectBuilder {
+	q := sq.StatementBuilder.
+		Select("tl_segment_patterns.*").
+		From("tl_segment_patterns").
+		Join("feed_versions on feed_versions.id = tl_segment_patterns.feed_version_id").
+		Join("current_feeds on current_feeds.id = feed_versions.feed_id").
+		OrderBy("tl_segment_patterns.id").
+		Limit(finderCheckLimit(limit))
+	if len(ids) > 0 {
+		q = q.Where(In("tl_segment_patterns.id", ids))
+	}
+	if after != nil && after.Valid && after.ID > 0 {
+		q = q.Where(sq.Gt{"tl_segment_patterns.id": after.ID})
+	}
+	q = pfJoinCheckFv(q, permFilter)
 	return q
 }

--- a/server/finders/dbfinder/segment.go
+++ b/server/finders/dbfinder/segment.go
@@ -10,16 +10,29 @@ import (
 
 func (f *Finder) SegmentsByFeedVersionIDs(ctx context.Context, limit *int, where *model.SegmentFilter, keys []int) ([][]*model.Segment, error) {
 	var ents []*model.Segment
+	// row_number/partition is intentional: lets the planner use the
+	// (feed_version_id, id) index. The PermFilter check is layered on
+	// outside the subquery so we don't disturb that index path.
+	subq := sq.StatementBuilder.
+		Select(
+			"tl_segments.id",
+			"tl_segments.feed_version_id",
+			"tl_segments.way_id",
+			"tl_segments.geometry",
+			"row_number() over (partition by tl_segments.feed_version_id order by tl_segments.id) as rn",
+		).
+		From("tl_segments").
+		Where(In("tl_segments.feed_version_id", keys))
+	q := sq.StatementBuilder.
+		Select("t.id", "t.feed_version_id", "t.way_id", "t.geometry").
+		FromSelect(subq, "t").
+		Join("feed_versions on feed_versions.id = t.feed_version_id").
+		Join("current_feeds on current_feeds.id = feed_versions.feed_id").
+		Where(sq.LtOrEq{"t.rn": finderCheckLimit(limit)})
+	q = pfJoinCheckFv(q, f.PermFilter(ctx))
 	err := dbutil.Select(ctx,
 		f.db,
-		lateralWrap(
-			segmentSelect(limit, nil, nil, f.PermFilter(ctx)),
-			"feed_versions",
-			"id",
-			"tl_segments",
-			"feed_version_id",
-			keys,
-		),
+		q,
 		&ents,
 	)
 	return arrangeGroup(keys, ents, func(ent *model.Segment) int { return ent.FeedVersionID }), err

--- a/server/finders/dbfinder/segment.go
+++ b/server/finders/dbfinder/segment.go
@@ -10,9 +10,8 @@ import (
 
 func (f *Finder) SegmentsByFeedVersionIDs(ctx context.Context, limit *int, where *model.SegmentFilter, keys []int) ([][]*model.Segment, error) {
 	var ents []*model.Segment
-	// row_number/partition is intentional: lets the planner use the
-	// (feed_version_id, id) index. The PermFilter check is layered on
-	// outside the subquery so we don't disturb that index path.
+	// row_number/partition preserves the (feed_version_id, id) index path;
+	// pfJoinCheckFv goes outside the subquery to keep it.
 	subq := sq.StatementBuilder.
 		Select(
 			"tl_segments.id",

--- a/server/finders/dbfinder/validation_report.go
+++ b/server/finders/dbfinder/validation_report.go
@@ -10,8 +10,10 @@ import (
 
 func (f *Finder) ValidationReportsByFeedVersionIDs(ctx context.Context, limit *int, where *model.ValidationReportFilter, keys []int) ([][]*model.ValidationReport, error) {
 	q := sq.StatementBuilder.
-		Select("*").
+		Select("tl_validation_reports.*").
 		From("tl_validation_reports").
+		Join("feed_versions on feed_versions.id = tl_validation_reports.feed_version_id").
+		Join("current_feeds on current_feeds.id = feed_versions.feed_id").
 		Limit(finderCheckLimit(limit)).
 		OrderBy("tl_validation_reports.created_at desc, tl_validation_reports.id desc")
 	if where != nil {
@@ -19,21 +21,22 @@ func (f *Finder) ValidationReportsByFeedVersionIDs(ctx context.Context, limit *i
 			q = q.Where(In("tl_validation_reports.id", where.ReportIds))
 		}
 		if where.Success != nil {
-			q = q.Where(sq.Eq{"success": where.Success})
+			q = q.Where(sq.Eq{"tl_validation_reports.success": where.Success})
 		}
 		if where.Validator != nil {
-			q = q.Where(sq.Eq{"validator": where.Validator})
+			q = q.Where(sq.Eq{"tl_validation_reports.validator": where.Validator})
 		}
 		if where.ValidatorVersion != nil {
-			q = q.Where(sq.Eq{"validator_version": where.ValidatorVersion})
+			q = q.Where(sq.Eq{"tl_validation_reports.validator_version": where.ValidatorVersion})
 		}
 		if where.IncludesRt != nil {
-			q = q.Where(sq.Eq{"includes_rt": where.IncludesRt})
+			q = q.Where(sq.Eq{"tl_validation_reports.includes_rt": where.IncludesRt})
 		}
 		if where.IncludesStatic != nil {
-			q = q.Where(sq.Eq{"includes_static": where.IncludesStatic})
+			q = q.Where(sq.Eq{"tl_validation_reports.includes_static": where.IncludesStatic})
 		}
 	}
+	q = pfJoinCheckFv(q, f.PermFilter(ctx))
 	var ents []*model.ValidationReport
 	err := dbutil.Select(ctx,
 		f.db,

--- a/server/gql/permfilter_negative_test.go
+++ b/server/gql/permfilter_negative_test.go
@@ -9,22 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Verifies PermFilter blocks unauthorized callers from segment / segment-pattern
-// loaders (H6) and from the feed-version-scoped service-level and validation-
-// report loaders (H10).
-//
-// Test fixtures mark every feed's feed_states.public = true, so the default
-// DenyAllChecker PermFilter ({}) still passes pfJoinCheckFv. Inside a rolled-
-// back tx we flip public = false everywhere, so the only way data comes back
-// is via AllowedFeeds/AllowedFeedVersions/IsGlobalAdmin — none of which the
-// default empty PermFilter has. Every loader should return empty.
-//
-// Fixture details:
-//   - HA feed_version_id = 6 (sha1 c969...) holds the segments+patterns
-//     inserted by testdata/server/test_supplement.pgsql, plus
-//     feed_version_service_levels and one tl_validation_reports row.
-//   - tl_segments ids: 1418704, 1418711.
-//   - tl_segment_patterns ids: 1, 2, 3 on routes 34, 39.
+// Flipping feed_states.public = false strips the only access path the default
+// empty PermFilter has, so every loader under test should now return zero rows.
+// If pfJoinCheckFv is missing from any loader, that loader will keep returning
+// data and the corresponding subtest fails.
 func TestPermFilter_Negative(t *testing.T) {
 	testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
 		ctx := model.WithConfig(context.Background(), cfg)
@@ -34,7 +22,6 @@ func TestPermFilter_Negative(t *testing.T) {
 
 		const haFv = 6
 		segmentIDs := []int{1418704, 1418711}
-		segmentPatternIDs := []int{1, 2, 3}
 		routeIDsWithSegments := []int{34, 39}
 
 		t.Run("SegmentsByFeedVersionIDs", func(t *testing.T) {
@@ -46,9 +33,14 @@ func TestPermFilter_Negative(t *testing.T) {
 		})
 
 		t.Run("SegmentsByIDs", func(t *testing.T) {
-			ents, _ := cfg.Finder.SegmentsByIDs(ctx, segmentIDs)
-			for i, ent := range ents {
-				assert.Nil(t, ent, "expected segment %d (id %d) to be nil", i, segmentIDs[i])
+			ents, errs := cfg.Finder.SegmentsByIDs(ctx, segmentIDs)
+			for _, err := range errs {
+				assert.NoError(t, err)
+			}
+			if assert.Len(t, ents, len(segmentIDs)) {
+				for i, ent := range ents {
+					assert.Nil(t, ent, "expected segment %d (id %d) to be nil", i, segmentIDs[i])
+				}
 			}
 		})
 
@@ -73,11 +65,11 @@ func TestPermFilter_Negative(t *testing.T) {
 		})
 
 		t.Run("SegmentPatternsBySegmentIDs", func(t *testing.T) {
-			got, err := cfg.Finder.SegmentPatternsBySegmentIDs(ctx, nil, nil, segmentPatternIDs)
+			got, err := cfg.Finder.SegmentPatternsBySegmentIDs(ctx, nil, nil, segmentIDs)
 			assert.NoError(t, err)
-			if assert.Len(t, got, len(segmentPatternIDs)) {
+			if assert.Len(t, got, len(segmentIDs)) {
 				for i, group := range got {
-					assert.Empty(t, group, "expected no segment patterns for segment id %d", segmentPatternIDs[i])
+					assert.Empty(t, group, "expected no segment patterns for segment id %d", segmentIDs[i])
 				}
 			}
 		})

--- a/server/gql/permfilter_negative_test.go
+++ b/server/gql/permfilter_negative_test.go
@@ -1,0 +1,101 @@
+package gql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/interline-io/transitland-lib/internal/testconfig"
+	"github.com/interline-io/transitland-lib/server/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// Verifies PermFilter blocks unauthorized callers from segment / segment-pattern
+// loaders (H6) and from the feed-version-scoped service-level and validation-
+// report loaders (H10).
+//
+// Test fixtures mark every feed's feed_states.public = true, so the default
+// DenyAllChecker PermFilter ({}) still passes pfJoinCheckFv. Inside a rolled-
+// back tx we flip public = false everywhere, so the only way data comes back
+// is via AllowedFeeds/AllowedFeedVersions/IsGlobalAdmin — none of which the
+// default empty PermFilter has. Every loader should return empty.
+//
+// Fixture details:
+//   - HA feed_version_id = 6 (sha1 c969...) holds the segments+patterns
+//     inserted by testdata/server/test_supplement.pgsql, plus
+//     feed_version_service_levels and one tl_validation_reports row.
+//   - tl_segments ids: 1418704, 1418711.
+//   - tl_segment_patterns ids: 1, 2, 3 on routes 34, 39.
+func TestPermFilter_Negative(t *testing.T) {
+	testconfig.ConfigTxRollback(t, testconfig.Options{}, func(cfg model.Config) {
+		ctx := model.WithConfig(context.Background(), cfg)
+		if _, err := cfg.Finder.DBX().ExecContext(ctx, "update feed_states set public = false"); err != nil {
+			t.Fatal(err)
+		}
+
+		const haFv = 6
+		segmentIDs := []int{1418704, 1418711}
+		segmentPatternIDs := []int{1, 2, 3}
+		routeIDsWithSegments := []int{34, 39}
+
+		t.Run("SegmentsByFeedVersionIDs", func(t *testing.T) {
+			got, err := cfg.Finder.SegmentsByFeedVersionIDs(ctx, nil, nil, []int{haFv})
+			assert.NoError(t, err)
+			if assert.Len(t, got, 1) {
+				assert.Empty(t, got[0], "expected no segments when caller cannot see FV %d", haFv)
+			}
+		})
+
+		t.Run("SegmentsByIDs", func(t *testing.T) {
+			ents, _ := cfg.Finder.SegmentsByIDs(ctx, segmentIDs)
+			for i, ent := range ents {
+				assert.Nil(t, ent, "expected segment %d (id %d) to be nil", i, segmentIDs[i])
+			}
+		})
+
+		t.Run("SegmentsByRouteIDs", func(t *testing.T) {
+			got, err := cfg.Finder.SegmentsByRouteIDs(ctx, nil, nil, routeIDsWithSegments)
+			assert.NoError(t, err)
+			if assert.Len(t, got, len(routeIDsWithSegments)) {
+				for i, group := range got {
+					assert.Empty(t, group, "expected no segments for route %d", routeIDsWithSegments[i])
+				}
+			}
+		})
+
+		t.Run("SegmentPatternsByRouteIDs", func(t *testing.T) {
+			got, err := cfg.Finder.SegmentPatternsByRouteIDs(ctx, nil, nil, routeIDsWithSegments)
+			assert.NoError(t, err)
+			if assert.Len(t, got, len(routeIDsWithSegments)) {
+				for i, group := range got {
+					assert.Empty(t, group, "expected no segment patterns for route %d", routeIDsWithSegments[i])
+				}
+			}
+		})
+
+		t.Run("SegmentPatternsBySegmentIDs", func(t *testing.T) {
+			got, err := cfg.Finder.SegmentPatternsBySegmentIDs(ctx, nil, nil, segmentPatternIDs)
+			assert.NoError(t, err)
+			if assert.Len(t, got, len(segmentPatternIDs)) {
+				for i, group := range got {
+					assert.Empty(t, group, "expected no segment patterns for segment id %d", segmentPatternIDs[i])
+				}
+			}
+		})
+
+		t.Run("ValidationReportsByFeedVersionIDs", func(t *testing.T) {
+			got, err := cfg.Finder.ValidationReportsByFeedVersionIDs(ctx, nil, nil, []int{haFv})
+			assert.NoError(t, err)
+			if assert.Len(t, got, 1) {
+				assert.Empty(t, got[0], "expected no validation reports for FV %d", haFv)
+			}
+		})
+
+		t.Run("FeedVersionServiceLevelsByFeedVersionIDs", func(t *testing.T) {
+			got, err := cfg.Finder.FeedVersionServiceLevelsByFeedVersionIDs(ctx, nil, nil, []int{haFv})
+			assert.NoError(t, err)
+			if assert.Len(t, got, 1) {
+				assert.Empty(t, got[0], "expected no service levels for FV %d", haFv)
+			}
+		})
+	})
+}


### PR DESCRIPTION
## Summary
Applies the existing `PermFilter` gate (`pfJoinCheckFv`) to several `dbfinder` loaders that were missing it, so callers without access to a feed version cannot read its segments, segment patterns, service levels, or validation reports. See interline-io/tlv2#334 and interline-io/tlv2#335 for context.

### Segment loaders
- Thread `f.PermFilter(ctx)` through `SegmentsByIDs`, `SegmentsByFeedVersionIDs`, `SegmentsByRouteIDs`, `SegmentPatternsByRouteIDs`, and `SegmentPatternsBySegmentIDs`.
- New `segmentSelect` and `segmentPatternSelect` builders join `feed_versions` and `current_feeds` and call `pfJoinCheckFv`.
- `SegmentsByFeedVersionIDs` keeps the existing `row_number() OVER (PARTITION BY feed_version_id ORDER BY id)` subquery so the `(feed_version_id, id)` index path is preserved; the perm check is layered on outside the subquery.
- `SegmentsByRouteIDs` is rebuilt with a `squirrel`-composed lateral so the perm joins can attach cleanly.

### Feed-version-scoped loaders
- `feedVersionServiceLevelSelect` now consumes the `permFilter` it accepts (previously discarded), adds the `feed_versions`/`current_feeds` joins, and applies `pfJoinCheckFv`. Where-clauses are re-qualified to `feed_version_service_levels.*` to avoid post-join column ambiguity.
- `ValidationReportsByFeedVersionIDs` joins `feed_versions`/`current_feeds`, applies `pfJoinCheckFv(q, f.PermFilter(ctx))`, and qualifies all column references.

### Tests
- New `server/gql/permfilter_negative_test.go` exercises each affected loader under a `testconfig.ConfigTxRollback` that flips every `feed_states.public` to false. With the default empty `PermFilter`, each loader returns empty — locking in the new gate without touching any fixture file.

## Test plan
- `go test ./server/gql/... ./server/finders/...` (database tests; requires `TL_TEST_SERVER_DATABASE_URL`).
- For segment-loader perf, eyeball `EXPLAIN` for `SegmentsByFeedVersionIDs` on a populated database and confirm the `(feed_version_id, id)` index is still used by the inner subquery.
