### PR TITLE
Fix release notes generation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,7 +185,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           TAG: ${{ github.event.release.tag_name }}
-        run: gh release edit "$TAG" --generate-notes
+        run: |
+          gh api "repos/${GH_REPO}/releases/generate-notes" -f tag_name="$TAG" --jq .body \
+            | gh release edit "$TAG" --notes-file -
 
   trigger-homebrew-update:
     needs: release


### PR DESCRIPTION
## Summary
The `release-notes` job in the release workflow failed on its first real run (v1.3.4) because it invoked `gh release edit "$TAG" --generate-notes`, and the `--generate-notes` flag only exists on `gh release create`, not `gh release edit`. This PR replaces that call with the [generate-notes API](https://docs.github.com/en/rest/releases/releases#generate-release-notes-content-for-a-release), piping the generated body into `gh release edit` via `--notes-file -`. The job's existing `contents: write` permission is sufficient for both calls.

The notes for the v1.3.4 release itself were already backfilled manually using the same API call.

## Test plan
- Verified the exact command locally against the v1.3.4 tag: `gh api "repos/interline-io/transitland-lib/releases/generate-notes" -f tag_name=v1.3.4 --jq .body | gh release edit v1.3.4 --notes-file -` populated the release notes successfully.
- On the next tagged release, confirm the `release-notes` job succeeds and the release body contains the generated changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)