### PR TITLE
Additional debug logging on onestop_id resolution

### DIFF
--- a/server/finders/dbfinder/stop.go
+++ b/server/finders/dbfinder/stop.go
@@ -27,6 +27,14 @@ func (f *Finder) FindStops(ctx context.Context, limit *int, after *model.Cursor,
 	if err := dbutil.Select(ctx, f.db, q, &ents); err != nil {
 		return nil, logErr(ctx, err)
 	}
+	// Temporary instrumentation for tlv2#354: only for bare-osid AllowPrev
+	// requests (the durable-key case), not pinned-version browsing. stopSelect
+	// has already merged where.OnestopID into where.OnestopIds.
+	if allowPrevProbeEnabled && where != nil &&
+		where.AllowPreviousOnestopIds != nil && *where.AllowPreviousOnestopIds &&
+		where.FeedVersionSha1 == nil && len(ids) == 0 && len(where.OnestopIds) > 0 {
+		f.probeAllowPrev(ctx, where.OnestopIds)
+	}
 	return ents, nil
 }
 

--- a/server/finders/dbfinder/stop_onestop_probe.go
+++ b/server/finders/dbfinder/stop_onestop_probe.go
@@ -35,21 +35,13 @@ type allowPrevProbeRow struct {
 	SearchWouldMatch bool   `db:"search_would_match"`
 }
 
-// probeAllowPrev resolves the requested Onestop IDs via the same (feed, stop_id)
-// continuity the AllowPrev query uses, then classifies each resolved current
-// stop:
-//   - differs: the stop's current Onestop ID is not the requested one, i.e. an
-//     exact lookup would have missed it and AllowPrev did real work.
-//   - search_would_match: a geohash-point + name search would also have found
-//     this stop, so a search-key resolver would not lose it.
-//
-// "meaningful" work (logged per row) is differs AND NOT search_would_match: the
-// resolutions that only stored history can recover. It measures raw continuity
-// resolution (no permission/license filtering) against active feed versions.
 // allowPrevProbeQuery builds the diagnostic query. Args bind in order: the osid
-// VALUES rows (CTE), then the radius and similarity threshold in the
+// VALUES rows (req CTE), then the radius and similarity threshold in the
 // search_would_match expression. squirrel emits CTE args before column args, so
-// placeholder positions line up.
+// placeholder positions line up. The hist CTE collapses the per-feed-version
+// history to one row per (requested osid, entity_id, feed) before joining to
+// stops, mirroring the production CTE's DISTINCT ON and avoiding fan-out for
+// pairs present in many feed versions.
 func allowPrevProbeQuery(osids []string) sq.SelectBuilder {
 	ph := make([]string, len(osids))
 	args := make([]interface{}, len(osids))
@@ -63,16 +55,16 @@ func allowPrevProbeQuery(osids []string) sq.SelectBuilder {
 	}
 	return sq.StatementBuilder.
 		Select(
-			"req.requested_osid",
+			"hist.requested_osid",
 			"gs.id as stop_db_id",
 			"gs.stop_id as stop_gtfs_id",
 			"coalesce(cur.onestop_id,'') as current_osid",
-			"(cur.onestop_id IS DISTINCT FROM req.requested_osid) as differs",
+			"(cur.onestop_id IS DISTINCT FROM hist.requested_osid) as differs",
 		).
 		Column(sq.Expr(
-			"(ST_DWithin(gs.geometry, ST_PointFromGeoHash(split_part(req.requested_osid,'-',2))::geography, ?) "+
-				"and (split_part(coalesce(cur.onestop_id,''),'-',3) = split_part(req.requested_osid,'-',3) "+
-				"or word_similarity(split_part(req.requested_osid,'-',3), split_part(coalesce(cur.onestop_id,''),'-',3)) > ?)) as search_would_match",
+			"(ST_DWithin(gs.geometry, ST_PointFromGeoHash(split_part(hist.requested_osid,'-',2))::geography, ?) "+
+				"and (split_part(coalesce(cur.onestop_id,''),'-',3) = split_part(hist.requested_osid,'-',3) "+
+				"or word_similarity(split_part(hist.requested_osid,'-',3), split_part(coalesce(cur.onestop_id,''),'-',3)) > ?)) as search_would_match",
 			allowPrevProbeRadiusM, allowPrevProbeSimilarity,
 		)).
 		Distinct().
@@ -81,15 +73,34 @@ func allowPrevProbeQuery(osids []string) sq.SelectBuilder {
 			ColumnList: []string{"requested_osid"},
 			Expression: sq.Expr("VALUES "+strings.Join(ph, ", "), args...),
 		}).
-		From("req").
-		Join("feed_version_stop_onestop_ids hist on hist.onestop_id = req.requested_osid").
-		Join("feed_versions hist_fv on hist_fv.id = hist.feed_version_id").
+		WithCTE(sq.CTE{
+			Alias: "hist",
+			Expression: sq.Expr("SELECT DISTINCT req.requested_osid, fvs.entity_id, fv.feed_id " +
+				"FROM req " +
+				"JOIN feed_version_stop_onestop_ids fvs ON fvs.onestop_id = req.requested_osid " +
+				"JOIN feed_versions fv ON fv.id = fvs.feed_version_id"),
+		}).
+		From("hist").
 		Join("gtfs_stops gs on gs.stop_id = hist.entity_id").
-		Join("feed_versions cur_fv on cur_fv.id = gs.feed_version_id and cur_fv.feed_id = hist_fv.feed_id").
+		Join("feed_versions cur_fv on cur_fv.id = gs.feed_version_id and cur_fv.feed_id = hist.feed_id").
 		Join("feed_states fs on fs.feed_version_id = gs.feed_version_id").
 		JoinClause("left join feed_version_stop_onestop_ids cur on cur.entity_id = gs.stop_id and cur.feed_version_id = gs.feed_version_id")
 }
 
+// probeAllowPrev resolves the requested Onestop IDs via the same (feed, stop_id)
+// continuity the AllowPrev query uses, then classifies each resolved current
+// stop:
+//   - differs: the stop's current Onestop ID is not the requested one, i.e. an
+//     exact lookup would have missed it and AllowPrev did real work.
+//   - search_would_match: a geohash-point + name search would also have found
+//     this stop, so a search-key resolver would not lose it.
+//
+// "meaningful" work (logged per row) is differs AND NOT search_would_match: the
+// resolutions that only stored history can recover. Stops with no current
+// Onestop ID (a stats data gap, where differs is ill-defined) are counted
+// separately as n_no_current and excluded from both, so they do not inflate the
+// meaningful count. It measures raw continuity resolution (no permission/license
+// filtering) against active feed versions.
 func (f *Finder) probeAllowPrev(ctx context.Context, osids []string) {
 	if len(osids) == 0 {
 		return
@@ -102,8 +113,12 @@ func (f *Finder) probeAllowPrev(ctx context.Context, osids []string) {
 		return
 	}
 
-	differs, meaningful := 0, 0
+	differs, meaningful, noCurrent := 0, 0, 0
 	for _, r := range rows {
+		if r.CurrentOsid == "" {
+			noCurrent++
+			continue
+		}
 		if r.Differs {
 			differs++
 			if !r.SearchWouldMatch {
@@ -116,10 +131,11 @@ func (f *Finder) probeAllowPrev(ctx context.Context, osids []string) {
 		Int("n_resolved", len(rows)).
 		Int("n_differs", differs).
 		Int("n_meaningful", meaningful).
+		Int("n_no_current", noCurrent).
 		Strs("requested_osids", osids).
 		Msg("allowprev_probe")
 	for _, r := range rows {
-		if r.Differs && !r.SearchWouldMatch {
+		if r.CurrentOsid != "" && r.Differs && !r.SearchWouldMatch {
 			log.For(ctx).Info().
 				Str("requested_osid", r.RequestedOsid).
 				Str("current_osid", r.CurrentOsid).

--- a/server/finders/dbfinder/stop_onestop_probe.go
+++ b/server/finders/dbfinder/stop_onestop_probe.go
@@ -1,0 +1,131 @@
+package dbfinder
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"github.com/interline-io/log"
+	"github.com/interline-io/transitland-lib/server/dbutil"
+	sq "github.com/irees/squirrel"
+)
+
+// Temporary instrumentation for interline-io/tlv2#354: measure how often the
+// AllowPreviousOnestopIds resolution actually does work beyond an exact lookup,
+// and how much of that work a geohash+name search would reproduce. Enable by
+// setting TL_LOG_ALLOWPREV_PROBE to any non-empty value; it is off otherwise and
+// adds no overhead. When on, it runs one extra read-only query per bare-osid
+// AllowPrev request and emits structured log lines ("allowprev_probe" /
+// "allowprev_probe_meaningful"). Safe to delete once the measurement is done.
+var allowPrevProbeEnabled = os.Getenv("TL_LOG_ALLOWPREV_PROBE") != ""
+
+// Match the parameters the candidate search-key resolver would use, so
+// search_would_match reflects what switching to search would actually return.
+const (
+	allowPrevProbeRadiusM    = 100.0
+	allowPrevProbeSimilarity = 0.4
+)
+
+type allowPrevProbeRow struct {
+	RequestedOsid    string `db:"requested_osid"`
+	StopDbID         int    `db:"stop_db_id"`
+	StopGtfsID       string `db:"stop_gtfs_id"`
+	CurrentOsid      string `db:"current_osid"`
+	Differs          bool   `db:"differs"`
+	SearchWouldMatch bool   `db:"search_would_match"`
+}
+
+// probeAllowPrev resolves the requested Onestop IDs via the same (feed, stop_id)
+// continuity the AllowPrev query uses, then classifies each resolved current
+// stop:
+//   - differs: the stop's current Onestop ID is not the requested one, i.e. an
+//     exact lookup would have missed it and AllowPrev did real work.
+//   - search_would_match: a geohash-point + name search would also have found
+//     this stop, so a search-key resolver would not lose it.
+//
+// "meaningful" work (logged per row) is differs AND NOT search_would_match: the
+// resolutions that only stored history can recover. It measures raw continuity
+// resolution (no permission/license filtering) against active feed versions.
+// allowPrevProbeQuery builds the diagnostic query. Args bind in order: the osid
+// VALUES rows (CTE), then the radius and similarity threshold in the
+// search_would_match expression. squirrel emits CTE args before column args, so
+// placeholder positions line up.
+func allowPrevProbeQuery(osids []string) sq.SelectBuilder {
+	ph := make([]string, len(osids))
+	args := make([]interface{}, len(osids))
+	for i, osid := range osids {
+		if i == 0 {
+			ph[i] = "(?::text)"
+		} else {
+			ph[i] = "(?)"
+		}
+		args[i] = osid
+	}
+	return sq.StatementBuilder.
+		Select(
+			"req.requested_osid",
+			"gs.id as stop_db_id",
+			"gs.stop_id as stop_gtfs_id",
+			"coalesce(cur.onestop_id,'') as current_osid",
+			"(cur.onestop_id IS DISTINCT FROM req.requested_osid) as differs",
+		).
+		Column(sq.Expr(
+			"(ST_DWithin(gs.geometry, ST_PointFromGeoHash(split_part(req.requested_osid,'-',2))::geography, ?) "+
+				"and (split_part(coalesce(cur.onestop_id,''),'-',3) = split_part(req.requested_osid,'-',3) "+
+				"or word_similarity(split_part(req.requested_osid,'-',3), split_part(coalesce(cur.onestop_id,''),'-',3)) > ?)) as search_would_match",
+			allowPrevProbeRadiusM, allowPrevProbeSimilarity,
+		)).
+		Distinct().
+		WithCTE(sq.CTE{
+			Alias:      "req",
+			ColumnList: []string{"requested_osid"},
+			Expression: sq.Expr("VALUES "+strings.Join(ph, ", "), args...),
+		}).
+		From("req").
+		Join("feed_version_stop_onestop_ids hist on hist.onestop_id = req.requested_osid").
+		Join("feed_versions hist_fv on hist_fv.id = hist.feed_version_id").
+		Join("gtfs_stops gs on gs.stop_id = hist.entity_id").
+		Join("feed_versions cur_fv on cur_fv.id = gs.feed_version_id and cur_fv.feed_id = hist_fv.feed_id").
+		Join("feed_states fs on fs.feed_version_id = gs.feed_version_id").
+		JoinClause("left join feed_version_stop_onestop_ids cur on cur.entity_id = gs.stop_id and cur.feed_version_id = gs.feed_version_id")
+}
+
+func (f *Finder) probeAllowPrev(ctx context.Context, osids []string) {
+	if len(osids) == 0 {
+		return
+	}
+	q := allowPrevProbeQuery(osids)
+
+	var rows []allowPrevProbeRow
+	if err := dbutil.Select(ctx, f.db, q, &rows); err != nil {
+		log.For(ctx).Warn().Err(err).Msg("allowprev_probe query failed")
+		return
+	}
+
+	differs, meaningful := 0, 0
+	for _, r := range rows {
+		if r.Differs {
+			differs++
+			if !r.SearchWouldMatch {
+				meaningful++
+			}
+		}
+	}
+	log.For(ctx).Info().
+		Int("n_requested", len(osids)).
+		Int("n_resolved", len(rows)).
+		Int("n_differs", differs).
+		Int("n_meaningful", meaningful).
+		Strs("requested_osids", osids).
+		Msg("allowprev_probe")
+	for _, r := range rows {
+		if r.Differs && !r.SearchWouldMatch {
+			log.For(ctx).Info().
+				Str("requested_osid", r.RequestedOsid).
+				Str("current_osid", r.CurrentOsid).
+				Str("stop_gtfs_id", r.StopGtfsID).
+				Int("stop_db_id", r.StopDbID).
+				Msg("allowprev_probe_meaningful")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds temporary, opt-in instrumentation to measure how often the `allow_previous_onestop_ids` stop resolution actually does work beyond an exact Onestop ID lookup, and how much of that work a content-based (geohash point + name) search would reproduce. This is decision-support for interline-io/tlv2#354, which is evaluating whether the `feed_version_stop_onestop_ids` history table (~640 GB in production, the bulk of it per-feed-version repetition) can be replaced by a search-key resolver without losing real resolutions. The instrumentation is gated behind an environment variable, off by default with zero overhead, read-only, and intended to be removed once the measurement window is complete.

### What it measures

For each resolved current stop, it classifies two things: `differs` — the stop's current Onestop ID is not the one that was requested, meaning an exact lookup would have missed it and the previous-id behavior did real work; and `search_would_match` — whether a geohash-point + name-similarity search (using the same 100 m radius and 0.4 `word_similarity` threshold a candidate search-key resolver would use) would also have found the stop. The decision metric is `n_meaningful` = `differs AND NOT search_would_match`: resolutions that only stored history can recover. If that count stays near zero over real traffic, a search-key resolver is safe; if not, it quantifies the recall a search-only design would lose.

### How it works

A probe in `FindStops` fires only when `TL_LOG_ALLOWPREV_PROBE` is set and the request is a bare-osid previous-id lookup — `allow_previous_onestop_ids` true, no `feed_version_sha1`, no explicit ids — which isolates the durable-key use case (e.g. a stored Onestop ID powering a departure board) from frontend pinned-version browsing. It runs one additional read-only query that reproduces the same `(feed, stop_id)` continuity the production resolver uses, then computes both classifications entirely in SQL, using `ST_PointFromGeoHash` to decode the requested geohash so no Go-side geohash or name-normalization logic is needed. Results are emitted as structured logs: one `allowprev_probe` summary line per request (`n_requested`, `n_resolved`, `n_differs`, `n_meaningful`, `requested_osids`) and one `allowprev_probe_meaningful` detail line per resolution that only history could recover.

### Scope and caveats

Off by default; when the env var is unset there is no added query or overhead. When enabled it adds one synchronous read-only query to qualifying requests, so it is a measurement-window tool rather than a permanent fixture. It measures raw continuity resolution without permission or license filtering, so counts reflect resolution capability rather than what any specific caller would be authorized to see. Pinned-feed-version previous-id requests are intentionally excluded as a different semantic. The whole change is one new file plus an eight-line guard in `FindStops`, so it is straightforward to delete afterward.

## Test plan

Set `TL_LOG_ALLOWPREV_PROBE=1` and start the server, then issue a GraphQL stops query with a bare previous Onestop ID, e.g. `stops(where:{onestop_id:"s-9q9nfswzpg-fruitvale", allow_previous_onestop_ids:true})`, and confirm an `allowprev_probe` log line is emitted with sensible counts (and an `allowprev_probe_meaningful` line only when a resolution would not be reproduced by search). Confirm that a request with `feed_version_sha1` also set produces no probe line. Unset the env var and confirm no probe log lines appear and no extra query is issued.
