### PR TITLE
Make max upload size configurable

### DIFF
--- a/server/gql/server.go
+++ b/server/gql/server.go
@@ -2,36 +2,94 @@ package gql
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/extension"
+	"github.com/99designs/gqlgen/graphql/handler/lru"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/interline-io/transitland-lib/internal/generated/gqlout"
+	"github.com/vektah/gqlparser/v2/ast"
 )
 
+// DefaultMaxUploadSize caps the size of a multipart upload body (e.g.
+// validate_gtfs / feed_version_fetch). This matches gqlgen's own conservative
+// default; deployments that accept larger GTFS feeds should raise it with
+// WithMaxUploadSize.
+const DefaultMaxUploadSize int64 = 32 << 20 // 32 MiB
+
+// maxMultipartMemory is the per-part threshold above which gqlgen spills an
+// upload to a temp file instead of buffering it in memory. This is not an
+// upload cap (that is MaxUploadSize); keep it modest.
+const maxMultipartMemory int64 = 32 << 20 // 32 MiB
+
+// serverConfig holds NewServer settings populated by ServerOptions before the
+// gqlgen server is constructed.
+type serverConfig struct {
+	maxUploadSize int64
+	extensions    []graphql.HandlerExtension
+}
+
 // ServerOption configures the gqlgen server instance
-type ServerOption func(s *handler.Server)
+type ServerOption func(c *serverConfig)
 
 // WithExtensions applies one or more gqlgen handler extensions to the server
 func WithExtensions(exts ...graphql.HandlerExtension) ServerOption {
-	return func(s *handler.Server) {
-		for _, ext := range exts {
-			if ext != nil {
-				s.Use(ext)
-			}
-		}
+	return func(c *serverConfig) {
+		c.extensions = append(c.extensions, exts...)
+	}
+}
+
+// WithMaxUploadSize sets the maximum size, in bytes, of a multipart upload
+// request body. Defaults to DefaultMaxUploadSize.
+func WithMaxUploadSize(n int64) ServerOption {
+	return func(c *serverConfig) {
+		c.maxUploadSize = n
 	}
 }
 
 func NewServer(opts ...ServerOption) (http.Handler, error) {
-	c := gqlout.Config{Resolvers: &Resolver{}}
-	// Setup server
-	srv := handler.NewDefaultServer(gqlout.NewExecutableSchema(c))
-	// Apply functional options
+	cfg := serverConfig{
+		maxUploadSize: DefaultMaxUploadSize,
+	}
 	for _, opt := range opts {
 		if opt != nil {
-			opt(srv)
+			opt(&cfg)
 		}
 	}
+
+	c := gqlout.Config{Resolvers: &Resolver{}}
+
+	// Equivalent to handler.NewDefaultServer, but with a configurable multipart
+	// upload cap. (gqlgen's default MultipartForm rejects bodies over 32 MiB,
+	// and because it matches the first transport that supports a request, the
+	// cap cannot be raised by adding a second MultipartForm after the fact — so
+	// the server has to be built explicitly here.)
+	srv := handler.New(gqlout.NewExecutableSchema(c))
+	srv.AddTransport(transport.Websocket{
+		KeepAlivePingInterval: 10 * time.Second,
+	})
+	srv.AddTransport(transport.Options{})
+	srv.AddTransport(transport.GET{})
+	srv.AddTransport(transport.POST{})
+	srv.AddTransport(transport.MultipartForm{
+		MaxUploadSize: cfg.maxUploadSize,
+		MaxMemory:     maxMultipartMemory,
+	})
+	srv.SetQueryCache(lru.New[*ast.QueryDocument](1000))
+	srv.Use(extension.Introspection{})
+	srv.Use(extension.AutomaticPersistedQuery{
+		Cache: lru.New[string](100),
+	})
+
+	// Apply caller-provided handler extensions.
+	for _, ext := range cfg.extensions {
+		if ext != nil {
+			srv.Use(ext)
+		}
+	}
+
 	graphqlServer := loaderMiddleware(srv)
 	return graphqlServer, nil
 }


### PR DESCRIPTION
## Summary

Makes the GraphQL server's multipart upload size limit configurable. gqlgen's `handler.NewDefaultServer` registers a `MultipartForm` transport with a hardcoded 32 MiB cap and no way to override it, so large multipart uploads (`validate_gtfs`, `feed_version_fetch`) are silently rejected with "request body too large" once a feed exceeds 32 MiB — which real regional/merged GTFS feeds routinely do.

This builds the gqlgen server explicitly so the cap can be set, and exposes it as a `NewServer` option. The default is unchanged (32 MiB, matching gqlgen); deployments raise it via `gql.WithMaxUploadSize(...)`.

### Changes

- Add `WithMaxUploadSize(n int64) ServerOption` and a `DefaultMaxUploadSize` constant (32 MiB).
- Replace `handler.NewDefaultServer` with an explicit `handler.New` + transports build, configuring `transport.MultipartForm{MaxUploadSize, MaxMemory}`. This is required: `NewDefaultServer` adds the default `MultipartForm` first, and gqlgen uses the first transport that supports a request, so the cap can't be raised by adding another transport afterward.
- `MaxMemory` is kept at 32 MiB — it's the per-part spill-to-disk threshold, not the reject cap, so larger uploads stream to a temp file rather than buffering in memory.
- Rework `ServerOption` to populate an internal `serverConfig` read at construction time (so the size is applied before transports are built). `WithExtensions` keeps its exact public signature.

### Compatibility

- Default behavior is unchanged (32 MiB).
- `NewServer` and `WithExtensions` signatures are unchanged, so existing callers (incl. `cmds/server_cmd.go` and downstream consumers using `WithExtensions`) need no changes.
- Also moves off `handler.NewDefaultServer`, which gqlgen marks deprecated / not for production.

## Test plan

- `go build ./...` and `go vet ./server/gql/` pass; existing callers compile unchanged.
- Manual: with `WithMaxUploadSize(128 << 20)`, `validate_gtfs` accepts a >32 MiB feed; without an override, uploads over 32 MiB are still rejected as before.
