### PR TITLE
Add --overwrite option to dbmigrate-natural-earth

### DIFF
--- a/doc/cli/transitland_dbmigrate-natural-earth.md
+++ b/doc/cli/transitland_dbmigrate-natural-earth.md
@@ -17,6 +17,7 @@ transitland dbmigrate-natural-earth [flags]
 ```
       --dburl string   Database URL (default: $TL_DATABASE_URL)
   -h, --help           help for dbmigrate-natural-earth
+      --overwrite      Reload even if data is already present (truncates first); default skips when present
 ```
 
 ### SEE ALSO

--- a/schema/ne/dbmigrate_cmd.go
+++ b/schema/ne/dbmigrate_cmd.go
@@ -24,8 +24,9 @@ import (
 // zip files in by importing transitland-lib/cmds.
 
 type Command struct {
-	DBURL   string
-	Adapter tldb.Adapter
+	DBURL     string
+	Overwrite bool
+	Adapter   tldb.Adapter
 }
 
 func (cmd *Command) HelpDesc() (string, string) {
@@ -34,6 +35,7 @@ func (cmd *Command) HelpDesc() (string, string) {
 
 func (cmd *Command) AddFlags(fl *pflag.FlagSet) {
 	fl.StringVar(&cmd.DBURL, "dburl", "", "Database URL (default: $TL_DATABASE_URL)")
+	fl.BoolVar(&cmd.Overwrite, "overwrite", false, "Reload even if data is already present (truncates first); default skips when present")
 }
 
 func (cmd *Command) Parse(args []string) error {
@@ -51,6 +53,23 @@ func (cmd *Command) Run(ctx context.Context) error {
 	}
 	defer atx.Close()
 	cmd.Adapter = postgresAdapter.NewPostgresAdapterFromDBX(db)
+
+	// The loader appends rows unconditionally (these tables have no natural unique key),
+	// so guard against duplicating an existing load: skip when data is already present
+	// unless --overwrite, which truncates both tables and reloads.
+	var count int
+	if err := cmd.Adapter.Get(ctx, &count, "SELECT count(*) FROM ne_10m_populated_places"); err != nil {
+		return err
+	}
+	if count > 0 && !cmd.Overwrite {
+		log.Info().Msgf("Natural Earth data already present (%d populated places); skipping (use --overwrite to reload)", count)
+		return nil
+	}
+	if cmd.Overwrite {
+		if _, err := cmd.Adapter.DBX().ExecContext(ctx, "TRUNCATE ne_10m_admin_1_states_provinces, ne_10m_populated_places"); err != nil {
+			return err
+		}
+	}
 
 	return fs.WalkDir(EmbeddedNaturalEarthData, ".", func(path string, info fs.DirEntry, err error) error {
 		if err != nil {


### PR DESCRIPTION
## Summary
Makes `dbmigrate-natural-earth` safe to re-run. The loader appends rows unconditionally because the Natural Earth tables have no natural unique key, so running it a second time silently duplicated every admin boundary and populated place. The command now skips when data is already present and only reloads when explicitly asked to, via a new `--overwrite` flag that truncates first.

### Behavior
- Default: if `ne_10m_populated_places` already has rows, log how many and return without loading — re-running is now a no-op instead of doubling the data.
- `--overwrite`: `TRUNCATE`s both `ne_10m_admin_1_states_provinces` and `ne_10m_populated_places`, then reloads from the embedded shapefiles.
- First run on an empty database is unchanged.

## Test plan
- On a fresh DB, run `dbmigrate-natural-earth` and confirm both tables populate.
- Run it again with no flag; confirm it logs the existing count and skips (row counts unchanged, no duplicates).
- Run with `--overwrite`; confirm the tables are truncated and reloaded to the same counts as the first run.
