### PR TITLE
Harden github actions and pin github action dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - go
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/gonconfig.json
+++ b/.github/gonconfig.json
@@ -1,9 +1,0 @@
-{
-  "source": ["./cmd/transitland/transitland"],
-  "bundle_id": "io.interline.transitland-lib",
-  "sign": {},
-  "zip": {
-    "output_path": "transitland.zip"
-  }
-}
-  

--- a/.github/gonconfig.json
+++ b/.github/gonconfig.json
@@ -1,0 +1,8 @@
+{
+  "source": ["./cmd/transitland/transitland"],
+  "bundle_id": "io.interline.transitland-lib",
+  "sign": {},
+  "zip": {
+    "output_path": "transitland.zip"
+  }
+}

--- a/.github/workflows/check-go-generate.yml
+++ b/.github/workflows/check-go-generate.yml
@@ -2,7 +2,7 @@ name: Check Generated Code
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 permissions:
   pull-requests: write  # Needed for commenting on PRs
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0  # Required for git diff to work properly
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.26.3'
 
@@ -49,7 +49,7 @@ jobs:
           fi
 
       - name: Comment on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         if: steps.check_changes.outputs.has_changes == 'true'
         with:
           script: |
@@ -100,7 +100,7 @@ jobs:
             }
 
       - name: Update success comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         if: steps.check_changes.outputs.has_changes != 'true'
         with:
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,22 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: read
     steps:
       - name: Check Test Suite Status
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
-            // Use the release commit SHA if available, otherwise fall back to context.sha
-            let commitSha = context.sha;
-            if (github.event && github.event.release && github.event.release.target_commitish) {
-              commitSha = github.event.release.target_commitish;
-            }
-
             const { data: workflows } = await github.rest.actions.listWorkflowRunsForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'test.yml',
-              head_sha: commitSha,
+              head_sha: context.sha,
               status: 'completed'
             });
             const testRun = workflows.workflow_runs.find(run => run.conclusion === 'success');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,30 +79,18 @@ jobs:
         with:
           p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
           p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
-      - name: Codesign binary
-        env:
-          AC_APPLICATION_IDENTITY: ${{ secrets.AC_APPLICATION_IDENTITY }}
+      - name: Install gon via HomeBrew for code signing and app notarization
         run: |
-          codesign --sign "$AC_APPLICATION_IDENTITY" --options runtime --timestamp --force ./cmd/transitland/transitland
-      - name: Zip binary for notarization
-        run: |
-          ditto -c -k --sequesterRsrc ./cmd/transitland/transitland ./transitland.zip
-      - name: Notarize binary
+          brew install Bearer/tap/gon
+      - name: Sign the mac binaries with Gon
         timeout-minutes: 20
         env:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
           AC_PROVIDER: ${{ secrets.AC_PROVIDER }}
+          AC_APPLICATION_IDENTITY: ${{ secrets.AC_APPLICATION_IDENTITY }}
         run: |
-          xcrun notarytool submit ./transitland.zip --apple-id "$AC_USERNAME" --password "$AC_PASSWORD" --team-id "$AC_PROVIDER" --wait
-      - name: Fetch notarytool log on failure
-        if: failure()
-        env:
-          AC_USERNAME: ${{ secrets.AC_USERNAME }}
-          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
-          AC_PROVIDER: ${{ secrets.AC_PROVIDER }}
-        run: |
-          xcrun notarytool history --apple-id "$AC_USERNAME" --password "$AC_PASSWORD" --team-id "$AC_PROVIDER" || true
+          gon -log-level=debug -log-json ./.github/gonconfig.json
       - name: Store macOS binary
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -132,30 +120,18 @@ jobs:
         with:
           p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
           p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
-      - name: Codesign binary
-        env:
-          AC_APPLICATION_IDENTITY: ${{ secrets.AC_APPLICATION_IDENTITY }}
+      - name: Install gon via HomeBrew for code signing and app notarization
         run: |
-          codesign --sign "$AC_APPLICATION_IDENTITY" --options runtime --timestamp --force ./cmd/transitland/transitland
-      - name: Zip binary for notarization
-        run: |
-          ditto -c -k --sequesterRsrc ./cmd/transitland/transitland ./transitland.zip
-      - name: Notarize binary
+          brew install Bearer/tap/gon
+      - name: Sign the mac binaries with Gon
         timeout-minutes: 20
         env:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
           AC_PROVIDER: ${{ secrets.AC_PROVIDER }}
+          AC_APPLICATION_IDENTITY: ${{ secrets.AC_APPLICATION_IDENTITY }}
         run: |
-          xcrun notarytool submit ./transitland.zip --apple-id "$AC_USERNAME" --password "$AC_PASSWORD" --team-id "$AC_PROVIDER" --wait
-      - name: Fetch notarytool log on failure
-        if: failure()
-        env:
-          AC_USERNAME: ${{ secrets.AC_USERNAME }}
-          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
-          AC_PROVIDER: ${{ secrets.AC_PROVIDER }}
-        run: |
-          xcrun notarytool history --apple-id "$AC_USERNAME" --password "$AC_PASSWORD" --team-id "$AC_PROVIDER" || true
+          gon -log-level=debug -log-json ./.github/gonconfig.json
       - name: Store macOS binary
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,165 +1,185 @@
-name: "Release"
+name: Release
+
 on:
-  workflow_run:
-    workflows: ["Test Suite"]
-    types: [completed]
-    branches: [main] 
   release:
     types: [created]
-
-permissions:
-  contents: write
-  actions: write
-  pull-requests: write
 
 jobs:
   check-tests:
     runs-on: ubuntu-latest
-    # Only run check-tests for release events, since workflow_run already means tests passed
-    if: ${{ github.event_name == 'release' }}
+    permissions:
+      contents: read
     steps:
-    - name: Check Test Suite Status
-      uses: actions/github-script@v7
-      with:
-        script: |
-          // Use the release commit SHA if available, otherwise fall back to context.sha
-          let commitSha = context.sha;
-          if (github.event && github.event.release && github.event.release.target_commitish) {
-            commitSha = github.event.release.target_commitish;
-          }
-          
-          const { data: workflows } = await github.rest.actions.listWorkflowRunsForRepo({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            workflow_id: 'test.yml',
-            head_sha: commitSha,
-            status: 'completed'
-          });
-          const testRun = workflows.workflow_runs.find(run => run.conclusion === 'success');
-          if (!testRun) {
-            core.setFailed('Test Suite workflow must pass before release can be built');
-          }
+      - name: Check Test Suite Status
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            // Use the release commit SHA if available, otherwise fall back to context.sha
+            let commitSha = context.sha;
+            if (github.event && github.event.release && github.event.release.target_commitish) {
+              commitSha = github.event.release.target_commitish;
+            }
+
+            const { data: workflows } = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'test.yml',
+              head_sha: commitSha,
+              status: 'completed'
+            });
+            const testRun = workflows.workflow_runs.find(run => run.conclusion === 'success');
+            if (!testRun) {
+              core.setFailed('Test Suite workflow must pass before release can be built');
+            }
 
   build-linux:
-    if: ${{ github.event_name == 'release' }}
     needs: check-tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         go-version: ['1.26.3']
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ matrix.go-version }}
       - name: Build on Linux
         working-directory: ${{ github.workspace }}/cmd/transitland
         run: CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -buildvcs=true -ldflags "-X main.tag=$(git describe --tags --abbrev=0)"
       - name: Store Linux binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: transitland-linux
           path: ${{ github.workspace }}/cmd/transitland/transitland
 
   build-macos-intel:
-    if: ${{ github.event_name == 'release' }}
     needs: check-tests
     runs-on: macos-15-large # macOS on Intel
+    permissions:
+      contents: read
     strategy:
       matrix:
         go-version: ['1.26.3']
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ matrix.go-version }}
       - name: Build on macOS
         working-directory: ${{ github.workspace }}/cmd/transitland
         run: CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -buildvcs=true -ldflags "-X main.tag=$(git describe --tags --abbrev=0)"
       - name: Import Code-Signing Certificates
-        uses: Apple-Actions/import-codesign-certs@11e1bb2d3771ad8ffa8459dfe527bc26b2dd4b62
+        uses: Apple-Actions/import-codesign-certs@95e84a1a18f2bdbc5c6ab9b7f4429372e4b13a8b # v5.0.3
         with:
           p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
           p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
-      - name: Install gon via HomeBrew for code signing and app notarization
+      - name: Codesign binary
+        env:
+          AC_APPLICATION_IDENTITY: ${{ secrets.AC_APPLICATION_IDENTITY }}
         run: |
-          brew install Bearer/tap/gon
-      - name: Sign the mac binaries with Gon
+          codesign --sign "$AC_APPLICATION_IDENTITY" --options runtime --timestamp --force ./cmd/transitland/transitland
+      - name: Zip binary for notarization
+        run: |
+          ditto -c -k --sequesterRsrc ./cmd/transitland/transitland ./transitland.zip
+      - name: Notarize binary
         timeout-minutes: 20
         env:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
           AC_PROVIDER: ${{ secrets.AC_PROVIDER }}
-          AC_APPLICATION_IDENTITY: ${{ secrets.AC_APPLICATION_IDENTITY }}
         run: |
-          gon -log-level=debug -log-json ./.github/gonconfig.json
+          xcrun notarytool submit ./transitland.zip --apple-id "$AC_USERNAME" --password "$AC_PASSWORD" --team-id "$AC_PROVIDER" --wait
+      - name: Fetch notarytool log on failure
+        if: failure()
+        env:
+          AC_USERNAME: ${{ secrets.AC_USERNAME }}
+          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+          AC_PROVIDER: ${{ secrets.AC_PROVIDER }}
+        run: |
+          xcrun notarytool history --apple-id "$AC_USERNAME" --password "$AC_PASSWORD" --team-id "$AC_PROVIDER" || true
       - name: Store macOS binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: transitland-macos-intel
           path: ${{ github.workspace }}/transitland.zip
 
   build-macos-apple:
-    if: ${{ github.event_name == 'release' }}
     needs: check-tests
     runs-on: macos-15 # macOS on Apple Silicon
+    permissions:
+      contents: read
     strategy:
       matrix:
         go-version: ['1.26.3']
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ matrix.go-version }}
       - name: Build on macOS
         working-directory: ${{ github.workspace }}/cmd/transitland
         run: CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -buildvcs=true -ldflags "-X main.tag=$(git describe --tags --abbrev=0)"
       - name: Import Code-Signing Certificates
-        uses: Apple-Actions/import-codesign-certs@11e1bb2d3771ad8ffa8459dfe527bc26b2dd4b62
+        uses: Apple-Actions/import-codesign-certs@95e84a1a18f2bdbc5c6ab9b7f4429372e4b13a8b # v5.0.3
         with:
           p12-file-base64: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_P12_BASE64 }}
           p12-password: ${{ secrets.APPLE_DEVELOPER_CERTIFICATE_PASSWORD }}
-      - name: Install gon via HomeBrew for code signing and app notarization
+      - name: Codesign binary
+        env:
+          AC_APPLICATION_IDENTITY: ${{ secrets.AC_APPLICATION_IDENTITY }}
         run: |
-          brew install Bearer/tap/gon
-      - name: Sign the mac binaries with Gon
+          codesign --sign "$AC_APPLICATION_IDENTITY" --options runtime --timestamp --force ./cmd/transitland/transitland
+      - name: Zip binary for notarization
+        run: |
+          ditto -c -k --sequesterRsrc ./cmd/transitland/transitland ./transitland.zip
+      - name: Notarize binary
         timeout-minutes: 20
         env:
           AC_USERNAME: ${{ secrets.AC_USERNAME }}
           AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
           AC_PROVIDER: ${{ secrets.AC_PROVIDER }}
-          AC_APPLICATION_IDENTITY: ${{ secrets.AC_APPLICATION_IDENTITY }}
         run: |
-          gon -log-level=debug -log-json ./.github/gonconfig.json
+          xcrun notarytool submit ./transitland.zip --apple-id "$AC_USERNAME" --password "$AC_PASSWORD" --team-id "$AC_PROVIDER" --wait
+      - name: Fetch notarytool log on failure
+        if: failure()
+        env:
+          AC_USERNAME: ${{ secrets.AC_USERNAME }}
+          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+          AC_PROVIDER: ${{ secrets.AC_PROVIDER }}
+        run: |
+          xcrun notarytool history --apple-id "$AC_USERNAME" --password "$AC_PASSWORD" --team-id "$AC_PROVIDER" || true
       - name: Store macOS binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: transitland-macos-apple
           path: ${{ github.workspace }}/transitland.zip
 
   release:
-    if: ${{ github.event_name == 'release' }}
     needs: [build-linux, build-macos-intel, build-macos-apple]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download Linux binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: transitland-linux
           path: transitland-linux
       - name: Download macOS Intel binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: transitland-macos-intel
           path: transitland-macos-intel
       - name: Download macOS Apple Silicon binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: transitland-macos-apple
           path: transitland-macos-apple
@@ -174,7 +194,7 @@ jobs:
       - name: Copy and rename Linux binary
         run: cp transitland-linux/transitland transitland-linux/transitland-linux
       - name: Upload Release Assets
-        uses: softprops/action-gh-release@fbadcc90e88ecface60a0a0d123795b784ceb239
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: |
             transitland-linux/transitland-linux
@@ -182,24 +202,22 @@ jobs:
             transitland-macos-apple/transitland-macos-apple
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+
   release-notes:
     needs: release
-    if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-      - run: npm install github-release-notes -g
-      - run: gren release --override
+      - name: Generate release notes
         env:
-          GREN_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: gh release edit "$TAG" --generate-notes
+
   trigger-homebrew-update:
     needs: release
-    if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -207,7 +225,7 @@ jobs:
     steps:
       - name: Create GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
@@ -216,7 +234,7 @@ jobs:
           permission-actions: write
 
       - name: Trigger Homebrew Update
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,17 +4,14 @@ on:
   pull_request:
     types:
       - opened
-  pull_request_target:
-    types:
-      - opened
+      - synchronize
+      - reopened
   push:
     branches:
       - '*'
 
 permissions:
-  contents: write
-  actions: write
-  pull-requests: write
+  contents: read
 
 jobs:
   test:
@@ -51,21 +48,23 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ matrix.go-version }}
-      id: go
-    - run: (cd cmd/transitland && go version && go install .)
-    - run: ./testdata/test_setup.sh
-    - name: Run tests
-      run: go test -coverprofile c.out ./...
-    - name: Produce coverage report
-      run: go tool cover -html=c.out -o coverage.html
-    - name: Save coverage report as artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: coverage-${{ matrix.os }}
-        path: coverage.html
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Set up Go
+        id: go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Install transitland CLI
+        run: (cd cmd/transitland && go version && go install .)
+      - name: Set up test database
+        run: ./testdata/test_setup.sh
+      - name: Run tests
+        run: go test -coverprofile c.out ./...
+      - name: Produce coverage report
+        run: go tool cover -html=c.out -o coverage.html
+      - name: Save coverage report as artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-${{ matrix.os }}
+          path: coverage.html

--- a/.grenrc.yml
+++ b/.grenrc.yml
@@ -1,5 +1,0 @@
----
-  dataSource: "prs"
-  onlyMilestones: false
-  groupBy: false
-  changelogFilename: "CHANGELOG.md"

--- a/testdata/server/authz/gen.go
+++ b/testdata/server/authz/gen.go
@@ -1,2 +1,2 @@
-//go:generate /bin/sh -c "npx @openfga/syntax-transformer transform --from dsl --inputFile tls.model > tls.json"
+//go:generate /bin/sh -c "npx -y @openfga/syntax-transformer@0.1.6 transform --from dsl --inputFile tls.model > tls.json"
 package authz


### PR DESCRIPTION
## Summary

Harden the GitHub Actions workflows against Mini Shai-Hulud-class supply-chain attacks: pin every action to a full commit SHA, scope workflow permissions to least-privilege, remove the `pull_request_target` Pwn-Request shape, and eliminate unpinned `npm install -g` invocations. Also adds Dependabot configuration to keep these pins fresh, and applies cosmetic harmony fixes across the workflow files. Notarization tooling (`gon`) is intentionally unchanged in this PR and will be reworked separately.

### Workflow triggers and permissions

- Remove `pull_request_target:` from `test.yml`. The `pull_request` trigger now covers `[opened, synchronize, reopened]` so fork PRs continue to re-test on every push.
- Drop the workflow-level `contents: write` / `actions: write` / `pull-requests: write` defaults in `test.yml` and `release.yml`. Replace with `permissions: contents: read` at the workflow level (default-deny) and per-job elevations only where needed: `check-tests` gets `actions: read` so `listWorkflowRunsForRepo` can fetch Test Suite history; `release` and `release-notes` get `contents: write`; `trigger-homebrew-update` keeps its existing scoped block.
- Drop the `workflow_run` trigger in `release.yml`. Every job was already gated on `github.event_name == 'release'`, so the trigger was dead code.
- Simplify the `check-tests` script in `release.yml` to query `listWorkflowRunsForRepo` with `head_sha: context.sha` directly. The previous code always overrode `context.sha` with `github.event.release.target_commitish` whenever the latter was set — but `target_commitish` is a branch or tag name (typically `main`), not a commit SHA, so the API would not match any workflow runs. Surfaced by code review.

### Dependency pinning

- SHA-pin every `actions/*` reference with `# vN.M.P` comments: `actions/checkout` (v4.3.1), `actions/setup-go` (v5.6.0), `actions/upload-artifact` (v4.6.2), `actions/download-artifact` (v4.3.0), `actions/github-script` (v7.1.0), `actions/create-github-app-token` (v2.2.2).
- Move two third-party pins from untagged `main` commits to tagged releases for verifiability: `Apple-Actions/import-codesign-certs` (v5.0.3) and `softprops/action-gh-release` (v2.6.2).
- Pin `@openfga/syntax-transformer` in `testdata/server/authz/gen.go` from floating `@latest` to `@0.1.6`. The 0.2.x line dropped the CLI binary entirely, so `npx @openfga/syntax-transformer` (unpinned) was already silently broken; 0.1.6 is the last version with the CLI and reproduces the existing committed `tls.json` byte-for-byte. A future change will replace this with a Go-based generator that uses the OpenFGA language package already in `go.mod`.
- Add `.github/dependabot.yml` with weekly updates for the `gomod` and `github-actions` ecosystems.

### Release tooling

- Remove the `npm install -g github-release-notes` (gren) step from `release.yml`. Replace `gren release --override` with `gh release edit "$TAG" --generate-notes`, using `GH_TOKEN` / `GH_REPO` / `TAG` env vars instead of template-interpolating into the shell. Delete the now-unused `.grenrc.yml`. The `release-notes` job no longer needs `actions/checkout` or `actions/setup-node`.
- Notarization (`gon` + `Bearer/tap/gon` HomeBrew tap) and `.github/gonconfig.json` are intentionally unchanged. Replacing `gon` with `xcrun notarytool` is a real behavioral change that needs its own validation cycle and will be done in a separate PR.

### Conventions and structure

- Rename `.github/workflows/check-go-generate.yaml` to `.yml` for consistency with the other workflow files.
- Drop quotes from `name: "Release"`.
- Normalize step indentation to 6 spaces across all jobs (was 4 spaces in `test.yml` and `release.yml:check-tests`).
- Name every previously-anonymous `run` step in `test.yml`.
- Normalize `branches: [ main ]` to `branches: [main]` and strip trailing whitespace in `release.yml`.

## Test plan

- Lint workflows locally with `actionlint .github/workflows/*.yml` before pushing.
- Confirm this PR's own CI run shows `Test Suite` and `Check Generated Code` passing once on PR open and again on each subsequent push, with `contents: read` token visible in the run page.
- Open a PR from a fork (throwaway branch) to verify fork PRs still get test runs via the `pull_request` trigger with the fork's workflow + read-only token. The coverage upload step should still succeed.
- Before the next real release: cut a pre-release tag on a branch and verify the full pipeline. `check-tests` should pass against the Test Suite run for the release commit (validates the `actions: read` permission and the `context.sha` simplification). `release` and `release-notes` should produce binaries and auto-generated notes equivalent to the prior gren-based pipeline.
- After merge, enable in repo Settings → Actions → General: "Require approval for all outside collaborators". This restores the manual gate for fork PRs that `pull_request_target` was (incorrectly) providing.
- After merge, confirm at Insights → Dependency graph → Dependabot that both ecosystems are detected, and at least one update PR opens within a week (or trigger manually via the "Check for updates" button).