### PR TITLE
Improve search behavior and consistency

### DIFF
--- a/server/finders/dbfinder/agency.go
+++ b/server/finders/dbfinder/agency.go
@@ -153,19 +153,19 @@ func agencySelect(limit *int, after *model.Cursor, ids []int, useActive *UseActi
 				Join("tl_agency_places tlap ON tlap.agency_id = gtfs_agencies.id").
 				Join("ne_10m_admin_1_states_provinces ne_admin on ne_admin.name = tlap.adm1name and ne_admin.admin = tlap.adm0name")
 			if where.Adm0Iso != nil {
-				q = q.Where(sq.ILike{"ne_admin.iso_a2": *where.Adm0Iso})
+				q = q.Where(sq.ILike{"ne_admin.iso_a2": dbutil.EscapeLike(*where.Adm0Iso, false, false)})
 			}
 			if where.Adm1Iso != nil {
-				q = q.Where(sq.ILike{"ne_admin.iso_3166_2": *where.Adm1Iso})
+				q = q.Where(sq.ILike{"ne_admin.iso_3166_2": dbutil.EscapeLike(*where.Adm1Iso, false, false)})
 			}
 			if where.Adm0Name != nil {
-				q = q.Where(sq.ILike{"tlap.adm0name": *where.Adm0Name})
+				q = q.Where(sq.ILike{"tlap.adm0name": dbutil.EscapeLike(*where.Adm0Name, false, false)})
 			}
 			if where.Adm1Name != nil {
-				q = q.Where(sq.ILike{"tlap.adm1name": *where.Adm1Name})
+				q = q.Where(sq.ILike{"tlap.adm1name": dbutil.EscapeLike(*where.Adm1Name, false, false)})
 			}
 			if where.CityName != nil {
-				q = q.Where(sq.ILike{"tlap.name": *where.CityName})
+				q = q.Where(sq.ILike{"tlap.name": dbutil.EscapeLike(*where.CityName, false, false)})
 			}
 		}
 		// Handle license filtering

--- a/server/finders/dbfinder/feed.go
+++ b/server/finders/dbfinder/feed.go
@@ -2,7 +2,6 @@ package dbfinder
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/interline-io/log"
 	"github.com/interline-io/transitland-lib/server/dbutil"
@@ -218,7 +217,7 @@ func feedSelect(ctx context.Context, limit *int, after *model.Cursor, ids []int,
 			rank, wc := tsTableQuery("current_feeds", *where.Search)
 			q = q.Column(rank).Where(sq.Or{
 				wc,
-				sq.ILike{"onestop_id": fmt.Sprintf("%%%s%%", *where.Search)},
+				sq.ILike{"onestop_id": dbutil.EscapeLike(*where.Search, true, true)},
 			})
 		}
 

--- a/server/finders/dbfinder/operator.go
+++ b/server/finders/dbfinder/operator.go
@@ -2,7 +2,6 @@ package dbfinder
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/interline-io/transitland-lib/server/dbutil"
 	"github.com/interline-io/transitland-lib/server/model"
@@ -140,19 +139,19 @@ func operatorSelectBase(distinct bool, where *model.OperatorFilter) sq.SelectBui
 				Join("tl_agency_places tlap ON tlap.agency_id = gtfs_agencies.id").
 				Join("ne_10m_admin_1_states_provinces ne_admin on ne_admin.name = tlap.adm1name and ne_admin.admin = tlap.adm0name")
 			if where.Adm0Iso != nil {
-				q = q.Where(sq.ILike{"ne_admin.iso_a2": *where.Adm0Iso})
+				q = q.Where(sq.ILike{"ne_admin.iso_a2": dbutil.EscapeLike(*where.Adm0Iso, false, false)})
 			}
 			if where.Adm1Iso != nil {
-				q = q.Where(sq.ILike{"ne_admin.iso_3166_2": *where.Adm1Iso})
+				q = q.Where(sq.ILike{"ne_admin.iso_3166_2": dbutil.EscapeLike(*where.Adm1Iso, false, false)})
 			}
 			if where.Adm0Name != nil {
-				q = q.Where(sq.ILike{"tlap.adm0name": *where.Adm0Name})
+				q = q.Where(sq.ILike{"tlap.adm0name": dbutil.EscapeLike(*where.Adm0Name, false, false)})
 			}
 			if where.Adm1Name != nil {
-				q = q.Where(sq.ILike{"tlap.adm1name": *where.Adm1Name})
+				q = q.Where(sq.ILike{"tlap.adm1name": dbutil.EscapeLike(*where.Adm1Name, false, false)})
 			}
 			if where.CityName != nil {
-				q = q.Where(sq.ILike{"tlap.name": *where.CityName})
+				q = q.Where(sq.ILike{"tlap.name": dbutil.EscapeLike(*where.CityName, false, false)})
 			}
 		}
 
@@ -164,7 +163,7 @@ func operatorSelectBase(distinct bool, where *model.OperatorFilter) sq.SelectBui
 			rank, wc := tsTableQuery("coif", *where.Search)
 			q = q.Column(rank).Where(sq.Or{
 				wc,
-				sq.ILike{"coif.resolved_onestop_id": fmt.Sprintf("%%%s%%", *where.Search)},
+				sq.ILike{"coif.resolved_onestop_id": dbutil.EscapeLike(*where.Search, true, true)},
 			})
 		}
 	}

--- a/server/gql/agency_resolver_test.go
+++ b/server/gql/agency_resolver_test.go
@@ -152,6 +152,14 @@ func TestAgencyResolver(t *testing.T) {
 			selectExpect: []string{},
 		},
 		{
+			// `%` is an ILIKE wildcard; unescaped it would match every adm0_iso.
+			name:         "places adm0_iso escapes ilike wildcards",
+			query:        `query { agencies(where:{adm0_iso: "%"}) {onestop_id}}`,
+			vars:         vars,
+			selector:     "agencies.#.onestop_id",
+			selectExpect: []string{},
+		},
+		{
 			name:         "places city",
 			query:        `query { agencies(where:{city_name: "Berkeley"}) {onestop_id places {adm0_name adm1_name city_name}}}`,
 			vars:         vars,

--- a/server/gql/feed_resolver_test.go
+++ b/server/gql/feed_resolver_test.go
@@ -146,6 +146,13 @@ func TestFeedResolver(t *testing.T) {
 			selectExpect: []string{"CT~rt", "BA~rt"},
 		},
 		{
+			// `_` and `%` are ILIKE wildcards; unescaped they over-match every row.
+			name:         "where search escapes ilike wildcards",
+			query:        `query { feeds(where:{search:"__"}) {onestop_id}}`,
+			selector:     "feeds.#.onestop_id",
+			selectExpect: []string{},
+		},
+		{
 			name:         "where tags test=ok",
 			query:        `query { feeds(where:{tags:{test:"ok"}}) {onestop_id}}`,
 			selector:     "feeds.#.onestop_id",

--- a/server/gql/operator_resolver_test.go
+++ b/server/gql/operator_resolver_test.go
@@ -115,6 +115,13 @@ func TestOperatorResolver(t *testing.T) {
 			selector:     "operators.#.onestop_id",
 			selectExpect: []string{},
 		},
+		{
+			// `_` and `%` are ILIKE wildcards; unescaped they over-match every row.
+			name:         "search escapes ilike wildcards",
+			query:        `query { operators(where:{search: "__"}) {onestop_id}}`,
+			selector:     "operators.#.onestop_id",
+			selectExpect: []string{},
+		},
 		// spatial
 		{
 			name:         "near 100m",


### PR DESCRIPTION
## Summary
Routes user-supplied ILIKE patterns through `dbutil.EscapeLike` so `%`, `_`, and `\` in caller input are matched literally instead of as wildcards. Closes interline-io/tlv2#338.

### Search filters
- Apply `dbutil.EscapeLike(*where.Search, true, true)` to the `Search` ILIKE in `feedSelect` and `operatorSelectBase`, keeping the substring-search semantic but escaping wildcard characters in the user input.

### Admin and city filters
- Apply `dbutil.EscapeLike(*v, false, false)` to the `Adm0Iso`, `Adm1Iso`, `Adm0Name`, `Adm1Name`, and `CityName` ILIKE filters in both `operatorSelectBase` and `agencySelect`. This preserves the case-insensitive exact-match behavior the schema documents for these fields (e.g. `adm1_iso: "us-ca"` continues to match `US-CA`) while preventing wildcard characters from acting as pattern operators.
- Drop the now-unused `fmt` import from `feed.go` and `operator.go`.

### Tests
- New negative cases in `feed_resolver_test.go`, `operator_resolver_test.go`, and `agency_resolver_test.go` pass wildcard-only inputs (`"__"`, `"%"`) and assert an empty result, locking in the escape behavior. For any input that does not contain `%`, `_`, or `\` the generated SQL is byte-identical to before, so all existing positive search and admin filter tests pass unchanged.

## Test plan
- `go test ./server/gql/... ./server/finders/...`
- Spot-check a search query like `feeds(where:{search:"BA"})` returns the same results as before the change.
- Spot-check that `agencies(where:{adm0_iso:"%"})` now returns an empty list rather than every row.
