### PR TITLE
Default admin-submitted jobs to the submitter's user ID

### DIFF
--- a/server/jobserver/server.go
+++ b/server/jobserver/server.go
@@ -284,7 +284,9 @@ func requireStatusQueue(w http.ResponseWriter, req *http.Request) (jobs.StatusQu
 }
 
 // scopeJobUserID stamps the authenticated user's ID onto the job. Admins
-// may submit on behalf of any user; non-admins always get their own ID
+// may submit on behalf of any user, but default to themselves when the
+// request doesn't name one — otherwise the job runs unattributed and workers
+// fall back to the synthetic job user. Non-admins always get their own ID
 // regardless of what the request body specified.
 func scopeJobUserID(ctx context.Context, job *jobs.Job) {
 	user := authn.ForContext(ctx)
@@ -292,6 +294,9 @@ func scopeJobUserID(ctx context.Context, job *jobs.Job) {
 		return
 	}
 	if user.HasRole("admin") {
+		if job.Opts.UserID == "" {
+			job.Opts.UserID = user.ID()
+		}
 		return
 	}
 	job.Opts.UserID = user.ID()

--- a/server/jobserver/server_test.go
+++ b/server/jobserver/server_test.go
@@ -356,3 +356,32 @@ func readSSE(t *testing.T, body interface {
 		return nil, false
 	}
 }
+
+func TestScopeJobUserID(t *testing.T) {
+	owner := authn.NewCtxUser("alice", "", "")
+	admin := authn.NewCtxUser("root", "", "").WithRoles("admin")
+
+	tcs := []struct {
+		name   string
+		user   authn.User
+		bodyID string
+		expect string
+	}{
+		{"non-admin gets own id", owner, "", "alice"},
+		{"non-admin cannot submit as someone else", owner, "carol", "alice"},
+		{"admin defaults to own id when unspecified", admin, "", "root"},
+		{"admin may submit on behalf of another user", admin, "carol", "carol"},
+		{"unauthenticated leaves body id unchanged", nil, "carol", "carol"},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tc.user != nil {
+				ctx = authn.WithUser(ctx, tc.user)
+			}
+			job := jobs.Job{Kind: "test", Opts: jobs.JobOpts{UserID: tc.bodyID}}
+			scopeJobUserID(ctx, &job)
+			assert.Equal(t, tc.expect, job.Opts.UserID)
+		})
+	}
+}


### PR DESCRIPTION
Jobs submitted by users with the admin role were left unattributed (empty user_id) unless the request body named a user explicitly. Default to the submitter's own ID in that case; admins can still submit on behalf of another user by specifying user_id.