### PR TITLE
Partial rebuild-stats

### DIFF
--- a/cmds/rebuild_stats.go
+++ b/cmds/rebuild_stats.go
@@ -95,7 +95,7 @@ func (cmd *RebuildStatsCommand) Parse(args []string) error {
 			}
 		}
 	}
-	if err := (stats.WriteOptions{Stats: cmd.Options.Stats}).Validate(); err != nil {
+	if err := stats.ValidateStatNames(cmd.Options.Stats); err != nil {
 		return err
 	}
 	return nil
@@ -111,9 +111,7 @@ func (cmd *RebuildStatsCommand) Run(ctx context.Context) error {
 		cmd.Adapter = writer.Adapter
 		defer writer.Close()
 	}
-	// Query to get FVs to import. Match the import_cmd default-query filter:
-	// skip soft-deleted feeds, soft-deleted feed versions, and feed versions
-	// missing the sha1/file pointer needed to open the GTFS file from storage.
+	// Match import_cmd's default-query filter: skip soft-deleted and storage-less FVs.
 	q := cmd.Adapter.Sqrl().
 		Select("feed_versions.id").
 		From("feed_versions").
@@ -144,23 +142,12 @@ func (cmd *RebuildStatsCommand) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	// Warn if explicit --fvid / --fv-sha1 selectors were dropped by the
-	// default-query filter (e.g. caller asked for a soft-deleted feed version
-	// or one missing sha1/file). Only checked when a single selector is used;
-	// when both are set they are AND'd at the SQL level and a "requested
-	// count" isn't meaningful.
-	var expected int
-	switch {
-	case len(cmd.FVIDs) > 0 && len(cmd.FVSHA1) == 0:
-		expected = len(uniqueStrings(cmd.FVIDs))
-	case len(cmd.FVSHA1) > 0 && len(cmd.FVIDs) == 0:
-		expected = len(uniqueStrings(cmd.FVSHA1))
-	}
-	if expected > 0 && len(qrs) < expected {
-		log.For(ctx).Warn().Msgf(
-			"Requested %d feed versions but only %d will be processed; %d were skipped (soft-deleted feed/feed_version, missing sha1/file, or not found)",
-			expected, len(qrs), expected-len(qrs),
-		)
+	if expected := explicitSelectorCount(cmd.FVIDs, cmd.FVSHA1); expected > len(qrs) {
+		log.For(ctx).Warn().
+			Int("requested", expected).
+			Int("processed", len(qrs)).
+			Int("skipped", expected-len(qrs)).
+			Msg("some explicitly requested feed versions were skipped (soft-deleted, missing sha1/file, or not found)")
 	}
 	///////////////
 	// Here we go
@@ -187,17 +174,25 @@ func (cmd *RebuildStatsCommand) Run(ctx context.Context) error {
 	return nil
 }
 
-func uniqueStrings(vals []string) []string {
-	seen := map[string]bool{}
-	var out []string
-	for _, v := range vals {
-		if seen[v] {
-			continue
-		}
-		seen[v] = true
-		out = append(out, v)
+// explicitSelectorCount returns the number of distinct explicit FV selectors
+// when exactly one of fvids/sha1s is set. When both or neither are set,
+// returns 0: with both, they are AND'd at the SQL level and "requested count"
+// isn't meaningful; with neither, no explicit selection was made.
+func explicitSelectorCount(fvids, sha1s []string) int {
+	var sel []string
+	switch {
+	case len(fvids) > 0 && len(sha1s) == 0:
+		sel = fvids
+	case len(sha1s) > 0 && len(fvids) == 0:
+		sel = sha1s
+	default:
+		return 0
 	}
-	return out
+	seen := map[string]bool{}
+	for _, v := range sel {
+		seen[v] = true
+	}
+	return len(seen)
 }
 
 func rebuildStatsWorker(id int, ctx context.Context, adapter tldb.Adapter, dryrun bool, jobs <-chan RebuildStatsOptions, results chan<- RebuildStatsResult, wg *sync.WaitGroup) {

--- a/cmds/rebuild_stats.go
+++ b/cmds/rebuild_stats.go
@@ -144,6 +144,24 @@ func (cmd *RebuildStatsCommand) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// Warn if explicit --fvid / --fv-sha1 selectors were dropped by the
+	// default-query filter (e.g. caller asked for a soft-deleted feed version
+	// or one missing sha1/file). Only checked when a single selector is used;
+	// when both are set they are AND'd at the SQL level and a "requested
+	// count" isn't meaningful.
+	var expected int
+	switch {
+	case len(cmd.FVIDs) > 0 && len(cmd.FVSHA1) == 0:
+		expected = len(uniqueStrings(cmd.FVIDs))
+	case len(cmd.FVSHA1) > 0 && len(cmd.FVIDs) == 0:
+		expected = len(uniqueStrings(cmd.FVSHA1))
+	}
+	if expected > 0 && len(qrs) < expected {
+		log.For(ctx).Warn().Msgf(
+			"Requested %d feed versions but only %d will be processed; %d were skipped (soft-deleted feed/feed_version, missing sha1/file, or not found)",
+			expected, len(qrs), expected-len(qrs),
+		)
+	}
 	///////////////
 	// Here we go
 	log.For(ctx).Info().Msgf("Rebuilding stats for %d feed versions", len(qrs))
@@ -167,6 +185,19 @@ func (cmd *RebuildStatsCommand) Run(ctx context.Context) error {
 	}
 	wg.Wait()
 	return nil
+}
+
+func uniqueStrings(vals []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, v := range vals {
+		if seen[v] {
+			continue
+		}
+		seen[v] = true
+		out = append(out, v)
+	}
+	return out
 }
 
 func rebuildStatsWorker(id int, ctx context.Context, adapter tldb.Adapter, dryrun bool, jobs <-chan RebuildStatsOptions, results chan<- RebuildStatsResult, wg *sync.WaitGroup) {

--- a/cmds/rebuild_stats.go
+++ b/cmds/rebuild_stats.go
@@ -3,6 +3,7 @@ package cmds
 import (
 	"context"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -23,6 +24,7 @@ type RebuildStatsOptions struct {
 	Storage                 string
 	ValidationReportStorage string
 	SaveValidationReport    bool
+	Stats                   []string
 }
 
 type RebuildStatsResult struct {
@@ -61,6 +63,7 @@ func (cmd *RebuildStatsCommand) AddFlags(fl *pflag.FlagSet) {
 	fl.StringVar(&cmd.Options.Storage, "storage", "", "Storage destination; can be s3://... az://... or path to a directory")
 	fl.BoolVar(&cmd.Options.SaveValidationReport, "validation-report", false, "Save validation report")
 	fl.StringVar(&cmd.Options.ValidationReportStorage, "validation-report-storage", "", "Storage path for saving validation report JSON")
+	fl.StringSliceVar(&cmd.Options.Stats, "stats", nil, "Subset of stats to rebuild (default all); valid: "+strings.Join(stats.AllStats, ","))
 }
 
 // Parse command line flags
@@ -91,6 +94,9 @@ func (cmd *RebuildStatsCommand) Parse(args []string) error {
 				cmd.FVSHA1 = append(cmd.FVSHA1, line)
 			}
 		}
+	}
+	if err := (stats.WriteOptions{Stats: cmd.Options.Stats}).Validate(); err != nil {
+		return err
 	}
 	return nil
 }
@@ -143,6 +149,7 @@ func (cmd *RebuildStatsCommand) Run(ctx context.Context) error {
 			Storage:                 cmd.Options.Storage,
 			ValidationReportStorage: cmd.Options.ValidationReportStorage,
 			SaveValidationReport:    cmd.Options.SaveValidationReport,
+			Stats:                   cmd.Options.Stats,
 		}
 	}
 	close(jobs)
@@ -209,7 +216,7 @@ func rebuildStatsMain(ctx context.Context, adapter tldb.Adapter, opts RebuildSta
 	}
 	// Save
 	errImport := adapter.Tx(func(atx tldb.Adapter) error {
-		if err := stats.CreateFeedStats(ctx, atx, reader, fv.ID); err != nil {
+		if err := stats.CreateFeedStats(ctx, atx, reader, fv.ID, stats.WriteOptions{Stats: opts.Stats}); err != nil {
 			return err
 		}
 		if opts.SaveValidationReport {

--- a/cmds/rebuild_stats.go
+++ b/cmds/rebuild_stats.go
@@ -111,11 +111,17 @@ func (cmd *RebuildStatsCommand) Run(ctx context.Context) error {
 		cmd.Adapter = writer.Adapter
 		defer writer.Close()
 	}
-	// Query to get FVs to import
+	// Query to get FVs to import. Match the import_cmd default-query filter:
+	// skip soft-deleted feeds, soft-deleted feed versions, and feed versions
+	// missing the sha1/file pointer needed to open the GTFS file from storage.
 	q := cmd.Adapter.Sqrl().
 		Select("feed_versions.id").
 		From("feed_versions").
 		Join("current_feeds ON current_feeds.id = feed_versions.feed_id").
+		Where("current_feeds.deleted_at IS NULL").
+		Where("feed_versions.deleted_at IS NULL").
+		Where("feed_versions.sha1 <> ''").
+		Where("feed_versions.file <> ''").
 		OrderBy("feed_versions.id desc")
 	if len(cmd.FeedIDs) > 0 {
 		// Limit to specified feeds

--- a/doc/cli/transitland_rebuild-stats.md
+++ b/doc/cli/transitland_rebuild-stats.md
@@ -21,6 +21,7 @@ transitland rebuild-stats [flags] [feeds...]
       --fvid strings                       Rebuild stats for specific feed version ID
       --fvid-file string                   Specify feed version IDs in file, one per line; equivalent to multiple --fvid
   -h, --help                               help for rebuild-stats
+      --stats strings                      Subset of stats to rebuild (default all); valid: file_infos,service_levels,service_windows,onestop_ids,geohash
       --storage string                     Storage destination; can be s3://... az://... or path to a directory
       --validation-report                  Save validation report
       --validation-report-storage string   Storage path for saving validation report JSON

--- a/fetch/static_fetch.go
+++ b/fetch/static_fetch.go
@@ -190,7 +190,7 @@ func (sfv *StaticFetchValidator) ValidateResponse(ctx context.Context, atx tldb.
 	}
 
 	// Save stats records (includes stop geohash cells for feed/feed_version spatial queries)
-	if err := stats.WriteFeedVersionStats(ctx, atx, feedVersionStats, fv.ID); err != nil {
+	if err := stats.WriteFeedVersionStats(ctx, atx, feedVersionStats, fv.ID, stats.WriteOptions{}); err != nil {
 		// Fatal err
 		return fetchValidationResult, err
 	}

--- a/importer/unimporter_test.go
+++ b/importer/unimporter_test.go
@@ -44,7 +44,7 @@ func setupImport(ctx context.Context, t *testing.T, atx tldb.Adapter) int {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := stats.CreateFeedStats(ctx, atx, tlreader, fvid); err != nil {
+	if err := stats.CreateFeedStats(ctx, atx, tlreader, fvid, stats.WriteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	// Import

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -15,9 +15,8 @@ import (
 	"github.com/interline-io/transitland-lib/tt"
 )
 
-// Stat names accepted by WriteOptions.Stats. Each stat maps to one or more
-// derived-stat tables; the write path deletes and re-inserts only the tables
-// for the selected stats.
+// Stat names accepted by WriteOptions.Stats. Each maps to one or more
+// FetchStatDerivedTables; only the selected stats are deleted and re-inserted.
 const (
 	StatFileInfos      = "file_infos"
 	StatServiceLevels  = "service_levels"
@@ -36,7 +35,8 @@ var AllStats = []string{
 }
 
 // statTables maps a stat name to the FetchStatDerivedTables it writes. The
-// union across all entries must equal dmfr.GetFeedVersionTables().FetchStatDerivedTables.
+// union across all entries must equal dmfr.GetFeedVersionTables().FetchStatDerivedTables;
+// TestStatRegistrationConsistency enforces this.
 var statTables = map[string][]string{
 	StatFileInfos:      {"feed_version_file_infos"},
 	StatServiceLevels:  {"feed_version_service_levels"},
@@ -49,38 +49,35 @@ var statTables = map[string][]string{
 	StatGeohash: {"tl_feed_version_geohashes"},
 }
 
-// WriteOptions configures which stats WriteFeedVersionStats persists.
-// Builders always run regardless of selection; this only gates the database
-// delete/insert step so callers can target a single stat without churning
-// records for the others.
+// WriteOptions configures which stats WriteFeedVersionStats persists. Builders
+// always run regardless of selection; only the database delete/insert step is
+// gated, so callers can target a single stat without churning unrelated records.
 type WriteOptions struct {
-	// Stats is the subset of stat names to write; an empty slice means all.
+	// Subset of stat names to write; empty means all.
 	Stats []string
 }
 
-// Validate returns an error if any stat name in o.Stats is not recognized.
-// Callers can use this to fail fast before doing expensive work (reading the
-// GTFS feed, opening a transaction, etc.) that WriteFeedVersionStats would
-// otherwise discover late.
-func (o WriteOptions) Validate() error {
-	_, err := o.resolveStats()
-	return err
+// ValidateStatNames returns an error if any name in names is not a recognized
+// stat. Empty/nil is valid and means "all stats".
+func ValidateStatNames(names []string) error {
+	for _, s := range names {
+		if _, ok := statTables[s]; !ok {
+			return fmt.Errorf("unknown stat name %q (valid: %v)", s, AllStats)
+		}
+	}
+	return nil
 }
 
-// resolveStats validates the selection and returns the set of stat names to
-// write. An empty selection enables every stat in AllStats.
 func (o WriteOptions) resolveStats() (map[string]bool, error) {
-	enabled := map[string]bool{}
-	if len(o.Stats) == 0 {
-		for _, s := range AllStats {
-			enabled[s] = true
-		}
-		return enabled, nil
+	if err := ValidateStatNames(o.Stats); err != nil {
+		return nil, err
 	}
-	for _, s := range o.Stats {
-		if _, ok := statTables[s]; !ok {
-			return nil, fmt.Errorf("unknown stat name %q (valid: %v)", s, AllStats)
-		}
+	enabled := map[string]bool{}
+	src := o.Stats
+	if len(src) == 0 {
+		src = AllStats
+	}
+	for _, s := range src {
 		enabled[s] = true
 	}
 	return enabled, nil
@@ -201,7 +198,6 @@ func WriteFeedVersionStats(ctx context.Context, atx tldb.Adapter, stats FeedVers
 		return err
 	}
 
-	// Delete existing records for selected stats only.
 	for _, stat := range AllStats {
 		if !enabled[stat] {
 			continue

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -2,6 +2,7 @@ package stats
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/interline-io/log"
 	"github.com/interline-io/transitland-lib/adapters"
@@ -13,6 +14,77 @@ import (
 	"github.com/interline-io/transitland-lib/tldb"
 	"github.com/interline-io/transitland-lib/tt"
 )
+
+// Stat names accepted by WriteOptions.Stats. Each stat maps to one or more
+// derived-stat tables; the write path deletes and re-inserts only the tables
+// for the selected stats.
+const (
+	StatFileInfos      = "file_infos"
+	StatServiceLevels  = "service_levels"
+	StatServiceWindows = "service_windows"
+	StatOnestopIDs     = "onestop_ids"
+	StatGeohash        = "geohash"
+)
+
+// AllStats lists every supported stat name in the order they are written.
+var AllStats = []string{
+	StatFileInfos,
+	StatServiceLevels,
+	StatServiceWindows,
+	StatOnestopIDs,
+	StatGeohash,
+}
+
+// statTables maps a stat name to the FetchStatDerivedTables it writes. The
+// union across all entries must equal dmfr.GetFeedVersionTables().FetchStatDerivedTables.
+var statTables = map[string][]string{
+	StatFileInfos:      {"feed_version_file_infos"},
+	StatServiceLevels:  {"feed_version_service_levels"},
+	StatServiceWindows: {"feed_version_service_windows"},
+	StatOnestopIDs: {
+		"feed_version_agency_onestop_ids",
+		"feed_version_route_onestop_ids",
+		"feed_version_stop_onestop_ids",
+	},
+	StatGeohash: {"tl_feed_version_geohashes"},
+}
+
+// WriteOptions configures which stats WriteFeedVersionStats persists.
+// Builders always run regardless of selection; this only gates the database
+// delete/insert step so callers can target a single stat without churning
+// records for the others.
+type WriteOptions struct {
+	// Stats is the subset of stat names to write; an empty slice means all.
+	Stats []string
+}
+
+// Validate returns an error if any stat name in o.Stats is not recognized.
+// Callers can use this to fail fast before doing expensive work (reading the
+// GTFS feed, opening a transaction, etc.) that WriteFeedVersionStats would
+// otherwise discover late.
+func (o WriteOptions) Validate() error {
+	_, err := o.resolveStats()
+	return err
+}
+
+// resolveStats validates the selection and returns the set of stat names to
+// write. An empty selection enables every stat in AllStats.
+func (o WriteOptions) resolveStats() (map[string]bool, error) {
+	enabled := map[string]bool{}
+	if len(o.Stats) == 0 {
+		for _, s := range AllStats {
+			enabled[s] = true
+		}
+		return enabled, nil
+	}
+	for _, s := range o.Stats {
+		if _, ok := statTables[s]; !ok {
+			return nil, fmt.Errorf("unknown stat name %q (valid: %v)", s, AllStats)
+		}
+		enabled[s] = true
+	}
+	return enabled, nil
+}
 
 type FeedVersionStats struct {
 	ServiceWindow    dmfr.FeedVersionServiceWindow
@@ -115,55 +187,68 @@ func NewFeedVersionOnestopIDBuilder() *FeedVersionOnestopIDBuilder {
 
 //////////
 
-func CreateFeedStats(ctx context.Context, atx tldb.Adapter, reader *tlcsv.Reader, fvid int) error {
+func CreateFeedStats(ctx context.Context, atx tldb.Adapter, reader *tlcsv.Reader, fvid int, opts WriteOptions) error {
 	stats, err := NewFeedStatsFromReader(reader)
 	if err != nil {
 		return err
 	}
-	return WriteFeedVersionStats(ctx, atx, stats, fvid)
+	return WriteFeedVersionStats(ctx, atx, stats, fvid, opts)
 }
 
-func WriteFeedVersionStats(ctx context.Context, atx tldb.Adapter, stats FeedVersionStats, fvid int) error {
-	// Delete any existing records
-	fvt := dmfr.GetFeedVersionTables()
-	tables := fvt.FetchStatDerivedTables
-	for _, table := range tables {
-		if err := FeedVersionTableDelete(ctx, atx, table, fvid, false); err != nil {
+func WriteFeedVersionStats(ctx context.Context, atx tldb.Adapter, stats FeedVersionStats, fvid int, opts WriteOptions) error {
+	enabled, err := opts.resolveStats()
+	if err != nil {
+		return err
+	}
+
+	// Delete existing records for selected stats only.
+	for _, stat := range AllStats {
+		if !enabled[stat] {
+			continue
+		}
+		for _, table := range statTables[stat] {
+			if err := FeedVersionTableDelete(ctx, atx, table, fvid, false); err != nil {
+				return err
+			}
+		}
+	}
+
+	if enabled[StatServiceWindows] {
+		fvsw := stats.ServiceWindow
+		fvsw.FeedVersionID = fvid
+		if _, err := atx.Insert(ctx, &fvsw); err != nil {
 			return err
 		}
 	}
 
-	// Insert FVSW
-	fvsw := stats.ServiceWindow
-	fvsw.FeedVersionID = fvid
-	if _, err := atx.Insert(ctx, &fvsw); err != nil {
-		return err
+	if enabled[StatOnestopIDs] {
+		if _, err := atx.MultiInsert(ctx, setFvid(convertToAny(stats.AgencyOnestopIDs), fvid)); err != nil {
+			return err
+		}
+		if _, err := atx.MultiInsert(ctx, setFvid(convertToAny(stats.RouteOnestopIDs), fvid)); err != nil {
+			return err
+		}
+		if _, err := atx.MultiInsert(ctx, setFvid(convertToAny(stats.StopOnestopIDs), fvid)); err != nil {
+			return err
+		}
 	}
 
-	// Batch insert OSIDs
-	if _, err := atx.MultiInsert(ctx, setFvid(convertToAny(stats.AgencyOnestopIDs), fvid)); err != nil {
-		return err
-	}
-	if _, err := atx.MultiInsert(ctx, setFvid(convertToAny(stats.RouteOnestopIDs), fvid)); err != nil {
-		return err
-	}
-	if _, err := atx.MultiInsert(ctx, setFvid(convertToAny(stats.StopOnestopIDs), fvid)); err != nil {
-		return err
+	if enabled[StatFileInfos] {
+		if _, err := atx.MultiInsert(ctx, setFvid(convertToAny(stats.FileInfos), fvid)); err != nil {
+			return err
+		}
 	}
 
-	// Insert FVFIs
-	if _, err := atx.MultiInsert(ctx, setFvid(convertToAny(stats.FileInfos), fvid)); err != nil {
-		return err
+	if enabled[StatServiceLevels] {
+		if _, err := atx.MultiInsert(ctx, setFvid(convertToAny(stats.ServiceLevels), fvid)); err != nil {
+			return err
+		}
 	}
 
-	// Batch insert FVSLs
-	if _, err := atx.MultiInsert(ctx, setFvid(convertToAny(stats.ServiceLevels), fvid)); err != nil {
-		return err
-	}
-
-	// Batch insert geohashes
-	if err := writeFeedVersionGeohashInserts(ctx, atx, fvid, stats.GeohashCells); err != nil {
-		return err
+	if enabled[StatGeohash] {
+		if err := writeFeedVersionGeohashInserts(ctx, atx, fvid, stats.GeohashCells); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -31,7 +31,7 @@ func TestStatRegistrationConsistency(t *testing.T) {
 	assert.Equal(t, len(AllStats), len(statTables), "AllStats and statTables have different lengths")
 }
 
-func TestWriteOptions_Validate(t *testing.T) {
+func TestValidateStatNames(t *testing.T) {
 	cases := []struct {
 		name    string
 		stats   []string
@@ -46,7 +46,7 @@ func TestWriteOptions_Validate(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := WriteOptions{Stats: tc.stats}.Validate()
+			err := ValidateStatNames(tc.stats)
 			if tc.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -1,0 +1,92 @@
+package stats
+
+import (
+	"testing"
+
+	"github.com/interline-io/transitland-lib/dmfr"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestStatTablesCoverFetchStatDerived guards against drift between statTables
+// (the WriteOptions stat-name → table mapping) and the canonical list in
+// dmfr.GetFeedVersionTables().FetchStatDerivedTables. If a new stat-derived
+// table is added without a corresponding statTables entry, the default
+// (no --stats flag) write path would silently skip deleting it on rebuild.
+func TestStatTablesCoverFetchStatDerived(t *testing.T) {
+	got := map[string]bool{}
+	for _, ts := range statTables {
+		for _, table := range ts {
+			got[table] = true
+		}
+	}
+	expected := dmfr.GetFeedVersionTables().FetchStatDerivedTables
+	for _, table := range expected {
+		assert.True(t, got[table], "table %q is in FetchStatDerivedTables but missing from statTables", table)
+	}
+	assert.Equal(t, len(expected), len(got), "statTables covers a different number of tables than FetchStatDerivedTables")
+}
+
+// TestAllStatsMatchesStatTables ensures every constant in AllStats has a
+// corresponding entry in statTables and vice versa.
+func TestAllStatsMatchesStatTables(t *testing.T) {
+	for _, stat := range AllStats {
+		_, ok := statTables[stat]
+		assert.True(t, ok, "AllStats entry %q has no statTables entry", stat)
+	}
+	assert.Equal(t, len(AllStats), len(statTables), "AllStats and statTables have different lengths")
+}
+
+func TestWriteOptions_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		stats   []string
+		wantErr bool
+	}{
+		{name: "empty means all", stats: nil, wantErr: false},
+		{name: "empty slice means all", stats: []string{}, wantErr: false},
+		{name: "single valid", stats: []string{StatGeohash}, wantErr: false},
+		{name: "multiple valid", stats: []string{StatGeohash, StatOnestopIDs, StatServiceLevels}, wantErr: false},
+		{name: "all valid names", stats: AllStats, wantErr: false},
+		{name: "single invalid", stats: []string{"badname"}, wantErr: true},
+		{name: "mix valid and invalid", stats: []string{StatGeohash, "badname"}, wantErr: true},
+		{name: "case sensitive", stats: []string{"Geohash"}, wantErr: true},
+		{name: "empty string is invalid", stats: []string{""}, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := WriteOptions{Stats: tc.stats}.Validate()
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestWriteOptions_resolveStats_defaults(t *testing.T) {
+	enabled, err := WriteOptions{}.resolveStats()
+	assert.NoError(t, err)
+	for _, stat := range AllStats {
+		assert.True(t, enabled[stat], "stat %q should be enabled when WriteOptions.Stats is empty", stat)
+	}
+	assert.Equal(t, len(AllStats), len(enabled))
+}
+
+func TestWriteOptions_resolveStats_subset(t *testing.T) {
+	enabled, err := WriteOptions{Stats: []string{StatGeohash}}.resolveStats()
+	assert.NoError(t, err)
+	assert.True(t, enabled[StatGeohash])
+	assert.False(t, enabled[StatFileInfos])
+	assert.False(t, enabled[StatServiceLevels])
+	assert.False(t, enabled[StatServiceWindows])
+	assert.False(t, enabled[StatOnestopIDs])
+}
+
+func TestWriteOptions_Validate_errorMessage(t *testing.T) {
+	err := WriteOptions{Stats: []string{"badname"}}.Validate()
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "badname")
+		assert.Contains(t, err.Error(), StatGeohash, "error should list valid stat names")
+	}
+}

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -7,28 +7,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestStatTablesCoverFetchStatDerived guards against drift between statTables
-// (the WriteOptions stat-name → table mapping) and the canonical list in
-// dmfr.GetFeedVersionTables().FetchStatDerivedTables. If a new stat-derived
-// table is added without a corresponding statTables entry, the default
-// (no --stats flag) write path would silently skip deleting it on rebuild.
-func TestStatTablesCoverFetchStatDerived(t *testing.T) {
-	got := map[string]bool{}
+// TestStatRegistrationConsistency guards against drift between three lists
+// that must stay aligned: statTables (stat-name → tables), AllStats (write
+// order), and dmfr.GetFeedVersionTables().FetchStatDerivedTables (canonical
+// stat-derived table list). A missing entry in any of them causes silent
+// skips at runtime.
+func TestStatRegistrationConsistency(t *testing.T) {
+	gotTables := map[string]bool{}
 	for _, ts := range statTables {
 		for _, table := range ts {
-			got[table] = true
+			gotTables[table] = true
 		}
 	}
-	expected := dmfr.GetFeedVersionTables().FetchStatDerivedTables
-	for _, table := range expected {
-		assert.True(t, got[table], "table %q is in FetchStatDerivedTables but missing from statTables", table)
+	for _, table := range dmfr.GetFeedVersionTables().FetchStatDerivedTables {
+		assert.True(t, gotTables[table], "table %q is in FetchStatDerivedTables but missing from statTables", table)
 	}
-	assert.Equal(t, len(expected), len(got), "statTables covers a different number of tables than FetchStatDerivedTables")
-}
+	assert.Equal(t, len(dmfr.GetFeedVersionTables().FetchStatDerivedTables), len(gotTables), "statTables covers a different number of tables than FetchStatDerivedTables")
 
-// TestAllStatsMatchesStatTables ensures every constant in AllStats has a
-// corresponding entry in statTables and vice versa.
-func TestAllStatsMatchesStatTables(t *testing.T) {
 	for _, stat := range AllStats {
 		_, ok := statTables[stat]
 		assert.True(t, ok, "AllStats entry %q has no statTables entry", stat)
@@ -43,9 +38,6 @@ func TestWriteOptions_Validate(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "empty means all", stats: nil, wantErr: false},
-		{name: "empty slice means all", stats: []string{}, wantErr: false},
-		{name: "single valid", stats: []string{StatGeohash}, wantErr: false},
-		{name: "multiple valid", stats: []string{StatGeohash, StatOnestopIDs, StatServiceLevels}, wantErr: false},
 		{name: "all valid names", stats: AllStats, wantErr: false},
 		{name: "single invalid", stats: []string{"badname"}, wantErr: true},
 		{name: "mix valid and invalid", stats: []string{StatGeohash, "badname"}, wantErr: true},
@@ -61,32 +53,5 @@ func TestWriteOptions_Validate(t *testing.T) {
 				assert.NoError(t, err)
 			}
 		})
-	}
-}
-
-func TestWriteOptions_resolveStats_defaults(t *testing.T) {
-	enabled, err := WriteOptions{}.resolveStats()
-	assert.NoError(t, err)
-	for _, stat := range AllStats {
-		assert.True(t, enabled[stat], "stat %q should be enabled when WriteOptions.Stats is empty", stat)
-	}
-	assert.Equal(t, len(AllStats), len(enabled))
-}
-
-func TestWriteOptions_resolveStats_subset(t *testing.T) {
-	enabled, err := WriteOptions{Stats: []string{StatGeohash}}.resolveStats()
-	assert.NoError(t, err)
-	assert.True(t, enabled[StatGeohash])
-	assert.False(t, enabled[StatFileInfos])
-	assert.False(t, enabled[StatServiceLevels])
-	assert.False(t, enabled[StatServiceWindows])
-	assert.False(t, enabled[StatOnestopIDs])
-}
-
-func TestWriteOptions_Validate_errorMessage(t *testing.T) {
-	err := WriteOptions{Stats: []string{"badname"}}.Validate()
-	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "badname")
-		assert.Contains(t, err.Error(), StatGeohash, "error should list valid stat names")
 	}
 }


### PR DESCRIPTION
## Summary

Adds a `--stats` flag to `transitland rebuild-stats` that selects which subset of fetch-derived stats get rebuilt. Existing behavior (rebuild all stats) is preserved when the flag is omitted. Motivated by needing to backfill the new `tl_feed_version_geohashes` table across all known feed versions without re-deleting and re-inserting unrelated stats records (onestop_ids, service_levels, service_windows, file_infos) per feed version.

Also tightens the rebuild-stats default query to skip soft-deleted feeds, soft-deleted feed versions, and feed versions missing the sha1/file pointer needed to open the GTFS file from storage, and warns when explicit `--fvid` / `--fv-sha1` selectors get dropped by that filter.

### `--stats` flag on rebuild-stats

- `transitland rebuild-stats --stats geohash` rebuilds only the geohash table for matched feed versions; other fetch-stat tables are untouched.
- Flag accepts a comma-separated list. Valid names: `file_infos`, `service_levels`, `service_windows`, `onestop_ids`, `geohash`. Unknown names error at flag parse time with the list of valid names, before any feed-version work begins.
- `onestop_ids` is one selectable stat that covers all three onestop-id tables (`feed_version_agency_onestop_ids`, `feed_version_route_onestop_ids`, `feed_version_stop_onestop_ids`), matching how the underlying builder produces them.

### stats package: `WriteOptions` and stat-name constants

- New `stats.WriteOptions{Stats: []string}` struct plumbed through `stats.CreateFeedStats` and `stats.WriteFeedVersionStats`. Empty `Stats` = write all stats (default behavior preserved).
- New exported constants `StatFileInfos`, `StatServiceLevels`, `StatServiceWindows`, `StatOnestopIDs`, `StatGeohash`, and `AllStats` enumerating the supported names.
- Internal `statTables` map names each stat to the `FetchStatDerivedTables` subset it owns. The union of all entries equals `dmfr.GetFeedVersionTables().FetchStatDerivedTables`.
- New `stats.ValidateStatNames(names []string) error` free function for fail-fast validation from callers (used by the CLI at flag-parse time).
- Builders are intentionally not gated — `NewFeedStatsFromReader` still runs every builder on every invocation. Selection only affects the database delete/insert step, where the cost actually lives (avoid churning unrelated table records, while keeping the compute path uniform).

### rebuild-stats default query filter

The rebuild-stats default query now matches the import_cmd phase-1 filter:

- `current_feeds.deleted_at IS NULL`
- `feed_versions.deleted_at IS NULL`
- `feed_versions.sha1 <> ''`
- `feed_versions.file <> ''`

These four conditions are required for the storage open in `rebuildStatsMain` to succeed; previously the default query would surface deleted or storage-less feed versions and only fail downstream.

### Warning for dropped explicit selectors

When exactly one of `--fvid` / `--fv-sha1` (or their `-file` variants) is used and the new filter drops some of them, a warning logs `requested` / `processed` / `skipped` counts as structured fields so an operator notices when, e.g., `--fvid 999` got silently skipped because FV 999 is soft-deleted. The check is skipped when both selectors are set (they AND at the SQL level and a "requested count" isn't meaningful).

### Caller updates

- `fetch/static_fetch.go` and `importer/unimporter_test.go` updated to pass `stats.WriteOptions{}` (default = all stats), preserving existing fetch and test behavior.

### Tests

- `TestStatRegistrationConsistency` — guards against drift between `statTables`, `AllStats`, and `dmfr.GetFeedVersionTables().FetchStatDerivedTables`. A missing entry in any of them causes silent skips at runtime.
- `TestValidateStatNames` — table-driven coverage of the validation entry point: empty/nil = ok, every name in `AllStats` = ok, unknown name = error, mix of valid+invalid = error, case-sensitive match, empty string rejected.

## Test plan

- `transitland rebuild-stats --help` shows the new `--stats` flag with the list of valid names.
- `transitland rebuild-stats --stats badname` exits with an error naming valid options, before opening the database.
- `transitland rebuild-stats --fvid <N> --stats geohash` against a feed version that already has full stats: confirm `tl_feed_version_geohashes` rows for that fvid are replaced and rows in the other six fetch-stat tables are untouched.
- `transitland rebuild-stats --fvid <N>` (no `--stats`) against a feed version: confirm all seven fetch-stat tables are replaced as before.
- `transitland rebuild-stats` with no `--fvid`/`--feed`: confirm matched feed versions exclude any with `deleted_at` set on the feed or feed version, and any with empty sha1 or file.
- `transitland rebuild-stats --fvid <deleted_fvid>`: confirm the warning log line fires with `requested=1 processed=0 skipped=1`.
- Run the standard fetch path on a small feed and confirm all fetch-stat tables are populated (regression check on the default `WriteOptions{}` path).