### PR TITLE
Early return in tlcsv ValidateStructure

### DIFF
--- a/tlcsv/reader.go
+++ b/tlcsv/reader.go
@@ -77,12 +77,21 @@ func (reader *Reader) ValidateStructure() []error {
 		err := reader.Adapter.OpenFile(efn, func(in io.Reader) {
 			rowcount := 0
 			rowheader := []string{}
-			readerr := ReadRows(in, func(row Row) {
-				if len(rowheader) == 0 {
+			var readerr error
+			// Structure validation only needs the header and whether at least one data
+			// row exists. ReadRowsIter reads the header (first non-empty line) internally
+			// and yields data rows, so the first iteration confirms both — read it and
+			// stop, no scanning whole files (stop_times.txt / shapes.txt can be tens of
+			// millions of rows). Zero iterations means header-only, treated as empty below.
+			for row, rerr := range ReadRowsIter(in) {
+				if rerr != nil {
+					readerr = rerr
+				} else {
 					rowheader = row.Header
+					rowcount++
 				}
-				rowcount++
-			})
+				break
+			}
 			// If the file is unreadable or has no rows then return
 			if readerr != nil {
 				fileerrs = append(fileerrs, causes.NewFileUnreadableError(efn, readerr))

--- a/tlcsv/reader.go
+++ b/tlcsv/reader.go
@@ -60,7 +60,12 @@ func (reader *Reader) ReadEntities(c interface{}) error {
 	return nil
 }
 
-// ValidateStructure returns if all required CSV files are present.
+// ValidateStructure checks the feed's structure: that the source opens and that each
+// expected file is present, has a header with its required columns (no duplicates),
+// and has at least one data row. It reads only the header and first data row of each
+// file, so it verifies file presence and shape, not full readability — a file that
+// opens cleanly but hits a read error partway through is caught during the actual data
+// pass, not here.
 func (reader *Reader) ValidateStructure() []error {
 	// Check if the archive can be opened
 	allerrs := []error{}

--- a/tlcsv/validate_structure_test.go
+++ b/tlcsv/validate_structure_test.go
@@ -86,6 +86,52 @@ func TestValidateStructure_Stops(t *testing.T) {
 	}
 }
 
+// TestValidateStructure_RequiresDataRow pins the header-vs-data-row distinction:
+// the early-out at the first row must still tell a header-only file (treated as
+// empty) apart from a file that has at least one data row. A required file errors
+// in the first case and validates in the second.
+func TestValidateStructure_RequiresDataRow(t *testing.T) {
+	header := []string{"route_id", "route_short_name", "route_long_name", "route_type"}
+	dataRow := []string{"r1", "R", "Route One", "3"}
+	routesRequired := func(errs []error) bool {
+		for _, err := range errs {
+			var fre *causes.FileRequiredError
+			if errors.As(err, &fre) && fre.Filename == "routes.txt" {
+				return true
+			}
+		}
+		return false
+	}
+	writeRoutes := func(t *testing.T, rows [][]string) *Reader {
+		t.Helper()
+		dir := t.TempDir()
+		w := NewDirAdapter(dir)
+		if err := w.WriteRows("routes.txt", rows); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		reader := &Reader{Adapter: NewDirAdapter(dir)}
+		if err := reader.Open(); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { reader.Close() })
+		return reader
+	}
+
+	t.Run("header only is treated as empty", func(t *testing.T) {
+		if !routesRequired(writeRoutes(t, [][]string{header}).ValidateStructure()) {
+			t.Error("header-only routes.txt should report a FileRequiredError")
+		}
+	})
+	t.Run("header plus a data row is not empty", func(t *testing.T) {
+		if routesRequired(writeRoutes(t, [][]string{header, dataRow}).ValidateStructure()) {
+			t.Error("routes.txt with a data row should not be treated as empty")
+		}
+	})
+}
+
 // TestValidateStructure_RequiredHeaderOnly ensures the empty-file handling does
 // not weaken required files: a required file with only a header (no data rows)
 // must still report a FileRequiredError.


### PR DESCRIPTION
## Summary
`Reader.ValidateStructure` only needs each file's header and whether it contains at least one data row, but it previously read every row of every file to determine that — on stop_times.txt or shapes.txt that means scanning tens of millions of rows for nothing. It now reads the header and the first data row via `ReadRowsIter` and stops, leaving the rest of structure validation (empty-file handling, required-column and duplicate-column checks, the conditional stops.txt handling for flex feeds) unchanged.

### Behavior preserved
- A header-only file is still treated as empty: required files report `FileRequiredError`, and optional files (such as stops.txt in a flex feed) are skipped without error.
- A file with at least one data row still runs the column-presence and duplicate-column checks against its header.

## Test plan
- A new `TestValidateStructure_RequiresDataRow` pins the header-vs-data-row distinction: a header-only required file reports `FileRequiredError`, while the same file with one data row validates.
- The existing `tlcsv` structure-validation tests (flex stops.txt conditionals, required-header-only) still pass, confirming the early return produces the same results as the previous full scan.
