### PR TITLE
Logging and memory benchmarks

### DIFF
--- a/copier/copier_membench_test.go
+++ b/copier/copier_membench_test.go
@@ -1,0 +1,94 @@
+package copier_test
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/interline-io/log"
+	"github.com/interline-io/transitland-lib/adapters/empty"
+	"github.com/interline-io/transitland-lib/copier"
+	"github.com/interline-io/transitland-lib/ext/builders"
+	"github.com/interline-io/transitland-lib/tlcsv"
+	"github.com/rs/zerolog"
+)
+
+// runCopierBench drains a feed through a Copier with the given options, writing to a
+// null writer, and logs the entity counts and peak HeapAlloc. Skips unless
+// TL_BENCH_FEED points at a feed (dir or .zip). Run under gctrace and graph the output
+// like the copy/validate logs:
+//
+//	TL_BENCH_FEED=feed.zip TL_GTFS_CHUNKSIZE=250000 TL_LOG=trace GODEBUG=gctrace=1 \
+//	  go test -run TestCopier...Mem -count=1 -timeout 1800s ./copier/ 2>&1 | tee out.log
+func runCopierBench(t *testing.T, opts copier.Options) {
+	path := os.Getenv("TL_BENCH_FEED")
+	if path == "" {
+		t.Skip("set TL_BENCH_FEED to a feed (dir or .zip) to run the copier memory benchmark")
+	}
+	log.SetLevel(zerolog.TraceLevel) // emit the reader's "read pass" + "trip chunk" lines
+	ctx := context.Background()
+
+	reader, err := tlcsv.NewReader(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+
+	cp, err := copier.NewCopier(ctx, reader, &empty.Writer{}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Track peak HeapAlloc while copying.
+	var peak uint64
+	done := make(chan struct{})
+	go func() {
+		var ms runtime.MemStats
+		tk := time.NewTicker(200 * time.Millisecond)
+		defer tk.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-tk.C:
+				runtime.ReadMemStats(&ms)
+				if v := atomic.LoadUint64(&peak); ms.HeapAlloc > v {
+					atomic.StoreUint64(&peak, ms.HeapAlloc)
+				}
+			}
+		}
+	}()
+
+	result, err := cp.Copy(ctx)
+	close(done)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%s: trips=%d stop_times=%d peak_heap_alloc=%dMB", t.Name(),
+		result.EntityCount["trips.txt"], result.EntityCount["stop_times.txt"],
+		atomic.LoadUint64(&peak)/(1024*1024))
+}
+
+// TestCopierBaselineMem is the floor: no validators, extensions, or filters, shape
+// caching off — the copier's own EntityMap + pattern tables above the reader.
+func TestCopierBaselineMem(t *testing.T) {
+	runCopierBench(t, copier.Options{NoValidators: true, NoShapeCache: true})
+}
+
+// TestCopierImportDefaultsMem is the ceiling: the full default stack an import runs —
+// the minimal validators, the shape geometry cache, and DefaultImportBuilders (route
+// geometries, route stops, headways, convex hulls, agency places) — against a null
+// writer, so it exercises everything a real import does without a database.
+func TestCopierImportDefaultsMem(t *testing.T) {
+	opts := copier.Options{}
+	for _, b := range builders.DefaultImportBuilders() {
+		opts.AddExtension(b)
+	}
+	runCopierBench(t, opts)
+}

--- a/copier/copier_membench_test.go
+++ b/copier/copier_membench_test.go
@@ -8,12 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/interline-io/log"
 	"github.com/interline-io/transitland-lib/adapters/empty"
 	"github.com/interline-io/transitland-lib/copier"
 	"github.com/interline-io/transitland-lib/ext/builders"
 	"github.com/interline-io/transitland-lib/tlcsv"
-	"github.com/rs/zerolog"
 )
 
 // runCopierBench drains a feed through a Copier with the given options, writing to a
@@ -28,7 +26,6 @@ func runCopierBench(t *testing.T, opts copier.Options) {
 	if path == "" {
 		t.Skip("set TL_BENCH_FEED to a feed (dir or .zip) to run the copier memory benchmark")
 	}
-	log.SetLevel(zerolog.TraceLevel) // emit the reader's "read pass" + "trip chunk" lines
 	ctx := context.Background()
 
 	reader, err := tlcsv.NewReader(path)

--- a/tlcsv/adapter.go
+++ b/tlcsv/adapter.go
@@ -283,7 +283,7 @@ func (adapter *ZipAdapter) ReadRows(filename string, cb func(Row)) error {
 	err := adapter.OpenFile(filename, func(in io.Reader) {
 		ReadRows(in, cb)
 	})
-	log.For(context.TODO()).Trace().Str("filename", filename).Str("elapsed", time.Since(t0).Round(time.Millisecond).String()).Msg("tlcsv: read pass complete")
+	log.For(context.TODO()).Trace().Str("filename", filename).Int("elapsed_ms", int(time.Since(t0).Milliseconds())).Msg("tlcsv: read pass complete")
 	return err
 }
 
@@ -657,7 +657,7 @@ func (adapter *DirAdapter) ReadRows(filename string, cb func(Row)) error {
 	err := adapter.OpenFile(filename, func(in io.Reader) {
 		ReadRows(in, cb)
 	})
-	log.For(context.TODO()).Trace().Str("filename", filename).Str("elapsed", time.Since(t0).Round(time.Millisecond).String()).Msg("tlcsv: read pass complete")
+	log.For(context.TODO()).Trace().Str("filename", filename).Int("elapsed_ms", int(time.Since(t0).Milliseconds())).Msg("tlcsv: read pass complete")
 	return err
 }
 

--- a/tlcsv/adapter.go
+++ b/tlcsv/adapter.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/interline-io/log"
 	"github.com/interline-io/transitland-lib/adapters"
@@ -277,10 +278,13 @@ func (adapter *ZipAdapter) OpenFile(filename string, cb func(io.Reader)) error {
 
 // ReadRows opens the specified file and runs the callback on each Row. An error is returned if the file cannot be read.
 func (adapter *ZipAdapter) ReadRows(filename string, cb func(Row)) error {
+	t0 := time.Now()
 	log.For(context.TODO()).Trace().Str("filename", filename).Msg("tlcsv: read pass")
-	return adapter.OpenFile(filename, func(in io.Reader) {
+	err := adapter.OpenFile(filename, func(in io.Reader) {
 		ReadRows(in, cb)
 	})
+	log.For(context.TODO()).Trace().Str("filename", filename).Str("elapsed", time.Since(t0).Round(time.Millisecond).String()).Msg("tlcsv: read pass complete")
+	return err
 }
 
 // SHA1 returns the SHA1 checksum of the zip archive.
@@ -648,10 +652,13 @@ func (adapter *DirAdapter) AddFile(filename string, reader io.Reader) error {
 
 // ReadRows opens the file and runs the callback for each row. An error is returned if the file cannot be read.
 func (adapter *DirAdapter) ReadRows(filename string, cb func(Row)) error {
+	t0 := time.Now()
 	log.For(context.TODO()).Trace().Str("filename", filename).Msg("tlcsv: read pass")
-	return adapter.OpenFile(filename, func(in io.Reader) {
+	err := adapter.OpenFile(filename, func(in io.Reader) {
 		ReadRows(in, cb)
 	})
+	log.For(context.TODO()).Trace().Str("filename", filename).Str("elapsed", time.Since(t0).Round(time.Millisecond).String()).Msg("tlcsv: read pass complete")
+	return err
 }
 
 // Exists checks if the specified directory exists.

--- a/tlcsv/overlay.go
+++ b/tlcsv/overlay.go
@@ -152,7 +152,7 @@ func (adapter OverlayAdapter) ReadRows(filename string, cb func(Row)) error {
 	err := adapter.OpenFile(filename, func(in io.Reader) {
 		ReadRows(in, cb)
 	})
-	log.For(context.TODO()).Trace().Str("filename", filename).Str("elapsed", time.Since(t0).Round(time.Millisecond).String()).Msg("tlcsv: read pass complete")
+	log.For(context.TODO()).Trace().Str("filename", filename).Int("elapsed_ms", int(time.Since(t0).Milliseconds())).Msg("tlcsv: read pass complete")
 	return err
 }
 

--- a/tlcsv/overlay.go
+++ b/tlcsv/overlay.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/interline-io/log"
 )
@@ -146,10 +147,13 @@ func (adapter OverlayAdapter) OpenFile(filename string, cb func(io.Reader)) erro
 
 // ReadRows implements CSV Adapter ReadRows.
 func (adapter OverlayAdapter) ReadRows(filename string, cb func(Row)) error {
+	t0 := time.Now()
 	log.For(context.TODO()).Trace().Str("filename", filename).Msg("tlcsv: read pass")
-	return adapter.OpenFile(filename, func(in io.Reader) {
+	err := adapter.OpenFile(filename, func(in io.Reader) {
 		ReadRows(in, cb)
 	})
+	log.For(context.TODO()).Trace().Str("filename", filename).Str("elapsed", time.Since(t0).Round(time.Millisecond).String()).Msg("tlcsv: read pass complete")
+	return err
 }
 
 // Open implements CSV Adapter Open.


### PR DESCRIPTION
## Summary
Adds lightweight observability and benchmarking for the GTFS read/copy pipeline so memory and time behavior on large feeds can be profiled and attributed to specific files and stages. There are two pieces: per-file read-pass timing in the CSV adapters, and skip-by-default copier memory benchmarks that measure peak heap for a bare copy versus a full default-import copy. There are no production behavior changes — the logging is trace-level (a per-file timestamp, not per-row) and the benchmarks only run when an environment variable points at a feed.

### Read-pass timing logs
- `ReadRows` on each CSV adapter (`ZipAdapter`, `DirAdapter`, `OverlayAdapter`) now emits a trace `tlcsv: read pass` when it starts a file and `tlcsv: read pass complete` with the elapsed time when it finishes, both tagged with the filename.
- This shows how long each file's read pass takes and which file is active at any point, which is useful when correlating with `GODEBUG=gctrace=1` output: the read-pass filename labels the phases in a memory-over-time view.
- Trace level, so there is no output at normal log levels and the only added work is one timestamp per file.

### Copier memory benchmarks
- Adds `copier/copier_membench_test.go` with a `runCopierBench` helper that drains a feed through a `Copier` to a null writer, samples peak `HeapAlloc` every 200ms, and logs trip/stop_time counts plus peak heap in MB. It skips unless `TL_BENCH_FEED` points at a feed (directory or .zip), so it has no effect on normal test runs.
- `TestCopierBaselineMem` is the floor: no validators, extensions, or filters, with shape caching off — just the copier's own EntityMap and pattern tables above the reader.
- `TestCopierImportDefaultsMem` is the ceiling: the full default import stack (minimal validators, the shape geometry cache, and `DefaultImportBuilders` — route geometries, route stops, headways, convex hulls, agency places) against a null writer, exercising everything a real import does without a database.

## Test plan
- `go test ./...` is unaffected: the benchmarks skip when `TL_BENCH_FEED` is unset.
- Run a benchmark against a feed and confirm it reports counts and peak heap, e.g. `TL_BENCH_FEED=<feed.zip> go test -run TestCopierImportDefaultsMem -count=1 -timeout 1800s ./copier/`; add `TL_LOG=trace GODEBUG=gctrace=1` and tee the output to profile memory over time.
- With `TL_LOG=trace`, run a normal copy or validate and confirm `tlcsv: read pass` / `tlcsv: read pass complete elapsed=...` lines appear once per file.
