### PR TITLE
Close reader in rebuild-stats to remove downloaded temp files

### DIFF
--- a/cmds/rebuild_stats.go
+++ b/cmds/rebuild_stats.go
@@ -243,6 +243,9 @@ func rebuildStatsMain(ctx context.Context, adapter tldb.Adapter, opts RebuildSta
 	if err != nil {
 		return RebuildStatsResult{}, err
 	}
+	// Close removes the temp file downloaded by NewStoreAdapter; without this,
+	// long-running batch rebuilds leak one zip per feed version and fill the disk
+	defer reader.Close()
 	if err := reader.Open(); err != nil {
 		return RebuildStatsResult{}, err
 	}


### PR DESCRIPTION
## Summary
`rebuildStatsMain` opens a reader from `tlcsv.NewStoreAdapter` (which downloads the feed version zip to a temp file) but never closes it, so each processed feed version leaks its zip in the temp directory. Long-running batch rebuilds over many feed versions can accumulate enough temp files to fill the disk.

Adds `defer reader.Close()`, matching the existing pattern in `importer.importFeedVersionTx`. The deferred close is placed before `reader.Open()` so the temp file is also removed if open fails.

## Test plan
Run `rebuild-stats` over a batch of feed versions and confirm temp `gtfs*` files no longer accumulate in $TMPDIR.