### PR TITLE
Remove additional panics in request path

### DIFF
--- a/server/finders/dbfinder/mutations.go
+++ b/server/finders/dbfinder/mutations.go
@@ -227,8 +227,10 @@ type canScan interface {
 }
 
 // scanCol assigns inval into val (via val.Scan) and appends colname to cols
-// when inval is non-nil. Any Scan error is reported through errp, which must
-// be non-nil; once *errp is set, subsequent scanCol calls short-circuit so
+// when inval is non-nil and colname is non-empty. (An empty colname is used at
+// sites that pre-append the column name explicitly and only want scanCol's
+// Scan side effect.) Any Scan error is reported through errp, which must be
+// non-nil; once *errp is set, subsequent scanCol calls short-circuit so
 // callers can chain several and inspect a single error at the end.
 func scanCol[T any, PT *T](val canScan, inval PT, colname string, cols []string, errp *error) []string {
 	if *errp != nil {
@@ -239,7 +241,9 @@ func scanCol[T any, PT *T](val canScan, inval PT, colname string, cols []string,
 			*errp = fmt.Errorf("scan %s: %w", colname, err)
 			return cols
 		}
-		cols = append(cols, colname)
+		if colname != "" {
+			cols = append(cols, colname)
+		}
 	}
 	return cols
 }

--- a/server/finders/dbfinder/mutations.go
+++ b/server/finders/dbfinder/mutations.go
@@ -48,33 +48,34 @@ func createUpdateStop(ctx context.Context, input model.StopSetInput) (int, error
 		&gtfs.Stop{},
 		func(ent *gtfs.Stop) ([]string, error) {
 			var cols []string
-			cols = scanCol(&ent.StopID, input.StopID, "stop_id", cols)
-			cols = scanCol(&ent.StopCode, input.StopCode, "stop_code", cols)
-			cols = scanCol(&ent.StopDesc, input.StopDesc, "stop_desc", cols)
-			cols = scanCol(&ent.StopTimezone, input.StopTimezone, "stop_timezone", cols)
-			cols = scanCol(&ent.StopName, input.StopName, "stop_name", cols)
-			cols = scanCol(&ent.StopURL, input.StopURL, "stop_url", cols)
-			cols = scanCol(&ent.LocationType, input.LocationType, "location_type", cols)
-			cols = scanCol(&ent.WheelchairBoarding, input.WheelchairBoarding, "wheelchair_boarding", cols)
-			cols = scanCol(&ent.ZoneID, input.ZoneID, "zone_id", cols)
-			cols = scanCol(&ent.TtsStopName, input.TtsStopName, "tts_stop_name", cols)
-			cols = scanCol(&ent.PlatformCode, input.PlatformCode, "platform_code", cols)
+			var err error
+			cols = scanCol(&ent.StopID, input.StopID, "stop_id", cols, &err)
+			cols = scanCol(&ent.StopCode, input.StopCode, "stop_code", cols, &err)
+			cols = scanCol(&ent.StopDesc, input.StopDesc, "stop_desc", cols, &err)
+			cols = scanCol(&ent.StopTimezone, input.StopTimezone, "stop_timezone", cols, &err)
+			cols = scanCol(&ent.StopName, input.StopName, "stop_name", cols, &err)
+			cols = scanCol(&ent.StopURL, input.StopURL, "stop_url", cols, &err)
+			cols = scanCol(&ent.LocationType, input.LocationType, "location_type", cols, &err)
+			cols = scanCol(&ent.WheelchairBoarding, input.WheelchairBoarding, "wheelchair_boarding", cols, &err)
+			cols = scanCol(&ent.ZoneID, input.ZoneID, "zone_id", cols, &err)
+			cols = scanCol(&ent.TtsStopName, input.TtsStopName, "tts_stop_name", cols, &err)
+			cols = scanCol(&ent.PlatformCode, input.PlatformCode, "platform_code", cols, &err)
 			if input.Geometry != nil && input.Geometry.Valid {
 				cols = checkCol(&ent.Geometry, input.Geometry, "geometry", cols)
 			}
 			if v := input.Parent; v != nil {
 				ent.ParentStation.Scan(nil)
 				cols = append(cols, "parent_station")
-				scanCol(&ent.ParentStation, v.ID, "parent_station", cols)
+				cols = scanCol(&ent.ParentStation, v.ID, "", cols, &err)
 			}
 			if v := input.Level; v != nil {
 				ent.LevelID.Scan(nil)
 				cols = append(cols, "level_id")
-				scanCol(&ent.LevelID, v.ID, "level_id", cols)
+				cols = scanCol(&ent.LevelID, v.ID, "", cols, &err)
 			}
 			// Set some defaults
 			ent.LocationType.OrSet(0)
-			return cols, nil
+			return cols, err
 		})
 	if err != nil {
 		return 0, err
@@ -94,12 +95,13 @@ func createUpdateStop(ctx context.Context, input model.StopSetInput) (int, error
 				&model.StopExternalReference{},
 				func(ent *model.StopExternalReference) ([]string, error) {
 					var cols []string
+					var err error
 					ent.StopID.SetInt(stopId)
-					cols = scanCol(&ent.StopID, &stopId, "stop_id", cols)
-					cols = scanCol(&ent.TargetFeedOnestopID, refInput.TargetFeedOnestopID, "target_feed_onestop_id", cols)
-					cols = scanCol(&ent.TargetStopID, refInput.TargetStopID, "target_stop_id", cols)
-					// cols = scanCol(&ent.Inactive, refInput.Inactive, "inactive", cols)
-					return cols, nil
+					cols = scanCol(&ent.StopID, &stopId, "stop_id", cols, &err)
+					cols = scanCol(&ent.TargetFeedOnestopID, refInput.TargetFeedOnestopID, "target_feed_onestop_id", cols, &err)
+					cols = scanCol(&ent.TargetStopID, refInput.TargetStopID, "target_stop_id", cols, &err)
+					// cols = scanCol(&ent.Inactive, refInput.Inactive, "inactive", cols, &err)
+					return cols, err
 				},
 			); err != nil {
 				return 0, fmt.Errorf("failed to create or update stop external reference for stop %d: %w", stopId, err)
@@ -144,25 +146,26 @@ func createUpdatePathway(ctx context.Context, input model.PathwaySetInput) (int,
 		&gtfs.Pathway{},
 		func(ent *gtfs.Pathway) ([]string, error) {
 			var cols []string
-			cols = scanCol(&ent.PathwayID, input.PathwayID, "pathway_id", cols)
-			cols = scanCol(&ent.PathwayMode, input.PathwayMode, "pathway_mode", cols)
-			cols = scanCol(&ent.IsBidirectional, input.IsBidirectional, "is_bidirectional", cols)
-			cols = scanCol(&ent.Length, input.Length, "length", cols)
-			cols = scanCol(&ent.TraversalTime, input.TraversalTime, "traversal_time", cols)
-			cols = scanCol(&ent.StairCount, input.StairCount, "stair_count", cols)
-			cols = scanCol(&ent.MaxSlope, input.MaxSlope, "max_slope", cols)
-			cols = scanCol(&ent.MinWidth, input.MinWidth, "min_width", cols)
-			cols = scanCol(&ent.SignpostedAs, input.SignpostedAs, "signposted_as", cols)
-			cols = scanCol(&ent.ReverseSignpostedAs, input.ReverseSignpostedAs, "reverse_signposted_as", cols)
+			var err error
+			cols = scanCol(&ent.PathwayID, input.PathwayID, "pathway_id", cols, &err)
+			cols = scanCol(&ent.PathwayMode, input.PathwayMode, "pathway_mode", cols, &err)
+			cols = scanCol(&ent.IsBidirectional, input.IsBidirectional, "is_bidirectional", cols, &err)
+			cols = scanCol(&ent.Length, input.Length, "length", cols, &err)
+			cols = scanCol(&ent.TraversalTime, input.TraversalTime, "traversal_time", cols, &err)
+			cols = scanCol(&ent.StairCount, input.StairCount, "stair_count", cols, &err)
+			cols = scanCol(&ent.MaxSlope, input.MaxSlope, "max_slope", cols, &err)
+			cols = scanCol(&ent.MinWidth, input.MinWidth, "min_width", cols, &err)
+			cols = scanCol(&ent.SignpostedAs, input.SignpostedAs, "signposted_as", cols, &err)
+			cols = scanCol(&ent.ReverseSignpostedAs, input.ReverseSignpostedAs, "reverse_signposted_as", cols, &err)
 			if v := input.FromStop; v != nil {
 				cols = append(cols, "from_stop_id")
-				scanCol(&ent.FromStopID, v.ID, "", nil)
+				cols = scanCol(&ent.FromStopID, v.ID, "", cols, &err)
 			}
 			if v := input.ToStop; v != nil {
 				cols = append(cols, "from_stop_id")
-				scanCol(&ent.ToStopID, v.ID, "", nil)
+				cols = scanCol(&ent.ToStopID, v.ID, "", cols, &err)
 			}
-			return cols, nil
+			return cols, err
 		})
 }
 
@@ -196,15 +199,16 @@ func createUpdateLevel(ctx context.Context, input model.LevelSetInput) (int, err
 		&model.Level{},
 		func(ent *model.Level) ([]string, error) {
 			var cols []string
-			cols = scanCol(&ent.LevelID, input.LevelID, "level_id", cols)
-			cols = scanCol(&ent.LevelName, input.LevelName, "level_name", cols)
-			cols = scanCol(&ent.LevelIndex, input.LevelIndex, "level_index", cols)
+			var err error
+			cols = scanCol(&ent.LevelID, input.LevelID, "level_id", cols, &err)
+			cols = scanCol(&ent.LevelName, input.LevelName, "level_name", cols, &err)
+			cols = scanCol(&ent.LevelIndex, input.LevelIndex, "level_index", cols, &err)
 			cols = checkCol(&ent.Geometry, input.Geometry, "geometry", cols)
 			if v := input.Parent; v != nil {
 				cols = append(cols, "parent_station")
-				scanCol(&ent.ParentStation, v.ID, "", nil)
+				cols = scanCol(&ent.ParentStation, v.ID, "", cols, &err)
 			}
-			return cols, nil
+			return cols, err
 		})
 }
 
@@ -222,10 +226,21 @@ type canScan interface {
 	Scan(any) error
 }
 
-func scanCol[T any, PT *T](val canScan, inval PT, colname string, cols []string) []string {
+// scanCol assigns inval into val (via val.Scan) and records colname in the cols
+// list when inval is non-nil. Any Scan error is reported via the optional errp
+// accumulator (subsequent calls become no-ops once errp is set), so callers can
+// chain several scanCol calls and inspect a single error at the end. Pass a nil
+// errp at sites that intentionally ignore the result.
+func scanCol[T any, PT *T](val canScan, inval PT, colname string, cols []string, errp *error) []string {
+	if errp != nil && *errp != nil {
+		return cols
+	}
 	if inval != nil {
 		if err := val.Scan(*inval); err != nil {
-			panic(err)
+			if errp != nil {
+				*errp = fmt.Errorf("scan %s: %w", colname, err)
+			}
+			return cols
 		}
 		cols = append(cols, colname)
 	}

--- a/server/finders/dbfinder/mutations.go
+++ b/server/finders/dbfinder/mutations.go
@@ -226,20 +226,17 @@ type canScan interface {
 	Scan(any) error
 }
 
-// scanCol assigns inval into val (via val.Scan) and records colname in the cols
-// list when inval is non-nil. Any Scan error is reported via the optional errp
-// accumulator (subsequent calls become no-ops once errp is set), so callers can
-// chain several scanCol calls and inspect a single error at the end. Pass a nil
-// errp at sites that intentionally ignore the result.
+// scanCol assigns inval into val (via val.Scan) and appends colname to cols
+// when inval is non-nil. Any Scan error is reported through errp, which must
+// be non-nil; once *errp is set, subsequent scanCol calls short-circuit so
+// callers can chain several and inspect a single error at the end.
 func scanCol[T any, PT *T](val canScan, inval PT, colname string, cols []string, errp *error) []string {
-	if errp != nil && *errp != nil {
+	if *errp != nil {
 		return cols
 	}
 	if inval != nil {
 		if err := val.Scan(*inval); err != nil {
-			if errp != nil {
-				*errp = fmt.Errorf("scan %s: %w", colname, err)
-			}
+			*errp = fmt.Errorf("scan %s: %w", colname, err)
 			return cols
 		}
 		cols = append(cols, colname)

--- a/server/finders/dbfinder/trip.go
+++ b/server/finders/dbfinder/trip.go
@@ -2,6 +2,7 @@ package dbfinder
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/interline-io/transitland-lib/server/dbutil"
 	"github.com/interline-io/transitland-lib/server/model"
@@ -15,7 +16,10 @@ func (f *Finder) FindTrips(ctx context.Context, limit *int, after *model.Cursor,
 	if len(ids) > 0 || (where != nil && where.FeedVersionSha1 != nil) || (where != nil && len(where.RouteIds) > 0) {
 		active = false
 	}
-	q := tripSelect(limit, after, ids, active, f.PermFilter(ctx), where, nil)
+	q, err := tripSelect(limit, after, ids, active, f.PermFilter(ctx), where, nil)
+	if err != nil {
+		return nil, err
+	}
 	if err := dbutil.Select(ctx, f.db, q, &ents); err != nil {
 		return nil, logErr(ctx, err)
 	}
@@ -59,10 +63,14 @@ func (f *Finder) TripsByRouteIDs(ctx context.Context, limit *int, where *model.T
 		if err != nil {
 			return nil, err
 		}
+		inner, err := tripSelect(limit, nil, nil, false, f.PermFilter(ctx), where, fvsw)
+		if err != nil {
+			return nil, err
+		}
 		if err := dbutil.Select(ctx,
 			f.db,
 			lateralWrap(
-				tripSelect(limit, nil, nil, false, f.PermFilter(ctx), where, fvsw),
+				inner,
 				"gtfs_routes",
 				"id",
 				"gtfs_trips",
@@ -86,11 +94,15 @@ func (f *Finder) TripsByFeedVersionIDs(ctx context.Context, limit *int, where *m
 		if err != nil {
 			return nil, err
 		}
+		inner, err := tripSelect(limit, nil, nil, false, f.PermFilter(ctx), where, fvsw)
+		if err != nil {
+			return nil, err
+		}
 		var q []*model.Trip
 		err = dbutil.Select(ctx,
 			f.db,
 			lateralWrap(
-				tripSelect(limit, nil, nil, false, f.PermFilter(ctx), where, fvsw),
+				inner,
 				"feed_versions",
 				"id",
 				"gtfs_trips",
@@ -107,7 +119,7 @@ func (f *Finder) TripsByFeedVersionIDs(ctx context.Context, limit *int, where *m
 	return arrangeGroup(keys, ents, func(ent *model.Trip) int { return ent.FeedVersionID }), nil
 }
 
-func tripSelect(limit *int, after *model.Cursor, ids []int, active bool, permFilter *model.PermFilter, where *model.TripFilter, fvsw *model.ServiceWindow) sq.SelectBuilder {
+func tripSelect(limit *int, after *model.Cursor, ids []int, active bool, permFilter *model.PermFilter, where *model.TripFilter, fvsw *model.ServiceWindow) (sq.SelectBuilder, error) {
 	q := sq.StatementBuilder.Select(
 		"gtfs_trips.id",
 		"gtfs_trips.feed_version_id",
@@ -137,10 +149,9 @@ func tripSelect(limit *int, after *model.Cursor, ids []int, active bool, permFil
 	// Process FVSW
 	if where != nil && fvsw != nil {
 		if where.RelativeDate != nil {
-			// This must be an enum; panic is OK
 			s, err := tt.RelativeDate(fvsw.NowLocal, kebabize(string(*where.RelativeDate)))
 			if err != nil {
-				panic(err)
+				return q, fmt.Errorf("invalid relative_date %q: %w", *where.RelativeDate, err)
 			}
 			where.ServiceDate = tzTruncate(s, fvsw.NowLocal.Location())
 		}
@@ -227,5 +238,5 @@ func tripSelect(limit *int, after *model.Cursor, ids []int, active bool, permFil
 
 	// Handle permissions
 	q = pfJoinCheckFv(q, permFilter)
-	return q
+	return q, nil
 }

--- a/server/gql/loaders.go
+++ b/server/gql/loaders.go
@@ -627,7 +627,13 @@ func paramGroupQuery[
 			// Run query function
 			ents, err := queryFunc(ctx, pgroup.Limit, pgroup.Where, pgroup.Keys)
 			if err != nil {
-				panic(err)
+				// Surface the failure to every caller in this group via the
+				// per-index errs slice (the existing dataloader path consumes
+				// errs[idx]), and skip merging results for this group.
+				for _, idx := range pgroup.Index {
+					errs[idx] = err
+				}
+				continue
 			}
 
 			// Group using keyFunc and merge into output

--- a/server/model/perm_filter.go
+++ b/server/model/perm_filter.go
@@ -2,10 +2,10 @@ package model
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 
 	"github.com/interline-io/log"
+	"github.com/interline-io/transitland-lib/internal/util"
 	"github.com/interline-io/transitland-lib/server/auth/authz"
 )
 
@@ -119,20 +119,12 @@ func AddPerms(checker Checker) func(http.Handler) http.Handler {
 			ctx, err := WithPerms(r.Context(), checker)
 			if err != nil {
 				log.For(r.Context()).Error().Err(err).Msg("AddPerms: failed to resolve caller permissions")
-				writePermJsonError(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				util.WriteJsonError(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 				return
 			}
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
-}
-
-func writePermJsonError(w http.ResponseWriter, msg string, statusCode int) {
-	a := map[string]string{"error": msg}
-	jj, _ := json.Marshal(&a)
-	w.Header().Add("Content-Type", "application/json")
-	w.WriteHeader(statusCode)
-	w.Write(jj)
 }
 
 func refsToInts(refs []authz.ObjectRef) []int {

--- a/server/model/perm_filter.go
+++ b/server/model/perm_filter.go
@@ -2,8 +2,10 @@ package model
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 
+	"github.com/interline-io/log"
 	"github.com/interline-io/transitland-lib/server/auth/authz"
 )
 
@@ -75,10 +77,13 @@ func PermsForContext(ctx context.Context) *PermFilter {
 //   - No existing filter: checker results are used directly
 //   - Existing filter + checker results: creates new filter with merged, deduplicated IDs
 //   - Either filter has IsGlobalAdmin=true: resulting filter has IsGlobalAdmin=true
-func WithPerms(ctx context.Context, checker Checker) context.Context {
+//
+// Returns an error if the Checker fails to resolve the caller's permissions.
+// The returned context still has the original PermFilter (if any) untouched.
+func WithPerms(ctx context.Context, checker Checker) (context.Context, error) {
 	checkerPf, err := checkActive(ctx, checker)
 	if err != nil {
-		panic(err)
+		return ctx, err
 	}
 
 	existing, hasExisting := ctx.Value(pfCtxKey).(*PermFilter)
@@ -101,21 +106,33 @@ func WithPerms(ctx context.Context, checker Checker) context.Context {
 			AllowedFeedVersions: dedupeInts(mergedFvs),
 			IsGlobalAdmin:       existing.IsGlobalAdmin || checkerPf.IsGlobalAdmin,
 		}
-		return context.WithValue(ctx, pfCtxKey, merged)
+		return context.WithValue(ctx, pfCtxKey, merged), nil
 	}
 
 	// No existing PermFilter, set the checker's result
-	return context.WithValue(ctx, pfCtxKey, checkerPf)
+	return context.WithValue(ctx, pfCtxKey, checkerPf), nil
 }
 
 func AddPerms(checker Checker) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx := r.Context()
-			r = r.WithContext(WithPerms(ctx, checker))
-			next.ServeHTTP(w, r)
+			ctx, err := WithPerms(r.Context(), checker)
+			if err != nil {
+				log.For(r.Context()).Error().Err(err).Msg("AddPerms: failed to resolve caller permissions")
+				writePermJsonError(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
+			}
+			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
+}
+
+func writePermJsonError(w http.ResponseWriter, msg string, statusCode int) {
+	a := map[string]string{"error": msg}
+	jj, _ := json.Marshal(&a)
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	w.Write(jj)
 }
 
 func refsToInts(refs []authz.ObjectRef) []int {

--- a/server/model/perm_filter_test.go
+++ b/server/model/perm_filter_test.go
@@ -2,6 +2,9 @@ package model
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"sort"
 	"testing"
@@ -423,4 +426,63 @@ func TestCheckActive(t *testing.T) {
 			t.Error("expected IsGlobalAdmin to be true")
 		}
 	})
+}
+
+// AddPerms must fail closed when the Checker can't resolve perms: 500 to the
+// client, downstream handler never invoked. Previously this path panicked.
+func TestAddPerms_CheckerErrorReturns500(t *testing.T) {
+	downstreamCalled := false
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		downstreamCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := AddPerms(&mockChecker{shouldError: true})(downstream)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	handler.ServeHTTP(rec, req)
+
+	if downstreamCalled {
+		t.Error("downstream handler should not be invoked when checker fails")
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected status 500, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response body is not JSON: %v (%s)", err, rec.Body.String())
+	}
+	if body["error"] == "" {
+		t.Errorf("expected error field in body, got %v", body)
+	}
+}
+
+func TestAddPerms_SuccessForwardsToDownstream(t *testing.T) {
+	downstreamCalled := false
+	var seenPf *PermFilter
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		downstreamCalled = true
+		seenPf = PermsForContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := AddPerms(&mockChecker{feeds: []int{1, 2}})(downstream)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	handler.ServeHTTP(rec, req)
+
+	if !downstreamCalled {
+		t.Fatal("downstream handler should be invoked on checker success")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+	if !reflect.DeepEqual(sortedInts(seenPf.AllowedFeeds), []int{1, 2}) {
+		t.Errorf("expected downstream ctx to carry checker's feeds [1, 2], got %v", seenPf.AllowedFeeds)
+	}
 }

--- a/server/model/perm_filter_test.go
+++ b/server/model/perm_filter_test.go
@@ -216,7 +216,7 @@ func TestWithPermFilter(t *testing.T) {
 
 		// Simulate what WithPerms would do - it should create a new filter
 		checker := &mockChecker{feeds: []int{4, 5}}
-		ctx = WithPerms(ctx, checker)
+		ctx, _ = WithPerms(ctx, checker)
 
 		// Original should be unchanged
 		if !reflect.DeepEqual(original.AllowedFeeds, []int{1, 2, 3}) {
@@ -240,7 +240,7 @@ func TestWithPerms(t *testing.T) {
 	t.Run("no existing filter - sets checker result", func(t *testing.T) {
 		ctx := context.Background()
 		checker := &mockChecker{feeds: []int{1, 2}, feedVersions: []int{10, 20}}
-		ctx = WithPerms(ctx, checker)
+		ctx, _ = WithPerms(ctx, checker)
 
 		pf := PermsForContext(ctx)
 		if !reflect.DeepEqual(sortedInts(pf.AllowedFeeds), []int{1, 2}) {
@@ -257,7 +257,7 @@ func TestWithPerms(t *testing.T) {
 		ctx = WithPermFilter(ctx, existing)
 
 		checker := &mockChecker{feeds: []int{3, 4}, feedVersions: []int{20, 30}}
-		ctx = WithPerms(ctx, checker)
+		ctx, _ = WithPerms(ctx, checker)
 
 		pf := PermsForContext(ctx)
 		if !reflect.DeepEqual(sortedInts(pf.AllowedFeeds), []int{1, 2, 3, 4}) {
@@ -275,7 +275,7 @@ func TestWithPerms(t *testing.T) {
 
 		// Checker returns overlapping IDs
 		checker := &mockChecker{feeds: []int{2, 3, 4}, feedVersions: []int{20, 30}}
-		ctx = WithPerms(ctx, checker)
+		ctx, _ = WithPerms(ctx, checker)
 
 		pf := PermsForContext(ctx)
 		if !reflect.DeepEqual(sortedInts(pf.AllowedFeeds), []int{1, 2, 3, 4}) {
@@ -292,7 +292,7 @@ func TestWithPerms(t *testing.T) {
 		ctx = WithPermFilter(ctx, existing)
 
 		checker := &mockChecker{feeds: []int{3}, feedVersions: []int{20}}
-		ctx = WithPerms(ctx, checker)
+		ctx, _ = WithPerms(ctx, checker)
 
 		pf := PermsForContext(ctx)
 		if pf == existing {
@@ -306,7 +306,7 @@ func TestWithPerms(t *testing.T) {
 		ctx = WithPermFilter(ctx, existing)
 
 		checker := &mockChecker{isAdmin: true}
-		ctx = WithPerms(ctx, checker)
+		ctx, _ = WithPerms(ctx, checker)
 
 		// For admin, the filter should have IsGlobalAdmin=true
 		pf := PermsForContext(ctx)
@@ -321,7 +321,7 @@ func TestWithPerms(t *testing.T) {
 	t.Run("global admin - no existing filter", func(t *testing.T) {
 		ctx := context.Background()
 		checker := &mockChecker{isAdmin: true}
-		ctx = WithPerms(ctx, checker)
+		ctx, _ = WithPerms(ctx, checker)
 
 		pf := PermsForContext(ctx)
 		if pf == nil {
@@ -347,7 +347,7 @@ func TestWithPerms(t *testing.T) {
 		ctx = WithPermFilter(ctx, existing)
 
 		checker := &mockChecker{feeds: []int{1, 2}} // non-admin checker
-		ctx = WithPerms(ctx, checker)
+		ctx, _ = WithPerms(ctx, checker)
 
 		pf := PermsForContext(ctx)
 		if !pf.IsGlobalAdmin {
@@ -375,7 +375,7 @@ func TestWithPerms_ThreadSafety(t *testing.T) {
 		ctx = WithPermFilter(ctx, original)
 
 		checker := &mockChecker{feeds: []int{4, 5}, feedVersions: []int{30}}
-		_ = WithPerms(ctx, checker)
+		_, _ = WithPerms(ctx, checker)
 
 		// Verify original was not mutated
 		if !reflect.DeepEqual(original.AllowedFeeds, originalFeedsCopy) {


### PR DESCRIPTION
## Summary
Converts four production-observed `panic(err)` sites in request paths to structured error returns so a bad row, malformed enum input, or checker outage no longer takes down the request. Closes interline-io/tlv2#337.

### Dataloader batch
- `paramGroupQuery` in `server/gql/loaders.go` no longer panics when the inner query function returns an error. The error is spread across every input index in the failing param group via the existing `errs[]` slice; dataloader consumers surface it as a per-key error.

### WithPerms / AddPerms
- `model.WithPerms` returns `(context.Context, error)` instead of panicking when the Checker can't resolve the caller's permissions. The returned context is the original ctx on error, with no merged PermFilter applied.
- The `AddPerms` HTTP middleware logs and writes a JSON 500 via `internal/util.WriteJsonError` on Checker failure and does not call the downstream handler. Previously this path panicked.
- `checkActive`'s nil-Checker panic is preserved (it's a config-time misconfiguration, not a runtime error).

### Mutations
- `scanCol` in `server/finders/dbfinder/mutations.go` takes a non-nil `*error` accumulator instead of panicking on Scan failure. Once `*errp` is set, subsequent scanCol calls short-circuit, so callers chain several and inspect a single error at the end.
- `scanCol` skips its internal append when `colname` is empty, so the existing sites that pre-append the column name explicitly (parent_station, level_id, from_stop_id, to_stop_id) keep working — they pass `""` to get only the Scan side effect.
- The four mutation callbacks (`Stop`, `StopExternalReference`, `Pathway`, `Level`) declare `var err error` and propagate it.

### Trips
- `tripSelect` in `server/finders/dbfinder/trip.go` returns `(sq.SelectBuilder, error)` instead of panicking on a `RelativeDate` enum-parse failure. The three callers (`FindTrips`, `TripsByRouteIDs`, `TripsByFeedVersionIDs`) propagate the error.

### Tests
- New `TestAddPerms_CheckerErrorReturns500` and `TestAddPerms_SuccessForwardsToDownstream` in `server/model/perm_filter_test.go` lock in the middleware's fail-closed 500 behavior and the happy-path context propagation (stdlib `httptest`, no DB).
- Existing `WithPerms` test sites updated to consume the new `(ctx, error)` return.

### Behavior changes to be aware of
- Checker resolution failures now return HTTP 500 to the client instead of crashing the process (or relying on panic recovery, depending on framework). Callers that never received error responses for these conditions will start seeing them.
- Malformed `RelativeDate` enum values now return a structured GraphQL error instead of crashing the request.
- Dataloader batch failures now propagate as per-key errors instead of crashing the entire request.
- `scanCol` Scan failures now surface as wrapped errors (`scan <col>: <inner>`) on the mutation response instead of crashing.

## Test plan
- `go test ./server/...`
- Send a mutation with a malformed `RelativeDate` enum and confirm a structured GraphQL error is returned rather than a 500 / crash.
- Stub the Checker to return an error and confirm `/query` returns a 500 JSON body and the request log shows the `AddPerms: failed to resolve caller permissions` error.
