### PR TITLE
Fix feed version by ID download

### DIFF
--- a/server/rest/feed_version_download.go
+++ b/server/rest/feed_version_download.go
@@ -20,7 +20,7 @@ import (
 )
 
 const latestFeedVersionQuery = `
-query($feed_onestop_id: String!, $ids: [Int!]) {
+query($feed_onestop_id: String, $ids: [Int!]) {
 	feeds(ids: $ids, where: { onestop_id: $feed_onestop_id }) {
 	  onestop_id
 	  license {
@@ -189,7 +189,7 @@ func feedVersionDownloadLatestHandler(graphqlHandler http.Handler, w http.Respon
 }
 
 const feedVersionFileQuery = `
-query($feed_version_sha1:String!, $ids: [Int!]) {
+query($feed_version_sha1: String, $ids: [Int!]) {
 	feed_versions(limit:1, ids: $ids, where:{sha1:$feed_version_sha1}) {
 	  sha1
 	  feed {
@@ -230,7 +230,7 @@ func feedVersionDownloadHandler(graphqlHandler http.Handler, w http.ResponseWrit
 	if v, ok := checkfv["feed_versions"].([]interface{}); len(v) > 0 && ok {
 		if v2, ok := v[0].(hw); ok {
 			fvsha1 = v2["sha1"].(string)
-			if fvsha1 == key {
+			if fvsha1 != "" {
 				found = true
 			}
 			if v3, ok := v2["feed"].(hw); ok {

--- a/server/rest/feed_version_download_test.go
+++ b/server/rest/feed_version_download_test.go
@@ -13,11 +13,27 @@ import (
 	"github.com/interline-io/transitland-lib/server/auth/mw/usercheck"
 	"github.com/interline-io/transitland-lib/testdata"
 	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
 	"google.golang.org/protobuf/proto"
 )
 
+// resolveID posts a GraphQL query to the handler as admin and returns the
+// integer id found at the given gjson path. Used to exercise the
+// download-by-integer-id paths, since fixture serial ids are not stable.
+func resolveID(t *testing.T, gqlSrv http.Handler, query string, path string) string {
+	req, _ := http.NewRequest("POST", "/", strings.NewReader(query))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	usercheck.AdminDefaultMiddleware("test")(gqlSrv).ServeHTTP(rr, req)
+	id := gjson.Get(rr.Body.String(), path).String()
+	if id == "" {
+		t.Fatalf("could not resolve id at %q from response: %s", path, rr.Body.String())
+	}
+	return id
+}
+
 func TestFeedVersionDownloadRequest(t *testing.T) {
-	_, restSrv, _ := testHandlersWithOptions(t, testconfig.Options{
+	gqlSrv, restSrv, _ := testHandlersWithOptions(t, testconfig.Options{
 		Storage: testdata.Path("server", "tmp"),
 	})
 
@@ -32,6 +48,17 @@ func TestFeedVersionDownloadRequest(t *testing.T) {
 		if sc := len(rr.Body.Bytes()); sc != 59324 {
 			t.Errorf("got %d bytes, expected 59324", sc)
 		}
+	})
+	t.Run("ok by integer id", func(t *testing.T) {
+		fvID := resolveID(t, gqlSrv,
+			`{"query":"{feed_versions(where:{sha1:\"d2813c293bcfd7a97dde599527ae6c62c98e66c6\"}){id}}"}`,
+			"data.feed_versions.0.id")
+		req, _ := http.NewRequest("GET", "/feed_versions/"+fvID+"/download", nil)
+		rr := httptest.NewRecorder()
+		asAdmin := usercheck.AdminDefaultMiddleware("test")(restSrv)
+		asAdmin.ServeHTTP(rr, req)
+		assert.Equal(t, 200, rr.Result().StatusCode, "status code")
+		assert.Equal(t, 59324, rr.Body.Len(), "body length")
 	})
 	t.Run("not authorized as anon", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/feed_versions/d2813c293bcfd7a97dde599527ae6c62c98e66c6/download", nil)
@@ -110,7 +137,7 @@ func TestFeedVersionDownloadRequest(t *testing.T) {
 }
 
 func TestFeedDownloadLatestRequest(t *testing.T) {
-	_, restSrv, _ := testHandlersWithOptions(t, testconfig.Options{
+	gqlSrv, restSrv, _ := testHandlersWithOptions(t, testconfig.Options{
 		Storage: testdata.Path("server", "tmp"),
 	})
 
@@ -125,6 +152,17 @@ func TestFeedDownloadLatestRequest(t *testing.T) {
 		if sc := len(rr.Body.Bytes()); sc != 59324 {
 			t.Errorf("got %d bytes, expected 59324", sc)
 		}
+	})
+	t.Run("ok by integer id", func(t *testing.T) {
+		feedID := resolveID(t, gqlSrv,
+			`{"query":"{feeds(where:{onestop_id:\"CT\"}){id}}"}`,
+			"data.feeds.0.id")
+		req, _ := http.NewRequest("GET", "/feeds/"+feedID+"/download_latest_feed_version", nil)
+		rr := httptest.NewRecorder()
+		asAdmin := usercheck.AdminDefaultMiddleware("test")(restSrv)
+		asAdmin.ServeHTTP(rr, req)
+		assert.Equal(t, 200, rr.Result().StatusCode, "status code")
+		assert.Equal(t, 59324, rr.Body.Len(), "body length")
 	})
 	t.Run("ok as user", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/feeds/CT/download_latest_feed_version", nil)


### PR DESCRIPTION
## Summary
Fixes the feed version download REST endpoints so they work when given an integer database ID instead of a string key. Both `/feed_versions/{key}/download` and `/feeds/{key}/download_latest_feed_version` already branch on whether the path parameter parses as an integer, sending it as the GraphQL `ids` variable instead of the sha1/onestop_id key — but the integer path was broken in two ways, so downloads by ID always failed.

### GraphQL variable nullability
The lookup queries declared their key variables as non-nullable (`$feed_version_sha1: String!`, `$feed_onestop_id: String!`). When downloading by integer ID the handler leaves those variables unset, which fails GraphQL validation before the query ever runs. Both are now nullable (`String`), so a request that supplies only `ids` is valid.

### Found-check no longer assumes the key is the sha1
`feedVersionDownloadHandler` decided a feed version was found by comparing the returned `sha1` against the request key (`fvsha1 == key`). That holds when the caller passes a sha1, but never when the caller passes an integer ID, so the handler returned 404 for valid IDs. It now treats the lookup as found whenever the query returns a non-empty sha1 (`fvsha1 != ""`). The latest-feed-version handler already used a gjson existence check and only needed the nullability fix.

### Tests
Adds a `resolveID` helper that posts a GraphQL query as admin and extracts an id via gjson, since fixture serial ids are not stable across runs. New subtests in `TestFeedVersionDownloadRequest` and `TestFeedDownloadLatestRequest` resolve the feed version / feed id, hit the download endpoints by integer id, and assert a 200 with the expected 59324-byte body.

## Test plan
- Resolve a feed version id via GraphQL and `GET /feed_versions/{id}/download` as admin; confirm a 200 and the full GTFS zip body.
- Resolve a feed id via GraphQL and `GET /feeds/{id}/download_latest_feed_version` as admin; confirm a 200 and the full zip body.
- Confirm the existing string-key paths (sha1 for feed versions, onestop_id for feeds) still download, and that anonymous requests to a redistribution-restricted feed remain unauthorized.
