### PR TITLE
Chunking improvements

### DIFF
--- a/causes/causes.go
+++ b/causes/causes.go
@@ -243,6 +243,24 @@ func (e *DuplicateKeyError) Error() string {
 
 ////////////////////////////
 
+// EntityLimitError reports when an entity's grouped child rows — a trip's
+// stop_times or a shape's points — exceeded the per-group limit and were capped.
+type EntityLimitError struct {
+	bc
+}
+
+// NewEntityLimitError returns an EntityLimitError for entity eid whose `field`
+// rows were capped at `limit`.
+func NewEntityLimitError(eid string, field string, limit int) *EntityLimitError {
+	return &EntityLimitError{bc: bc{EntityID: eid, Field: field, Value: fmt.Sprintf("%d", limit)}}
+}
+
+func (e *EntityLimitError) Error() string {
+	return fmt.Sprintf("entity '%s' exceeded the limit of %s %s and was capped", e.EntityID, e.Value, e.Field)
+}
+
+////////////////////////////
+
 // DuplicateServiceExceptionError reports when a (service_id,date) value is present more than once.
 type DuplicateServiceExceptionError struct {
 	ServiceID string

--- a/tlcsv/gtcsv.go
+++ b/tlcsv/gtcsv.go
@@ -35,8 +35,9 @@ func init() {
 	ext.RegisterReader("ftp", r)
 	w := func(url string) (adapters.Writer, error) { return NewWriter(url) }
 	ext.RegisterWriter("csv", w)
-	// Set chunkSize from config.
-	if v, e := strconv.Atoi(os.Getenv("TL_GTFS_CHUNKSIZE")); e == nil {
+	// Set chunkSize from config. Ignore a non-positive value: it would make the
+	// per-group cap (len >= chunkSize) drop every row.
+	if v, e := strconv.Atoi(os.Getenv("TL_GTFS_CHUNKSIZE")); e == nil && v > 0 {
 		chunkSize = v
 	}
 }

--- a/tlcsv/gtcsv.go
+++ b/tlcsv/gtcsv.go
@@ -17,7 +17,12 @@ var bufferSize = 1000
 // geometries while the writer drains a batch.
 var groupBufferSize = 32
 
-var chunkSize = 250000
+// chunkSize is the single knob (TL_GTFS_CHUNKSIZE) for the join's group sizing: the
+// unsorted path's per-chunk stop_time buffer, the sorted path's per-chunk trip count,
+// and the per-group cap (max stop_times per trip, max points per shape). The sorted
+// path counts trips rather than stop_times, so at the same value it covers far more
+// trips per chunk than the stop_time-bounded unsorted path.
+var chunkSize = 100000
 
 func init() {
 	// Register readers/writers

--- a/tlcsv/reader.go
+++ b/tlcsv/reader.go
@@ -277,15 +277,15 @@ func (reader *Reader) TripsWithStopTimes(ids ...string) chan gtfs.TripStopTimes 
 			return ok
 		}
 		counts, order, grouped := reader.scanTripStopTimes(keep)
-		chunks := chunkByCount(order, counts)
-		order = nil
 		if grouped {
-			// Grouped: one streaming pass, emitting each trip as it completes.
-			reader.streamTripStopTimes(out, keep, chunks)
+			// Sorted fast path: one streaming pass, chunked by trip count (only one
+			// trip's stop_times is held at a time, so trips.txt drives the chunk size).
+			reader.streamTripStopTimes(out, keep, order)
 		} else {
-			// Ungrouped: re-read stop_times.txt once per chunk to gather its records.
-			reader.chunkTripStopTimes(out, chunks)
+			// Unsorted fallback: re-read stop_times.txt once per stop_time-bounded chunk.
+			reader.chunkTripStopTimes(out, order, counts)
 		}
+		order = nil
 		// Trips with no stop_times never appeared above; emit them last, in trips.txt
 		// order (counts is now the set of trip_ids that had stop_times).
 		reader.Adapter.ReadRows("trips.txt", func(row Row) {
@@ -321,6 +321,9 @@ func (reader *Reader) scanTripStopTimes(keep func(string) bool) (counts map[stri
 			grouped = false
 		}
 		if !seen {
+			// Clone out of the csv reader's per-record string so this long-lived key
+			// retains only the trip_id, not the whole pinned stop_times row.
+			sid = strings.Clone(sid)
 			order = append(order, sid)
 		}
 		counts[sid]++
@@ -349,6 +352,26 @@ func chunkByCount(order []string, counts map[string]int) s2D {
 	return chunks
 }
 
+// chunkByTrips splits trip_ids (in order) into chunks of at most n trips. The sorted
+// path uses this because its live stop_time buffer is already one trip, so the chunk
+// size only governs how many trip records are held while reading trips.txt — far cheaper
+// than the stop_time budget chunkByCount enforces, so n can be large and the trips.txt
+// passes few.
+func chunkByTrips(order []string, n int) s2D {
+	if n < 1 {
+		n = 1
+	}
+	var chunks s2D
+	for i := 0; i < len(order); i += n {
+		end := i + n
+		if end > len(order) {
+			end = len(order)
+		}
+		chunks = append(chunks, order[i:end])
+	}
+	return chunks
+}
+
 // readTripsForIDs reads trips.txt and returns the rows for the given trip_ids, grouped
 // by id in file order so duplicate rows are preserved.
 func (reader *Reader) readTripsForIDs(ids []string) map[string][]gtfs.Trip {
@@ -368,60 +391,83 @@ func (reader *Reader) readTripsForIDs(ids []string) map[string][]gtfs.Trip {
 
 // emitJoinedTrip emits one trip joined with its stop_times (sorted by stop_sequence).
 // rows are the trips.txt rows for the id: none means an orphan (Valid = false); any
-// extras are duplicate trip rows, emitted after the first with empty StopTimes.
-func emitJoinedTrip(out chan<- gtfs.TripStopTimes, rows []gtfs.Trip, sts []gtfs.StopTime) {
+// extras are duplicate trip rows, emitted after the first with empty StopTimes. When
+// capped is set the stop_times were truncated at chunkSize, so the emitted entity
+// carries an EntityLimitError.
+func emitJoinedTrip(out chan<- gtfs.TripStopTimes, rows []gtfs.Trip, sts []gtfs.StopTime, capped bool) {
 	sort.Slice(sts, func(i, j int) bool { return sts[i].StopSequence.Val < sts[j].StopSequence.Val })
 	if len(rows) == 0 {
+		if capped && len(sts) > 0 {
+			sts[0].AddError(causes.NewEntityLimitError(sts[0].TripID.Val, "stop_times", chunkSize))
+		}
 		out <- gtfs.TripStopTimes{StopTimes: sts}
 		return
 	}
-	out <- gtfs.TripStopTimes{Valid: true, Trip: rows[0], StopTimes: sts}
+	trip := rows[0]
+	if capped {
+		trip.AddError(causes.NewEntityLimitError(trip.EntityID(), "stop_times", chunkSize))
+	}
+	out <- gtfs.TripStopTimes{Valid: true, Trip: trip, StopTimes: sts}
 	for _, dup := range rows[1:] {
 		out <- gtfs.TripStopTimes{Valid: true, Trip: dup}
 	}
 }
 
 // streamTripStopTimes handles a grouped stop_times.txt: one streaming pass completes
-// trips in order, holding only the current trip's stop_times. A chunk's trips are read
-// from trips.txt when its first trip is reached, so peak memory is one trip's
-// stop_times plus one chunk's trips.
-func (reader *Reader) streamTripStopTimes(out chan<- gtfs.TripStopTimes, keep func(string) bool, chunks s2D) {
+// trips in order, holding only the current trip's stop_times (capped at chunkSize). A
+// chunk's trips are read from trips.txt when its first trip is reached, so peak memory
+// is at most chunkSize stop_times plus one chunk's trips. Because stop_time memory is
+// already bounded to one trip, chunks are sized by trip count (chunkSize, counted in
+// trips here), keeping trips.txt passes proportional to trips rather than the much
+// larger stop_time count.
+func (reader *Reader) streamTripStopTimes(out chan<- gtfs.TripStopTimes, keep func(string) bool, order []string) {
+	chunks := chunkByTrips(order, chunkSize)
 	ci, pi := 0, 0 // current chunk index, position within it
 	var chunkTrips map[string][]gtfs.Trip
-	emit := func(tid string, sts []gtfs.StopTime) {
+	emit := func(tid string, sts []gtfs.StopTime, capped bool) {
 		if pi == 0 {
 			log.For(context.TODO()).Trace().Int("chunk", ci+1).Int("chunks", len(chunks)).Int("trips", len(chunks[ci])).Msg("tlcsv: processing trip chunk")
 			chunkTrips = reader.readTripsForIDs(chunks[ci])
 		}
-		emitJoinedTrip(out, chunkTrips[tid], sts)
+		emitJoinedTrip(out, chunkTrips[tid], sts, capped)
 		if pi++; pi == len(chunks[ci]) {
 			ci, pi, chunkTrips = ci+1, 0, nil
 		}
 	}
 	var sts []gtfs.StopTime
 	last := ""
+	capped := false
 	reader.Adapter.ReadRows("stop_times.txt", func(row Row) {
 		sid, _ := row.Get("trip_id")
 		if !keep(sid) {
 			return
 		}
 		if last != "" && sid != last {
-			emit(last, sts)
+			emit(last, sts, capped)
 			sts = nil
+			capped = false
+		}
+		last = sid
+		// Cap one trip's stop_times at chunkSize so a degenerate trip can't grow this
+		// buffer without bound; the trip is still emitted, flagged via emitJoinedTrip.
+		if len(sts) >= chunkSize {
+			capped = true
+			return
 		}
 		st := gtfs.StopTime{}
 		loadRow(&st, row)
 		sts = append(sts, st)
-		last = sid
 	})
 	if last != "" {
-		emit(last, sts)
+		emit(last, sts, capped)
 	}
 }
 
 // chunkTripStopTimes handles an ungrouped stop_times.txt: each chunk re-reads
-// stop_times.txt to gather its scattered records, then emits.
-func (reader *Reader) chunkTripStopTimes(out chan<- gtfs.TripStopTimes, chunks s2D) {
+// stop_times.txt to gather its scattered records, then emits. Chunks are sized by
+// stop_time count (chunkByCount) because a chunk buffers all of its stop_times at once.
+func (reader *Reader) chunkTripStopTimes(out chan<- gtfs.TripStopTimes, order []string, counts map[string]int) {
+	chunks := chunkByCount(order, counts)
 	for i, chunk := range chunks {
 		log.For(context.TODO()).Trace().
 			Int("chunk", i+1).
@@ -430,9 +476,15 @@ func (reader *Reader) chunkTripStopTimes(out chan<- gtfs.TripStopTimes, chunks s
 			Msg("tlcsv: processing trip chunk")
 		set := stringsToSet(chunk)
 		stm := map[string][]gtfs.StopTime{}
+		capped := map[string]bool{}
 		reader.Adapter.ReadRows("stop_times.txt", func(row Row) {
 			sid, _ := row.Get("trip_id")
 			if _, ok := set[sid]; !ok {
+				return
+			}
+			// Cap each trip's stop_times at chunkSize (see streamTripStopTimes).
+			if len(stm[sid]) >= chunkSize {
+				capped[sid] = true
 				return
 			}
 			st := gtfs.StopTime{}
@@ -441,7 +493,7 @@ func (reader *Reader) chunkTripStopTimes(out chan<- gtfs.TripStopTimes, chunks s
 		})
 		tripRows := reader.readTripsForIDs(chunk)
 		for _, tid := range chunk {
-			emitJoinedTrip(out, tripRows[tid], stm[tid])
+			emitJoinedTrip(out, tripRows[tid], stm[tid], capped[tid])
 		}
 	}
 }
@@ -508,36 +560,47 @@ func (reader *Reader) ShapesByShapeID(shapeIDs ...string) chan []gtfs.Shape {
 		for _, chunk := range chunks {
 			set := stringsToSet(chunk)
 			m := map[string][]gtfs.Shape{}
+			capped := map[string]bool{}
+			// emitShape sorts a shape's points by sequence, flags it if its points were
+			// capped at chunkSize, sends it, and drops it from the buffer.
+			emitShape := func(sid string) {
+				v := m[sid]
+				sort.Slice(v, func(i, j int) bool {
+					return v[i].ShapePtSequence.Val < v[j].ShapePtSequence.Val
+				})
+				if capped[sid] && len(v) > 0 {
+					v[0].AddError(causes.NewEntityLimitError(sid, "shapes", chunkSize))
+				}
+				out <- v
+				delete(m, sid)
+			}
 			last := ""
 			reader.Adapter.ReadRows("shapes.txt", func(row Row) {
 				sid, _ := row.Get("shape_id")
 				if _, ok := set[sid]; ok {
-					ent := gtfs.Shape{}
-					loadRow(&ent, row)
-					m[sid] = append(m[sid], ent)
+					// Cap one shape's points at chunkSize so a degenerate shape can't grow
+					// this buffer without bound; it is still emitted, flagged.
+					if len(m[sid]) >= chunkSize {
+						capped[sid] = true
+					} else {
+						ent := gtfs.Shape{}
+						loadRow(&ent, row)
+						m[sid] = append(m[sid], ent)
+					}
 				}
 				// If we know the file is grouped, send the shape at transition
 				if grouped && sid != last && last != "" {
-					v := m[last]
-					sort.Slice(v, func(i, j int) bool {
-						return v[i].ShapePtSequence.Val < v[j].ShapePtSequence.Val
-					})
-					out <- v
-					delete(m, last)
+					emitShape(last)
 				}
 				last = sid
 			})
 			// Emit remaining shapes in first-appearance (chunk) order: for a grouped
 			// file that's just the final shape; otherwise the whole chunk.
 			for _, sid := range chunk {
-				v, ok := m[sid]
-				if !ok {
+				if _, ok := m[sid]; !ok {
 					continue
 				}
-				sort.Slice(v, func(i, j int) bool {
-					return v[i].ShapePtSequence.Val < v[j].ShapePtSequence.Val
-				})
-				out <- v
+				emitShape(sid)
 			}
 		}
 		close(out)

--- a/tlcsv/reader.go
+++ b/tlcsv/reader.go
@@ -390,16 +390,14 @@ func (reader *Reader) readTripsForIDs(ids []string) map[string][]gtfs.Trip {
 }
 
 // emitJoinedTrip emits one trip joined with its stop_times (sorted by stop_sequence).
-// rows are the trips.txt rows for the id: none means an orphan (Valid = false); any
-// extras are duplicate trip rows, emitted after the first with empty StopTimes. When
-// capped is set the stop_times were truncated at chunkSize, so the emitted entity
-// carries an EntityLimitError.
+// rows are the trips.txt rows for the id: none means an orphan (Valid = false), already
+// reported as an invalid reference, so a cap is not flagged on it; any extras are
+// duplicate trip rows, emitted after the first with empty StopTimes. When capped is set
+// the stop_times were truncated at chunkSize, so the emitted trip carries an
+// EntityLimitError.
 func emitJoinedTrip(out chan<- gtfs.TripStopTimes, rows []gtfs.Trip, sts []gtfs.StopTime, capped bool) {
 	sort.Slice(sts, func(i, j int) bool { return sts[i].StopSequence.Val < sts[j].StopSequence.Val })
 	if len(rows) == 0 {
-		if capped && len(sts) > 0 {
-			sts[0].AddError(causes.NewEntityLimitError(sts[0].TripID.Val, "stop_times", chunkSize))
-		}
 		out <- gtfs.TripStopTimes{StopTimes: sts}
 		return
 	}

--- a/tlcsv/reader_test.go
+++ b/tlcsv/reader_test.go
@@ -344,6 +344,62 @@ func TestReader_GroupCapsOversizedEntities(t *testing.T) {
 	})
 }
 
+// TestReader_ChunkCapsUngrouped covers the per-trip cap on the ungrouped (chunked)
+// path: when stop_times.txt is not grouped by trip_id, a trip with more than chunkSize
+// stop_times must still be truncated and flagged, the same as the sorted fast path.
+func TestReader_ChunkCapsUngrouped(t *testing.T) {
+	old := chunkSize
+	chunkSize = 3
+	defer func() { chunkSize = old }()
+
+	dir := t.TempDir()
+	w := NewDirAdapter(dir)
+	if err := w.WriteRows("trips.txt", [][]string{
+		{"route_id", "service_id", "trip_id"},
+		{"r", "s", "big"},
+		{"r", "s", "small"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	st := func(trip, seq string) []string { return []string{trip, "a", seq, "08:00:00", "08:00:00"} }
+	// "big" reappears after "small", forcing the ungrouped/chunked path; it has 5
+	// stop_times (capped to 3 at chunkSize=3), "small" has 1 (uncapped).
+	if err := w.WriteRows("stop_times.txt", [][]string{
+		{"trip_id", "stop_id", "stop_sequence", "arrival_time", "departure_time"},
+		st("big", "1"), st("small", "1"), st("big", "2"), st("big", "3"), st("big", "4"), st("big", "5"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := NewReader(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+
+	counts := map[string]int{}
+	capped := map[string]bool{}
+	for tst := range reader.TripsWithStopTimes() {
+		if !tst.Valid {
+			continue
+		}
+		counts[tst.Trip.TripID.Val] = len(tst.StopTimes)
+		capped[tst.Trip.TripID.Val] = hasEntityLimitError(tt.CheckErrors(&tst.Trip))
+	}
+	if counts["big"] != 3 || !capped["big"] {
+		t.Errorf("big: got %d stop_times capped=%v, want 3 capped=true", counts["big"], capped["big"])
+	}
+	if counts["small"] != 1 || capped["small"] {
+		t.Errorf("small: got %d stop_times capped=%v, want 1 capped=false", counts["small"], capped["small"])
+	}
+}
+
 func hasEntityLimitError(errs []error) bool {
 	for _, err := range errs {
 		if _, ok := err.(*causes.EntityLimitError); ok {

--- a/tlcsv/reader_test.go
+++ b/tlcsv/reader_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 
 	"github.com/interline-io/transitland-lib/adapters"
+	"github.com/interline-io/transitland-lib/causes"
 	"github.com/interline-io/transitland-lib/internal/testreader"
 	"github.com/interline-io/transitland-lib/request"
+	"github.com/interline-io/transitland-lib/tt"
 )
 
 func TestReader_TripsWithStopTimes(t *testing.T) {
@@ -22,7 +24,8 @@ func TestReader_TripsWithStopTimes(t *testing.T) {
 	}
 	defer reader.Close()
 
-	// Force small chunks so the example feed's trips span several chunks.
+	// chunkSize=5 splits the example feed's 11 trips into several sorted-path chunks while
+	// staying at the busiest trip's stop_time count, so nothing is capped.
 	old := chunkSize
 	chunkSize = 5
 	defer func() { chunkSize = old }()
@@ -91,7 +94,7 @@ func TestReader_TripsWithStopTimes(t *testing.T) {
 // feed, both in stop_times first-appearance order.
 func TestReader_TripsWithStopTimes_Grouping(t *testing.T) {
 	old := chunkSize
-	chunkSize = 3 // force several chunks for 3 trips x 2 stop_times
+	chunkSize = 2 // force several chunks for 3 trips x 2 stop_times (none capped at 2)
 	defer func() { chunkSize = old }()
 
 	writeFeed := func(t *testing.T, stopTimes [][]string) string {
@@ -265,4 +268,87 @@ func TestReader(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestReader_GroupCapsOversizedEntities verifies that a trip's stop_times and a
+// shape's points are capped at chunkSize and flagged, rather than buffered without
+// bound. The example feed's CITY1 has 5 stop_times and shape "ok" has 4 points, so
+// a chunkSize of 3 truncates both.
+func TestReader_GroupCapsOversizedEntities(t *testing.T) {
+	old := chunkSize
+	chunkSize = 3
+	defer func() { chunkSize = old }()
+
+	reader, err := NewReader(testreader.ExampleDir.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Open(); err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+
+	t.Run("trip stop_times", func(t *testing.T) {
+		capped, uncapped := 0, 0
+		for tst := range reader.TripsWithStopTimes() {
+			if !tst.Valid {
+				continue
+			}
+			limited := hasEntityLimitError(tt.CheckErrors(&tst.Trip))
+			if tst.Trip.TripID.Val == "CITY1" {
+				if len(tst.StopTimes) != 3 {
+					t.Errorf("CITY1: got %d stop_times, want 3 (capped)", len(tst.StopTimes))
+				}
+				if !limited {
+					t.Errorf("CITY1: expected EntityLimitError")
+				}
+			}
+			if limited {
+				capped++
+				if len(tst.StopTimes) != 3 {
+					t.Errorf("trip %q flagged but holds %d stop_times, want 3", tst.Trip.TripID.Val, len(tst.StopTimes))
+				}
+			} else {
+				uncapped++
+				if len(tst.StopTimes) > 3 {
+					t.Errorf("trip %q not flagged but holds %d stop_times (over cap)", tst.Trip.TripID.Val, len(tst.StopTimes))
+				}
+			}
+		}
+		if capped == 0 {
+			t.Error("expected at least one capped trip")
+		}
+		if uncapped == 0 {
+			t.Error("expected at least one uncapped trip")
+		}
+	})
+
+	t.Run("shape points", func(t *testing.T) {
+		capped := 0
+		for grp := range reader.ShapesByShapeID() {
+			if len(grp) == 0 {
+				continue
+			}
+			if hasEntityLimitError(tt.CheckErrors(&grp[0])) {
+				capped++
+				if len(grp) != 3 {
+					t.Errorf("shape %q flagged but holds %d points, want 3", grp[0].ShapeID.Val, len(grp))
+				}
+			} else if len(grp) > 3 {
+				t.Errorf("shape %q not flagged but holds %d points (over cap)", grp[0].ShapeID.Val, len(grp))
+			}
+		}
+		if capped == 0 {
+			t.Error("expected at least one capped shape")
+		}
+	})
+}
+
+func hasEntityLimitError(errs []error) bool {
+	for _, err := range errs {
+		if _, ok := err.(*causes.EntityLimitError); ok {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
Reworks the tlcsv reader's trips↔stop_times join to bound its memory and sharply cut repeated reads of trips.txt on large feeds, and adds a safeguard so a single oversized trip or shape can't grow a buffer without bound. Output is unchanged for well-formed feeds: trips are still emitted in stop_times first-appearance order, with stop_time-less trips trailing in trips.txt order.

### Trip-count chunking on the sorted fast path
- When stop_times.txt is already grouped by trip_id (the common case), the join completes in a single streaming pass and sizes its chunks by trip count instead of by stop_time count. Only one trip's stop_times are buffered at a time, so the chunk size governs how many trip records are read from trips.txt per pass, making trips.txt re-reads proportional to the trip count rather than to the much larger stop_time total.
- Feeds whose stop_times.txt is not grouped by trip_id keep the previous behavior: stop_times.txt is re-read once per chunk, with chunks sized by stop_time count.
- Chunk sizing is a single knob, `TL_GTFS_CHUNKSIZE` (default 100000), covering the sorted-path trip count, the unsorted-path stop_time buffer, and the per-group cap below.

### Bounded per-group buffers
- A single trip's stop_times and a single shape's points are capped at `chunkSize`, so one degenerate entity can't grow a per-group buffer without bound. The entity is still emitted, and carries a new `EntityLimitError` (added to `causes`) recording the field and the limit it hit.

### Reduced string retention while scanning
- The pre-scan of stop_times.txt now clones each first-seen trip_id (`strings.Clone`) before keeping it. Go's csv reader returns fields as substrings of a single per-record allocation, so retaining a trip_id would otherwise pin that entire stop_times row in memory for the duration of the scan; cloning keeps only the id.

## Test plan
- The `tlcsv` tests cover grouped vs. ungrouped chunking and output ordering, and `TestReader_GroupCapsOversizedEntities` asserts that a trip with too many stop_times and a shape with too many points are truncated at the limit and flagged with `EntityLimitError`.
- On a large feed, set `TL_GTFS_CHUNKSIZE` to different values and confirm at trace log level that trips.txt is re-read fewer times as the value increases, with no change to the emitted entities.
