### PR TITLE
Improve builder memory usage

### DIFF
--- a/ext/builders/agency_place_builder.go
+++ b/ext/builders/agency_place_builder.go
@@ -37,7 +37,6 @@ func (rs *AgencyPlace) Filename() string {
 type AgencyPlaceBuilder struct {
 	stops       map[string]string // store just geohash
 	routeAgency map[string]string
-	tripAgency  map[string]string
 	agencyStops map[string]map[string]int
 }
 
@@ -45,7 +44,6 @@ func NewAgencyPlaceBuilder() *AgencyPlaceBuilder {
 	return &AgencyPlaceBuilder{
 		stops:       map[string]string{},
 		routeAgency: map[string]string{},
-		tripAgency:  map[string]string{},
 		agencyStops: map[string]map[string]int{},
 	}
 }
@@ -60,15 +58,24 @@ func (pp *AgencyPlaceBuilder) AfterWrite(eid string, ent tt.Entity, emap *tt.Ent
 	case *gtfs.Route:
 		pp.routeAgency[eid] = v.AgencyID.Val
 	case *gtfs.Trip:
-		pp.tripAgency[eid] = pp.routeAgency[v.RouteID.Val]
-	case *gtfs.StopTime:
-		if !v.StopID.Valid {
+		// Tally the agency's stop geohashes from the trip's own stop_times rather than
+		// keeping a trip->agency map for every trip. With journey-pattern dedup this also
+		// counts deduplicated trips, weighting by service frequency; stop ids resolve
+		// through the EntityMap.
+		agencyStops, ok := pp.agencyStops[pp.routeAgency[v.RouteID.Val]]
+		if !ok {
 			return nil
 		}
-		aid := pp.tripAgency[v.TripID.Val]
-		if sg, ok := pp.stops[v.StopID.Val]; ok {
-			if v, ok := pp.agencyStops[aid]; ok {
-				v[sg] += 1
+		for _, st := range v.StopTimes {
+			if !st.StopID.Valid {
+				continue
+			}
+			stopId, ok := emap.Get("stops.txt", st.StopID.Val)
+			if !ok {
+				continue
+			}
+			if sg, ok := pp.stops[stopId]; ok {
+				agencyStops[sg] += 1
 			}
 		}
 	}

--- a/ext/builders/agency_place_builder_test.go
+++ b/ext/builders/agency_place_builder_test.go
@@ -1,3 +1,62 @@
 package builders
 
-// TODO
+import (
+	"context"
+	"testing"
+
+	"github.com/interline-io/transitland-lib/adapters/direct"
+	"github.com/interline-io/transitland-lib/copier"
+	"github.com/interline-io/transitland-lib/internal/testreader"
+	"github.com/interline-io/transitland-lib/tlcsv"
+	"github.com/stretchr/testify/assert"
+)
+
+// runAgencyPlace copies a feed through an AgencyPlaceBuilder and returns it for
+// white-box inspection of the accumulated per-agency geohash tally. The Copy step
+// (which needs a postgres writer) is intentionally not exercised here; the refactor
+// only affects how AfterWrite tallies stop visits.
+func runAgencyPlace(t *testing.T, url string, dedup bool) *AgencyPlaceBuilder {
+	t.Helper()
+	reader, err := tlcsv.NewReader(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts := copier.Options{DeduplicateJourneyPatterns: dedup}
+	e := NewAgencyPlaceBuilder()
+	opts.AddExtension(e)
+	if _, err := copier.CopyWithOptions(context.Background(), reader, direct.NewWriter(), opts); err != nil {
+		t.Fatal(err)
+	}
+	return e
+}
+
+func agencyVisits(b *AgencyPlaceBuilder, aid string) (geohashes int, total int) {
+	gh := b.agencyStops[aid]
+	for _, c := range gh {
+		total += c
+	}
+	return len(gh), total
+}
+
+func TestAgencyPlaceBuilder(t *testing.T) {
+	// The builder tallies one visit per valid stop_time across the agency's trips,
+	// reading each trip's own stop_times in its AfterWrite and resolving stop ids
+	// through the EntityMap. BART is a single-agency feed, so every stop_time counts
+	// toward BART.
+	t.Run("tallies stop visits per agency", func(t *testing.T) {
+		b := runAgencyPlace(t, testreader.ExampleFeedBART.URL, false)
+		geohashes, total := agencyVisits(b, "BART")
+		assert.Equal(t, 48, geohashes, "distinct stop geohashes for BART")
+		assert.Equal(t, 33167, total, "total stop_time visits for BART")
+	})
+
+	// Because the tally is driven by each trip's own stop_times in the Trip AfterWrite
+	// (not by individually written StopTime entities), journey-pattern deduplication —
+	// which drops duplicate trips' written stop_times — does not change the agency
+	// tally. Deduplicated trips are still counted, weighting by service frequency.
+	t.Run("deduplication does not change the tally", func(t *testing.T) {
+		_, totalOff := agencyVisits(runAgencyPlace(t, testreader.ExampleFeedBART.URL, false), "BART")
+		_, totalOn := agencyVisits(runAgencyPlace(t, testreader.ExampleFeedBART.URL, true), "BART")
+		assert.Equal(t, totalOff, totalOn, "dedup on/off must tally the same")
+	})
+}

--- a/ext/builders/convex_hull_builder.go
+++ b/ext/builders/convex_hull_builder.go
@@ -45,7 +45,6 @@ func (ent *FeedVersionGeometry) TableName() string {
 
 type ConvexHullBuilder struct {
 	stops              map[string]*stopGeom
-	tripRoutes         map[string]string
 	routeStopGeoms     map[string]*routeStopGeoms
 	locationGeometries []tt.Geometry
 }
@@ -53,7 +52,6 @@ type ConvexHullBuilder struct {
 func NewConvexHullBuilder() *ConvexHullBuilder {
 	return &ConvexHullBuilder{
 		stops:          map[string]*stopGeom{},
-		tripRoutes:     map[string]string{},
 		routeStopGeoms: map[string]*routeStopGeoms{},
 	}
 }
@@ -75,22 +73,26 @@ func (pp *ConvexHullBuilder) AfterWrite(eid string, ent tt.Entity, emap *tt.Enti
 			stopGeoms: map[string]*stopGeom{},
 		}
 	case *gtfs.Trip:
-		pp.tripRoutes[eid] = v.RouteID.Val
-	case *gtfs.StopTime:
-		if !v.StopID.Valid {
-			return nil
-		}
-		r, ok := pp.routeStopGeoms[pp.tripRoutes[v.TripID.Val]]
+		// Record the route's visited stop geometries from the trip's own stop_times
+		// (see RouteStopBuilder); resolve stop ids through the EntityMap.
+		r, ok := pp.routeStopGeoms[v.RouteID.Val]
 		if !ok {
-			// log.For(ctx).Debug().Msgf("no route:", v.TripID, pp.tripRoutes[v.TripID])
 			return nil
 		}
-		s, ok := pp.stops[v.StopID.Val]
-		if !ok {
-			// log.For(ctx).Debug().Msgf("no stop:", v.StopID)
-			return nil
+		for _, st := range v.StopTimes {
+			if !st.StopID.Valid {
+				continue
+			}
+			stopId, ok := emap.Get("stops.txt", st.StopID.Val)
+			if !ok {
+				continue
+			}
+			s, ok := pp.stops[stopId]
+			if !ok {
+				continue
+			}
+			r.stopGeoms[stopId] = s
 		}
-		r.stopGeoms[v.StopID.Val] = s
 	}
 	return nil
 }

--- a/ext/builders/onestop_id_builder.go
+++ b/ext/builders/onestop_id_builder.go
@@ -58,7 +58,6 @@ func (ent *AgencyOnestopID) TableName() string {
 type OnestopIDBuilder struct {
 	agencyNames    map[string]string
 	stops          map[string]*stopGeom
-	tripRoutes     map[string]string
 	routeStopGeoms map[string]*routeStopGeoms
 }
 
@@ -66,7 +65,6 @@ func NewOnestopIDBuilder() *OnestopIDBuilder {
 	return &OnestopIDBuilder{
 		agencyNames:    map[string]string{},
 		stops:          map[string]*stopGeom{},
-		tripRoutes:     map[string]string{},
 		routeStopGeoms: map[string]*routeStopGeoms{},
 	}
 }
@@ -92,22 +90,26 @@ func (pp *OnestopIDBuilder) AfterWrite(eid string, ent tt.Entity, emap *tt.Entit
 			stopGeoms: map[string]*stopGeom{},
 		}
 	case *gtfs.Trip:
-		pp.tripRoutes[eid] = v.RouteID.Val
-	case *gtfs.StopTime:
-		if !v.StopID.Valid {
-			return nil
-		}
-		r, ok := pp.routeStopGeoms[pp.tripRoutes[v.TripID.Val]]
+		// Record the route's visited stop geometries from the trip's own stop_times
+		// (see RouteStopBuilder); resolve stop ids through the EntityMap.
+		r, ok := pp.routeStopGeoms[v.RouteID.Val]
 		if !ok {
-			// log.For(ctx).Debug().Msgf("OnestopIDBuilder no route:", v.TripID, pp.tripRoutes[v.TripID])
 			return nil
 		}
-		s, ok := pp.stops[v.StopID.Val]
-		if !ok {
-			// log.For(ctx).Debug().Msgf("OnestopIDBuilder no stop:", v.StopID)
-			return nil
+		for _, st := range v.StopTimes {
+			if !st.StopID.Valid {
+				continue
+			}
+			stopId, ok := emap.Get("stops.txt", st.StopID.Val)
+			if !ok {
+				continue
+			}
+			s, ok := pp.stops[stopId]
+			if !ok {
+				continue
+			}
+			r.stopGeoms[stopId] = s
 		}
-		r.stopGeoms[v.StopID.Val] = s
 	}
 	return nil
 }

--- a/ext/builders/route_headway_builder.go
+++ b/ext/builders/route_headway_builder.go
@@ -33,12 +33,6 @@ func (ent *RouteHeadway) TableName() string {
 
 //////
 
-type riTrip struct {
-	RouteID   string
-	ServiceID string
-	Direction uint8
-}
-
 type riKey struct {
 	StopID    string
 	ServiceID string
@@ -46,18 +40,20 @@ type riKey struct {
 }
 
 type RouteHeadwayBuilder struct {
-	tripDetails     map[string]riTrip
-	routeDepartures map[string]map[riKey][]int
-	serviceDays     map[string][]string
-	tripService     map[string]string
+	// Departure seconds are accumulated for every stop_time in the feed, so they are
+	// stored as int32 (seconds-since-midnight fits easily) to halve this map's footprint
+	// on large feeds; widened back to int only for the selected stop's stats.
+	routeDepartures map[string]map[riKey][]int32
+	// services holds one Service per service_id. The active-days materialization is
+	// deferred to Copy and scoped to each route's own services there, instead of
+	// expanding every service into a feed-wide date->services map up front.
+	services map[string]*service.Service
 }
 
 func NewRouteHeadwayBuilder() *RouteHeadwayBuilder {
 	return &RouteHeadwayBuilder{
-		tripDetails:     map[string]riTrip{},
-		routeDepartures: map[string]map[riKey][]int{},
-		tripService:     map[string]string{},
-		serviceDays:     map[string][]string{},
+		routeDepartures: map[string]map[riKey][]int32{},
+		services:        map[string]*service.Service{},
 	}
 }
 
@@ -65,18 +61,10 @@ func (pp *RouteHeadwayBuilder) AfterWrite(eid string, ent tt.Entity, emap *tt.En
 	// Keep track of all services and departures
 	switch v := ent.(type) {
 	case *gtfs.Calendar:
-		// Use only the first 30 days of service
-		svc := service.NewService(*v, v.CalendarDates...)
-		startDate := v.StartDate.Val
-		for i := 0; i < 31; i++ {
-			if svc.IsActive(startDate) {
-				d := startDate.Format("2006-01-02")
-				pp.serviceDays[d] = append(pp.serviceDays[d], eid)
-			}
-			startDate = startDate.AddDate(0, 0, 1)
-		}
+		// Cache the service; its active days are materialized lazily in Copy.
+		pp.services[eid] = service.NewService(*v, v.CalendarDates...)
 	case *gtfs.Route:
-		pp.routeDepartures[eid] = map[riKey][]int{}
+		pp.routeDepartures[eid] = map[riKey][]int32{}
 	case *gtfs.Trip:
 		// Process StopTimes assuming they will all be written
 		// otherwise this breaks on journey pattern deduplication.
@@ -94,7 +82,7 @@ func (pp *RouteHeadwayBuilder) AfterWrite(eid string, ent tt.Entity, emap *tt.En
 				StopID:    stopId,
 			}
 			if rd, ok := pp.routeDepartures[v.RouteID.Val]; ok && st.DepartureTime.Valid {
-				rd[rkey] = append(rd[rkey], st.DepartureTime.Int())
+				rd[rkey] = append(rd[rkey], int32(st.DepartureTime.Int()))
 			}
 		}
 	}
@@ -108,17 +96,24 @@ func (pp *RouteHeadwayBuilder) Copy(copier adapters.EntityCopier) error {
 		for k, v := range routeDepartures {
 			departuresByService[k.ServiceID] += len(v)
 		}
+		// Materialize active days for only this route's services (deferred from
+		// accumulation), scoped to the route instead of scanning every feed service.
+		routeServiceDays := map[string]map[string]bool{}
+		for sid := range departuresByService {
+			if svc, ok := pp.services[sid]; ok {
+				routeServiceDays[sid] = serviceWindowDays(svc)
+			}
+		}
 		tripsByDay := map[string]int{}
-		for day, serviceids := range pp.serviceDays {
-			for _, sid := range serviceids {
-				tripsByDay[day] += departuresByService[sid]
+		for sid, n := range departuresByService {
+			for day := range routeServiceDays[sid] {
+				tripsByDay[day] += n
 			}
 		}
 		// Stable sort
 		tripsByDaySorted := sortMap(tripsByDay)
 		// Get the highest trip count for each dow category
 		dowCatDay := map[int]string{}
-		dowCatCounts := map[int]int{}
 		for _, day := range tripsByDaySorted {
 			// parse day again to get weekday
 			d, _ := time.Parse("2006-01-02", day)
@@ -132,21 +127,17 @@ func (pp *RouteHeadwayBuilder) Copy(copier adapters.EntityCopier) error {
 			}
 			if _, ok := dowCatDay[dowCat]; !ok {
 				dowCatDay[dowCat] = day
-				dowCatCounts[dowCat] = tripsByDay[day]
 			}
 		}
 		// For each direction...
 		for direction := uint8(0); direction < 2; direction++ {
 			// Find the stop with the most visits on the highest day in each dow category
-			for dowCat, dowCatDay := range dowCatDay {
-				d, _ := time.Parse("2006-01-02", dowCatDay)
-				stopDepartures := map[string][]int{}
-				serviceIds := pp.serviceDays[dowCatDay]
+			for dowCat, day := range dowCatDay {
+				d, _ := time.Parse("2006-01-02", day)
+				stopDepartures := map[string][]int32{}
 				for k, v := range routeDepartures {
-					for _, sid := range serviceIds {
-						if k.Direction == direction && k.ServiceID == sid {
-							stopDepartures[k.StopID] = append(stopDepartures[k.StopID], v...)
-						}
+					if k.Direction == direction && routeServiceDays[k.ServiceID][day] {
+						stopDepartures[k.StopID] = append(stopDepartures[k.StopID], v...)
 					}
 				}
 				stopsByVisits := sortMapSlice(stopDepartures)
@@ -154,7 +145,7 @@ func (pp *RouteHeadwayBuilder) Copy(copier adapters.EntityCopier) error {
 					continue
 				}
 				mostVisitedStop := stopsByVisits[0]
-				departures := stopDepartures[mostVisitedStop]
+				departures := intsFromInt32(stopDepartures[mostVisitedStop])
 				sort.Ints(departures)
 				rh := RouteHeadway{
 					RouteID:        rid,
@@ -218,7 +209,31 @@ func median(v []int) float64 {
 	return float64(v[m-1]+v[m]) / 2
 }
 
-func sortMapSlice(value map[string][]int) []string {
+// intsFromInt32 widens a departures slice (stored as int32 to bound memory across the
+// whole feed) back to []int for the stats helpers and tt.Ints output.
+func intsFromInt32(v []int32) []int {
+	out := make([]int, len(v))
+	for i, x := range v {
+		out[i] = int(x)
+	}
+	return out
+}
+
+// serviceWindowDays returns the YYYY-MM-DD dates a service is active on within the
+// first 31 days of its calendar — the window the headway day-selection uses.
+func serviceWindowDays(svc *service.Service) map[string]bool {
+	days := map[string]bool{}
+	d := svc.StartDate.Val
+	for i := 0; i < 31; i++ {
+		if svc.IsActive(d) {
+			days[d.Format("2006-01-02")] = true
+		}
+		d = d.AddDate(0, 0, 1)
+	}
+	return days
+}
+
+func sortMapSlice(value map[string][]int32) []string {
 	type kv struct {
 		Key   string
 		Value int

--- a/ext/builders/route_stop_builder.go
+++ b/ext/builders/route_stop_builder.go
@@ -26,14 +26,12 @@ func (rs *RouteStop) Filename() string {
 
 type RouteStopBuilder struct {
 	routeAgencies map[string]string
-	tripRoutes    map[string]string
 	routeStops    map[string]map[string]bool
 }
 
 func NewRouteStopBuilder() *RouteStopBuilder {
 	return &RouteStopBuilder{
 		routeAgencies: map[string]string{},
-		tripRoutes:    map[string]string{},
 		routeStops:    map[string]map[string]bool{},
 	}
 }
@@ -43,18 +41,25 @@ func (pp *RouteStopBuilder) AfterWrite(eid string, ent tt.Entity, emap *tt.Entit
 	case *gtfs.Route:
 		pp.routeAgencies[eid] = v.AgencyID.Val
 	case *gtfs.Trip:
-		pp.tripRoutes[eid] = v.RouteID.Val
-	case *gtfs.StopTime:
-		if !v.StopID.Valid {
-			return nil
+		// The trip carries its stop_times, so record the route's stops here from
+		// v.RouteID rather than keeping a trip->route map until each StopTime arrives.
+		// The attached stop_times are raw, so resolve stop ids through the EntityMap.
+		rid := v.RouteID.Val
+		for _, st := range v.StopTimes {
+			if !st.StopID.Valid {
+				continue
+			}
+			stopId, ok := emap.Get("stops.txt", st.StopID.Val)
+			if !ok {
+				continue
+			}
+			rs, ok := pp.routeStops[rid]
+			if !ok {
+				rs = map[string]bool{}
+				pp.routeStops[rid] = rs
+			}
+			rs[stopId] = true
 		}
-		rid := pp.tripRoutes[v.TripID.Val]
-		rs, ok := pp.routeStops[rid]
-		if !ok {
-			rs = map[string]bool{}
-			pp.routeStops[rid] = rs
-		}
-		rs[v.StopID.Val] = true
 	}
 	return nil
 }

--- a/ext/builders/route_stop_builder.go
+++ b/ext/builders/route_stop_builder.go
@@ -45,6 +45,7 @@ func (pp *RouteStopBuilder) AfterWrite(eid string, ent tt.Entity, emap *tt.Entit
 		// v.RouteID rather than keeping a trip->route map until each StopTime arrives.
 		// The attached stop_times are raw, so resolve stop ids through the EntityMap.
 		rid := v.RouteID.Val
+		var rs map[string]bool // bound on the first kept stop; nil until then avoids an empty route entry
 		for _, st := range v.StopTimes {
 			if !st.StopID.Valid {
 				continue
@@ -53,10 +54,11 @@ func (pp *RouteStopBuilder) AfterWrite(eid string, ent tt.Entity, emap *tt.Entit
 			if !ok {
 				continue
 			}
-			rs, ok := pp.routeStops[rid]
-			if !ok {
-				rs = map[string]bool{}
-				pp.routeStops[rid] = rs
+			if rs == nil {
+				if rs = pp.routeStops[rid]; rs == nil {
+					rs = map[string]bool{}
+					pp.routeStops[rid] = rs
+				}
 			}
 			rs[stopId] = true
 		}


### PR DESCRIPTION
## Summary
Reduces the memory the default import builders hold on large feeds. Several builders kept a map from every trip_id to its route or agency, and RouteHeadway accumulated a departure value per stop_time plus a fully materialized per-feed service-day calendar; all of these scale with the trip and stop_time counts. This reworks them to carry less per-feed state without changing their output, with one intentional exception noted below.

### Drop the per-trip lookup maps
- route_stop, convex_hull, agency_place, and onestop previously held a `map[trip_id]route_id` (or agency) populated for every trip, because they consumed stop_times one at a time and had lost the trip context by then. They now process each trip's stop_times inside the Trip `AfterWrite`, where the trip and its route/agency are already in hand (the approach RouteHeadway already used), resolving stop ids through the EntityMap. The per-trip maps are removed.
- Output is identical for the set-based builders (route_stop, convex_hull, onestop). agency_place, which counts stop visits, now also counts journey-pattern-deduplicated trips, weighting by service frequency rather than by pattern count — consistent with how RouteHeadway already treats deduplicated trips. This is the one intentional behavior change; a new agency_place builder test pins the per-agency tally and that deduplication does not change it.

### Shrink RouteHeadway's accumulated state
- Departure times are stored as `int32` (seconds-since-midnight fits easily) rather than `int`, halving the largest accumulator, which holds one value per stop_time across the whole feed.
- The per-service active-day calendar is no longer materialized up front for the entire feed. RouteHeadway caches each Service and materializes active days lazily in `Copy`, scoped to each route's own services instead of scanning every feed service for every route — which also removes a large per-route loop.
- Removes dead state: the `riTrip`, `tripDetails`, and `tripService` fields and the unused `dowCatCounts` map.

## Test plan
- `ext/builders` and `stats` tests pass. The RouteHeadway tests assert identical headway output per route, direction, and day-of-week category; the new agency_place test pins its per-agency stop-visit tally and that journey-pattern deduplication leaves the tally unchanged.
- On a large feed import, confirm peak memory drops and that route headway, route stop, and agency place outputs are unchanged aside from agency_place's frequency-weighting under deduplication.
