### PR TITLE
Reduce wasted GitHub Actions minutes with cancellation and path filters

### DIFF
--- a/.github/workflows/check-go-generate.yml
+++ b/.github/workflows/check-go-generate.yml
@@ -3,6 +3,16 @@ name: Check Generated Code
 on:
   pull_request:
     branches: [main]
+    # go generate ./... skips testdata/ directories and does not read test
+    # files, so changes limited to those paths cannot affect generated code.
+    paths-ignore:
+      - 'testdata/**'
+      - '**/*_test.go'
+      - 'README.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   pull-requests: write  # Needed for commenting on PRs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,17 @@ on:
       - opened
       - synchronize
       - reopened
+    paths-ignore:
+      - '**.md'
   push:
     branches:
-      - '*'
+      - main
+
+# Cancel superseded runs on PR branches; never cancel runs on main, since the
+# release workflow requires a completed Test Suite run for the tagged commit.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Reduces unnecessary GitHub Actions usage by canceling superseded workflow runs and skipping runs for changes that cannot affect their outcome.

### Test Suite
- Cancel in-progress runs when a PR branch is updated; runs on main are never canceled since the release workflow requires a completed run for the tagged commit
- Run push builds only on main, so PR branches no longer run the suite twice per push
- Skip PRs that only change markdown files

### Check Generated Code
- Cancel superseded PR runs
- Skip PRs limited to testdata/, test files, or README.md, none of which affect go generate output (generated CLI docs are markdown, so other markdown changes still run the check)

## Test plan
Push a follow-up commit to this PR branch and confirm the prior in-progress runs are canceled. Open a markdown-only PR and confirm the test suite is skipped while merges to main still run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)