### PR TITLE
Accept integer enum values for ObjectType and Relation in JSON request bodies

### DIFF
--- a/server/auth/authz/types.go
+++ b/server/auth/authz/types.go
@@ -1,6 +1,9 @@
 package authz
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // Action represents a permission action that can be checked.
 type Action int32
@@ -123,6 +126,26 @@ func (o *ObjectType) UnmarshalText(text []byte) error {
 	return fmt.Errorf("unknown object type: %s", text)
 }
 
+// UnmarshalJSON accepts either a JSON number (proto3 enum int value) or a
+// JSON string (enum name). The admin REST API migration guide documents
+// that request bodies use integer enum values; this keeps that working
+// without giving up the string form used elsewhere.
+func (o *ObjectType) UnmarshalJSON(data []byte) error {
+	var n int32
+	if err := json.Unmarshal(data, &n); err == nil {
+		if _, ok := ObjectType_name[n]; !ok {
+			return fmt.Errorf("unknown object type: %d", n)
+		}
+		*o = ObjectType(n)
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("invalid object type: %s", string(data))
+	}
+	return o.UnmarshalText([]byte(s))
+}
+
 // Relation represents a relationship between entities.
 type Relation int32
 
@@ -175,6 +198,24 @@ func (r *Relation) UnmarshalText(text []byte) error {
 		return nil
 	}
 	return fmt.Errorf("unknown relation: %s", text)
+}
+
+// UnmarshalJSON accepts either a JSON number (proto3 enum int value) or a
+// JSON string (enum name). See ObjectType.UnmarshalJSON for rationale.
+func (r *Relation) UnmarshalJSON(data []byte) error {
+	var n int32
+	if err := json.Unmarshal(data, &n); err == nil {
+		if _, ok := Relation_name[n]; !ok {
+			return fmt.Errorf("unknown relation: %d", n)
+		}
+		*r = Relation(n)
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("invalid relation: %s", string(data))
+	}
+	return r.UnmarshalText([]byte(s))
 }
 
 //////

--- a/server/auth/authz/types_test.go
+++ b/server/auth/authz/types_test.go
@@ -1,0 +1,98 @@
+package authz
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestObjectType_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    ObjectType
+		wantErr bool
+	}{
+		{"number user", `5`, ObjectType_user, false},
+		{"number feed", `3`, ObjectType_feed, false},
+		{"number empty", `0`, ObjectType_empty_object, false},
+		{"string user", `"user"`, ObjectType_user, false},
+		{"string feed_version", `"feed_version"`, ObjectType_feed_version, false},
+		{"string group alias for org", `"group"`, ObjectType_org, false},
+		{"unknown number", `999`, 0, true},
+		{"unknown string", `"frobnicator"`, 0, true},
+		{"invalid json", `{}`, 0, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got ObjectType
+			err := json.Unmarshal([]byte(tc.input), &got)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err=%v wantErr=%v", err, tc.wantErr)
+			}
+			if !tc.wantErr && got != tc.want {
+				t.Fatalf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRelation_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    Relation
+		wantErr bool
+	}{
+		{"number viewer", `4`, Relation_viewer, false},
+		{"number admin", `1`, Relation_admin, false},
+		{"number empty", `0`, Relation_empty_relation, false},
+		{"string viewer", `"viewer"`, Relation_viewer, false},
+		{"string manager", `"manager"`, Relation_manager, false},
+		{"unknown number", `99`, 0, true},
+		{"unknown string", `"overlord"`, 0, true},
+		{"invalid json", `[]`, 0, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got Relation
+			err := json.Unmarshal([]byte(tc.input), &got)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err=%v wantErr=%v", err, tc.wantErr)
+			}
+			if !tc.wantErr && got != tc.want {
+				t.Fatalf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEntityRelation_UnmarshalJSON_IntegerEnums(t *testing.T) {
+	// Reproduces the admin permissions request body shape sent by the
+	// tlv2-admin frontend. The admin-api migration guide documents that
+	// integer enum values are accepted.
+	body := `{"id":"auth0|6a18684b0cd1dfbdd0beb98c","type":5,"relation":4}`
+	var er EntityRelation
+	if err := json.Unmarshal([]byte(body), &er); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if er.Type != ObjectType_user {
+		t.Errorf("type = %v, want user", er.Type)
+	}
+	if er.Relation != Relation_viewer {
+		t.Errorf("relation = %v, want viewer", er.Relation)
+	}
+	if er.Id != "auth0|6a18684b0cd1dfbdd0beb98c" {
+		t.Errorf("id = %q", er.Id)
+	}
+}
+
+func TestEntityRelation_UnmarshalJSON_StringEnums(t *testing.T) {
+	body := `{"id":"auth0|x","type":"user","relation":"viewer","ref_relation":"member"}`
+	var er EntityRelation
+	if err := json.Unmarshal([]byte(body), &er); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if er.Type != ObjectType_user || er.Relation != Relation_viewer || er.RefRelation != Relation_member {
+		t.Errorf("got %+v", er)
+	}
+}


### PR DESCRIPTION
The admin REST API migration guide (`doc/admin-api-migration.md`) states that request bodies accept integer enum values for `type` and `relation`, matching the previous proto3 JSON format. However, `ObjectType` and `Relation` only implement `encoding.TextUnmarshaler`, so `encoding/json` rejects numbers:

```
json: cannot unmarshal number into Go struct field EntityRelation.type of type authz.ObjectType
```

This PR adds `UnmarshalJSON` to both types so they accept either a JSON number or a JSON string. Unknown values still error. `MarshalText` is unchanged, so JSON-map-key behavior is preserved.

Includes unit tests covering integer form, string form, unknown values, and the full `EntityRelation` request body shape.

Surfaced by https://github.com/interline-io/mtc-regional-feed/issues/374 (private repo).