### PR TITLE
Specify automatic/manual import

### DIFF
--- a/dmfr/feed_version_import.go
+++ b/dmfr/feed_version_import.go
@@ -6,14 +6,23 @@ import (
 	"github.com/interline-io/transitland-lib/tt"
 )
 
+// Import sources, recorded on FeedVersionImport.ImportSource, indicate whether
+// an import was initiated by a user or by an automatic/maintenance process.
+// Garbage collection uses this to retain user-initiated imports longer.
+const (
+	ImportSourceAutomatic = "automatic" // queued or run by a maintenance process
+	ImportSourceManual    = "manual"    // initiated by a user
+)
+
 // FeedVersionImport is a record of when a feed version was imported into the database.
 type FeedVersionImport struct {
 	ImportLog                 string
 	ExceptionLog              string
-	ImportLevel               int  // deprecated
-	Success                   bool // Finished, Success Yes/No
-	InProgress                bool // In Progress
-	ScheduleRemoved           bool // Stop times and trips have been uimported
+	ImportLevel               int    // deprecated
+	ImportSource              string // "automatic" or "manual"; see ImportSource* constants
+	Success                   bool   // Finished, Success Yes/No
+	InProgress                bool   // In Progress
+	ScheduleRemoved           bool   // Stop times and trips have been uimported
 	InterpolatedStopTimeCount int
 	EntityCount               tt.Counts
 	WarningCount              tt.Counts

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -21,6 +21,10 @@ type Options struct {
 	FeedVersionID int
 	Storage       string
 	Activate      bool
+	// ImportSource records whether the import was initiated automatically (by a
+	// maintenance/queue process) or manually (by a user). See the
+	// dmfr.ImportSource* constants. Defaults to "automatic" when empty.
+	ImportSource string
 	// ErrorThreshold sets the maximum error percentage (0-100) allowed per file.
 	// The key is the filename (e.g., "stops.txt") or "*" for the default threshold.
 	// If any file exceeds its threshold, the import is considered failed.
@@ -54,7 +58,11 @@ func ActivateFeedVersion(ctx context.Context, atx tldb.Adapter, fvid int) error 
 // ImportFeedVersion create FVI and run Copier inside a Tx.
 func ImportFeedVersion(ctx context.Context, adapter tldb.Adapter, opts Options) (Result, error) {
 	// Get FV
-	fvi := dmfr.FeedVersionImport{InProgress: true}
+	importSource := opts.ImportSource
+	if importSource == "" {
+		importSource = dmfr.ImportSourceAutomatic
+	}
+	fvi := dmfr.FeedVersionImport{InProgress: true, ImportSource: importSource}
 	fvi.FeedVersionID = opts.FeedVersionID
 	fv := dmfr.FeedVersion{}
 	fv.ID = opts.FeedVersionID
@@ -101,6 +109,7 @@ func ImportFeedVersion(ctx context.Context, adapter tldb.Adapter, opts Options) 
 		fviresult.ID = fvi.ID
 		fviresult.CreatedAt = fvi.CreatedAt
 		fviresult.FeedVersionID = fv.ID
+		fviresult.ImportSource = fvi.ImportSource
 		fviresult.ImportLevel = 4
 		fviresult.Success = true
 		fviresult.InProgress = false

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -43,6 +43,10 @@ func TestImportFeedVersion(t *testing.T) {
 			if fvi.InProgress != false {
 				t.Errorf("expected in_progress = false")
 			}
+			// An import with no ImportSource set defaults to automatic.
+			if fvi.ImportSource != dmfr.ImportSourceAutomatic {
+				t.Errorf("expected import_source = %q, got %q", dmfr.ImportSourceAutomatic, fvi.ImportSource)
+			}
 			count := 0
 			expstops := testreader.ExampleZip.Counts["stops.txt"]
 			testdb.ShouldGet(t, atx, &count, "SELECT count(*) FROM gtfs_stops WHERE feed_version_id = ?", fvid)
@@ -52,6 +56,22 @@ func TestImportFeedVersion(t *testing.T) {
 			expfvistops := fvi.EntityCount["stops.txt"]
 			if count != expfvistops {
 				t.Errorf("got %d stops, expect %d stops", count, expfvistops)
+			}
+			return nil
+		})
+	})
+	t.Run("ManualSource", func(t *testing.T) {
+		testdb.TempSqlite(func(atx tldb.Adapter) error {
+			fvid := setup(atx, testreader.ExampleZip.URL)
+			atx2 := testdb.AdapterIgnoreTx{Adapter: atx}
+			_, err := ImportFeedVersion(ctx, &atx2, Options{FeedVersionID: fvid, Storage: "/", ImportSource: dmfr.ImportSourceManual})
+			if err != nil {
+				t.Fatal(err)
+			}
+			fvi := dmfr.FeedVersionImport{}
+			testdb.ShouldGet(t, atx, &fvi, "SELECT * FROM feed_version_gtfs_imports WHERE feed_version_id = ?", fvid)
+			if fvi.ImportSource != dmfr.ImportSourceManual {
+				t.Errorf("expected import_source = %q, got %q", dmfr.ImportSourceManual, fvi.ImportSource)
 			}
 			return nil
 		})

--- a/internal/generated/gqlout/generated.go
+++ b/internal/generated/gqlout/generated.go
@@ -407,6 +407,7 @@ type ComplexityRoot struct {
 		EntityCount               func(childComplexity int) int
 		ExceptionLog              func(childComplexity int) int
 		ID                        func(childComplexity int) int
+		ImportSource              func(childComplexity int) int
 		InProgress                func(childComplexity int) int
 		InterpolatedStopTimeCount func(childComplexity int) int
 		ScheduleRemoved           func(childComplexity int) int
@@ -3259,6 +3260,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.FeedVersionGtfsImport.ID(childComplexity), true
+	case "FeedVersionGtfsImport.import_source":
+		if e.ComplexityRoot.FeedVersionGtfsImport.ImportSource == nil {
+			break
+		}
+
+		return e.ComplexityRoot.FeedVersionGtfsImport.ImportSource(childComplexity), true
 	case "FeedVersionGtfsImport.in_progress":
 		if e.ComplexityRoot.FeedVersionGtfsImport.InProgress == nil {
 			break
@@ -9317,6 +9324,8 @@ type FeedVersionGtfsImport {
   skip_entity_marked_count: Any
   "Number of stop_times whose arrival/departure times were filled in by interpolation during import"
   interpolated_stop_time_count: Int
+  "How the import was initiated: 'manual' (by a user) or 'automatic' (by a maintenance/queue process)"
+  import_source: String!
   "Time the import record was created"
   created_at: Time
   "Time the import record was last updated"
@@ -12650,6 +12659,8 @@ func (ec *executionContext) childFields_FeedVersionGtfsImport(ctx context.Contex
 		return ec.fieldContext_FeedVersionGtfsImport_skip_entity_marked_count(ctx, field)
 	case "interpolated_stop_time_count":
 		return ec.fieldContext_FeedVersionGtfsImport_interpolated_stop_time_count(ctx, field)
+	case "import_source":
+		return ec.fieldContext_FeedVersionGtfsImport_import_source(ctx, field)
 	case "created_at":
 		return ec.fieldContext_FeedVersionGtfsImport_created_at(ctx, field)
 	case "updated_at":
@@ -23347,6 +23358,29 @@ func (ec *executionContext) _FeedVersionGtfsImport_interpolated_stop_time_count(
 }
 func (ec *executionContext) fieldContext_FeedVersionGtfsImport_interpolated_stop_time_count(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("FeedVersionGtfsImport", field, false, false, errors.New("field of type Int does not have child fields"))
+}
+
+func (ec *executionContext) _FeedVersionGtfsImport_import_source(ctx context.Context, field graphql.CollectedField, obj *model.FeedVersionGtfsImport) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_FeedVersionGtfsImport_import_source(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.ImportSource, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_FeedVersionGtfsImport_import_source(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("FeedVersionGtfsImport", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
 func (ec *executionContext) _FeedVersionGtfsImport_created_at(ctx context.Context, field graphql.CollectedField, obj *model.FeedVersionGtfsImport) (ret graphql.Marshaler) {
@@ -48935,6 +48969,11 @@ func (ec *executionContext) _FeedVersionGtfsImport(ctx context.Context, sel ast.
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "interpolated_stop_time_count":
 			out.Values[i] = ec._FeedVersionGtfsImport_interpolated_stop_time_count(ctx, field, obj)
+		case "import_source":
+			out.Values[i] = ec._FeedVersionGtfsImport_import_source(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		case "created_at":
 			out.Values[i] = ec._FeedVersionGtfsImport_created_at(ctx, field, obj)
 		case "updated_at":

--- a/schema/graphql/schema.graphqls
+++ b/schema/graphql/schema.graphqls
@@ -540,6 +540,8 @@ type FeedVersionGtfsImport {
   skip_entity_marked_count: Any
   "Number of stop_times whose arrival/departure times were filled in by interpolation during import"
   interpolated_stop_time_count: Int
+  "How the import was initiated: 'manual' (by a user) or 'automatic' (by a maintenance/queue process)"
+  import_source: String!
   "Time the import record was created"
   created_at: Time
   "Time the import record was last updated"

--- a/schema/postgres/migrations/20260605000001_add_import_source.up.pgsql
+++ b/schema/postgres/migrations/20260605000001_add_import_source.up.pgsql
@@ -1,0 +1,6 @@
+-- Track whether a feed version import was initiated automatically (by a
+-- maintenance/queue process) or manually (by a user). Used by garbage
+-- collection to retain user-initiated imports longer. Existing rows predate
+-- the feature and are treated as automatic.
+ALTER TABLE feed_version_gtfs_imports
+  ADD COLUMN import_source text NOT NULL DEFAULT 'automatic';

--- a/schema/sqlite/sqlite.sql
+++ b/schema/sqlite/sqlite.sql
@@ -52,6 +52,7 @@ CREATE TABLE IF NOT EXISTS "feed_version_gtfs_imports" (
   "in_progress" bool,
   "exception_log" blob,
   "import_level" integer not null,
+  "import_source" text not null default 'automatic',
   "interpolated_stop_time_count" integer not null,
   "skip_entity_error_count" blob,
   "skip_entity_reference_count" blob,

--- a/server/finders/actions/fv.go
+++ b/server/finders/actions/fv.go
@@ -30,6 +30,10 @@ func FeedVersionImport(ctx context.Context, fvid int) (*model.FeedVersionImportR
 	opts := importer.Options{
 		FeedVersionID: fvid,
 		Storage:       cfg.Storage,
+		// Imports initiated through this action (e.g. the GraphQL
+		// feed_version_import mutation) are user-initiated. Direct/maintenance
+		// imports go through importer.ImportFeedVersion and default to automatic.
+		ImportSource: dmfr.ImportSourceManual,
 		Options: copier.Options{
 			InterpolateStopTimes:       true,
 			CreateMissingShapes:        true,


### PR DESCRIPTION
## Summary
Adds an `import_source` field to feed version imports that records whether an import was initiated manually by a user or automatically by a maintenance/queue process. This distinction lets downstream garbage collection retain user-initiated imports longer than automatic ones. Imports default to `automatic` when no source is specified, and imports triggered through the GraphQL `feed_version_import` mutation are tagged as `manual`.

### Data model and persistence
- Add `ImportSource` field to `dmfr.FeedVersionImport`, along with `ImportSourceAutomatic` ("automatic") and `ImportSourceManual` ("manual") string constants documenting their meaning.
- New Postgres migration `20260605000001_add_import_source.up.pgsql` adds a `NOT NULL DEFAULT 'automatic'` `import_source` column to `feed_version_gtfs_imports`; existing rows predate the feature and are treated as automatic.
- Add the matching `import_source` column to the SQLite schema.

### Import pipeline
- `importer.Options` gains an `ImportSource` field. `ImportFeedVersion` writes it to the FVI record, defaulting to `automatic` when empty, and propagates it onto the result.
- The GraphQL-facing `actions.FeedVersionImport` sets `ImportSource: dmfr.ImportSourceManual`, so user-initiated imports through the mutation are recorded as manual while direct/maintenance imports remain automatic.

### API
- Expose `import_source: String!` on the `FeedVersionGtfsImport` GraphQL type (with regenerated gqlgen output).

### Tests
- Assert that an import with no source set defaults to `automatic`.
- Add a `ManualSource` subtest verifying an import run with `ImportSource: dmfr.ImportSourceManual` persists as `manual`.

## Test plan
- Run `transitland dbmigrate up` against a Postgres/PostGIS test DB and confirm the `import_source` column is added with default `automatic`.
- Import a feed version via the GraphQL `feed_version_import` mutation and confirm the resulting `FeedVersionGtfsImport.import_source` is `manual`.
- Import a feed version directly (CLI/maintenance path) and confirm `import_source` is `automatic`.
- Query an import record through GraphQL and confirm the `import_source` field is returned.

closes https://github.com/interline-io/calact-network-analysis-tool/issues/385