### PR TITLE
Drift checker experiment

### DIFF
--- a/gtfs/entities.go
+++ b/gtfs/entities.go
@@ -1,0 +1,45 @@
+package gtfs
+
+import "github.com/interline-io/transitland-lib/tt"
+
+// AllEntities returns a fresh zero-value instance of every GTFS entity type
+// defined in this package, in roughly reference.md order. It is the canonical
+// enumeration of GTFS entities, intended as a single source of truth for
+// schema-drift checks and any future field-level code generation.
+//
+// Note: fare_leg_join_rules.txt has no model yet and is intentionally absent.
+func AllEntities() []tt.Entity {
+	return []tt.Entity{
+		&Agency{},
+		&Stop{},
+		&Route{},
+		&Trip{},
+		&StopTime{},
+		&Calendar{},
+		&CalendarDate{},
+		&FareAttribute{},
+		&FareRule{},
+		&Timeframe{},
+		&RiderCategory{},
+		&FareMedia{},
+		&FareProduct{},
+		&FareLegRule{},
+		&FareTransferRule{},
+		&Area{},
+		&StopArea{},
+		&Network{},
+		&RouteNetwork{},
+		&Shape{},
+		&Frequency{},
+		&Transfer{},
+		&Pathway{},
+		&Level{},
+		&LocationGroup{},
+		&LocationGroupStop{},
+		&Location{},
+		&BookingRule{},
+		&Translation{},
+		&FeedInfo{},
+		&Attribution{},
+	}
+}

--- a/internal/feedstate/manager.go
+++ b/internal/feedstate/manager.go
@@ -211,15 +211,11 @@ func (m *Manager) DematerializeFeedVersion(ctx context.Context, feedVersionID in
 	return nil
 }
 
-// MaterializeFeedVersion inserts routes/stops/agencies for a feed version into materialized tables
-func (m *Manager) MaterializeFeedVersion(ctx context.Context, feedVersionID int) error {
-	// Clear any existing materialized data for this feed version first
-	if err := m.DematerializeFeedVersion(ctx, feedVersionID); err != nil {
-		return fmt.Errorf("failed to dematerialize feed version %d before materializing: %w", feedVersionID, err)
-	}
-
-	// Build route column mappings (destination column -> source expression)
-	routeFields := map[string]string{
+// routeMaterializeFields returns the destination-column -> source-expression
+// projection used to populate tl_materialized_active_routes. When spatial is
+// true the geometry is simplified (PostGIS); otherwise it is copied as-is (SQLite).
+func routeMaterializeFields(spatial bool) map[string]string {
+	fields := map[string]string{
 		"id":                  "gtfs_routes.id",
 		"route_id":            "gtfs_routes.route_id",
 		"route_short_name":    "gtfs_routes.route_short_name",
@@ -245,36 +241,18 @@ func (m *Manager) MaterializeFeedVersion(ctx context.Context, feedVersionID int)
 		"created_at":          "gtfs_routes.created_at",
 		"updated_at":          "gtfs_routes.updated_at",
 	}
-
-	// Add geometry column - full geometry for SQLite, simplified for PostGIS
-	routeFields["geometry_simplified"] = "tlrg.geometry"
-	if m.adapter.SupportsSpatialFunctions() {
-		routeFields["geometry_simplified"] = "ST_Simplify(tlrg.geometry::geometry, 0.01)"
+	// Geometry column - full geometry for SQLite, simplified for PostGIS
+	fields["geometry_simplified"] = "tlrg.geometry"
+	if spatial {
+		fields["geometry_simplified"] = "ST_Simplify(tlrg.geometry::geometry, 0.01)"
 	}
+	return fields
+}
 
-	// Extract columns and selects from the map, sorted for consistency
-	routeColumns, routeSelects := sortedColumnsAndSelects(routeFields)
-
-	// Insert routes with derived data using Squirrel
-	routeQuery := m.adapter.Sqrl().
-		Insert("tl_materialized_active_routes").
-		Columns(routeColumns...).
-		Select(m.adapter.Sqrl().
-			Select(routeSelects...).
-			From("gtfs_routes").
-			Join("gtfs_agencies ON gtfs_agencies.id = gtfs_routes.agency_id").
-			Join("feed_versions ON feed_versions.id = gtfs_routes.feed_version_id").
-			LeftJoin("feed_version_route_onestop_ids osid ON osid.entity_id = gtfs_routes.route_id AND osid.feed_version_id = feed_versions.id").
-			LeftJoin("tl_route_geometries tlrg ON tlrg.route_id = gtfs_routes.id").
-			Where(sq.Eq{"gtfs_routes.feed_version_id": feedVersionID}))
-
-	_, err := routeQuery.ExecContext(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to insert routes for feed version %d: %w", feedVersionID, err)
-	}
-
-	// Build stop column mappings (destination column -> source expression)
-	stopFields := map[string]string{
+// stopMaterializeFields returns the destination-column -> source-expression
+// projection used to populate tl_materialized_active_stops.
+func stopMaterializeFields() map[string]string {
+	return map[string]string{
 		"id":                  "gtfs_stops.id",
 		"stop_id":             "gtfs_stops.stop_id",
 		"stop_code":           "gtfs_stops.stop_code",
@@ -299,6 +277,77 @@ func (m *Manager) MaterializeFeedVersion(ctx context.Context, feedVersionID int)
 		"created_at":          "gtfs_stops.created_at",
 		"updated_at":          "gtfs_stops.updated_at",
 	}
+}
+
+// agencyMaterializeFields returns the destination-column -> source-expression
+// projection used to populate tl_materialized_active_agencies.
+func agencyMaterializeFields() map[string]string {
+	return map[string]string{
+		"id":              "gtfs_agencies.id",
+		"agency_id":       "gtfs_agencies.agency_id",
+		"agency_name":     "gtfs_agencies.agency_name",
+		"agency_url":      "gtfs_agencies.agency_url",
+		"agency_timezone": "gtfs_agencies.agency_timezone",
+		"agency_lang":     "gtfs_agencies.agency_lang",
+		"agency_phone":    "gtfs_agencies.agency_phone",
+		"agency_fare_url": "gtfs_agencies.agency_fare_url",
+		"agency_email":    "gtfs_agencies.agency_email",
+		"cemv_support":    "gtfs_agencies.cemv_support",
+		"feed_version_id": "feed_versions.id",
+		"feed_id":         "feed_versions.feed_id",
+		"onestop_id":      "osid.onestop_id",
+		"textsearch":      "gtfs_agencies.textsearch",
+		"created_at":      "gtfs_agencies.created_at",
+		"updated_at":      "gtfs_agencies.updated_at",
+	}
+}
+
+// MaterializedTableFields returns, for each materialized active table, the
+// destination-column -> source-expression projection used by
+// MaterializeFeedVersion. These maps are the single source of truth for what
+// those tables must contain; schema-drift checks assert that every destination
+// column exists in the corresponding table.
+func MaterializedTableFields(spatial bool) map[string]map[string]string {
+	return map[string]map[string]string{
+		"tl_materialized_active_routes":   routeMaterializeFields(spatial),
+		"tl_materialized_active_stops":    stopMaterializeFields(),
+		"tl_materialized_active_agencies": agencyMaterializeFields(),
+	}
+}
+
+// MaterializeFeedVersion inserts routes/stops/agencies for a feed version into materialized tables
+func (m *Manager) MaterializeFeedVersion(ctx context.Context, feedVersionID int) error {
+	// Clear any existing materialized data for this feed version first
+	if err := m.DematerializeFeedVersion(ctx, feedVersionID); err != nil {
+		return fmt.Errorf("failed to dematerialize feed version %d before materializing: %w", feedVersionID, err)
+	}
+
+	// Build route column mappings (destination column -> source expression)
+	routeFields := routeMaterializeFields(m.adapter.SupportsSpatialFunctions())
+
+	// Extract columns and selects from the map, sorted for consistency
+	routeColumns, routeSelects := sortedColumnsAndSelects(routeFields)
+
+	// Insert routes with derived data using Squirrel
+	routeQuery := m.adapter.Sqrl().
+		Insert("tl_materialized_active_routes").
+		Columns(routeColumns...).
+		Select(m.adapter.Sqrl().
+			Select(routeSelects...).
+			From("gtfs_routes").
+			Join("gtfs_agencies ON gtfs_agencies.id = gtfs_routes.agency_id").
+			Join("feed_versions ON feed_versions.id = gtfs_routes.feed_version_id").
+			LeftJoin("feed_version_route_onestop_ids osid ON osid.entity_id = gtfs_routes.route_id AND osid.feed_version_id = feed_versions.id").
+			LeftJoin("tl_route_geometries tlrg ON tlrg.route_id = gtfs_routes.id").
+			Where(sq.Eq{"gtfs_routes.feed_version_id": feedVersionID}))
+
+	_, err := routeQuery.ExecContext(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to insert routes for feed version %d: %w", feedVersionID, err)
+	}
+
+	// Build stop column mappings (destination column -> source expression)
+	stopFields := stopMaterializeFields()
 
 	// Extract columns and selects from the map, sorted for consistency
 	stopColumns, stopSelects := sortedColumnsAndSelects(stopFields)
@@ -320,24 +369,7 @@ func (m *Manager) MaterializeFeedVersion(ctx context.Context, feedVersionID int)
 	}
 
 	// Build agency column mappings (destination column -> source expression)
-	agencyFields := map[string]string{
-		"id":              "gtfs_agencies.id",
-		"agency_id":       "gtfs_agencies.agency_id",
-		"agency_name":     "gtfs_agencies.agency_name",
-		"agency_url":      "gtfs_agencies.agency_url",
-		"agency_timezone": "gtfs_agencies.agency_timezone",
-		"agency_lang":     "gtfs_agencies.agency_lang",
-		"agency_phone":    "gtfs_agencies.agency_phone",
-		"agency_fare_url": "gtfs_agencies.agency_fare_url",
-		"agency_email":    "gtfs_agencies.agency_email",
-		"cemv_support":    "gtfs_agencies.cemv_support",
-		"feed_version_id": "feed_versions.id",
-		"feed_id":         "feed_versions.feed_id",
-		"onestop_id":      "osid.onestop_id",
-		"textsearch":      "gtfs_agencies.textsearch",
-		"created_at":      "gtfs_agencies.created_at",
-		"updated_at":      "gtfs_agencies.updated_at",
-	}
+	agencyFields := agencyMaterializeFields()
 
 	// Extract columns and selects from the map, sorted for consistency
 	agencyColumns, agencySelects := sortedColumnsAndSelects(agencyFields)

--- a/schema/sqlite/sqlite.sql
+++ b/schema/sqlite/sqlite.sql
@@ -668,6 +668,9 @@ CREATE TABLE gtfs_fare_leg_rules (
   "from_area_id" varchar(255),
   "to_area_id" varchar(255),
   "fare_product_id" varchar(255),
+  "from_timeframe_group_id" varchar(255),
+  "to_timeframe_group_id" varchar(255),
+  "rule_priority" integer,
   "transfer_only" integer,
   foreign key(feed_version_id) REFERENCES feed_versions(id)
 );
@@ -683,6 +686,7 @@ CREATE TABLE gtfs_fare_transfer_rules (
   duration_limit_type int,
   fare_transfer_type int,
   fare_product_id varchar(255),
+  filter_fare_product_id varchar(255),
   foreign key(feed_version_id) REFERENCES feed_versions(id)
 );
 CREATE TABLE gtfs_fare_products (

--- a/tldb/schema_drift_sqlite_test.go
+++ b/tldb/schema_drift_sqlite_test.go
@@ -1,0 +1,53 @@
+//go:build cgo
+
+package tldb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/interline-io/transitland-lib/tldb"
+	"github.com/interline-io/transitland-lib/tldb/sqlite"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSchemaDrift_SQLite checks that every column each GTFS entity writes exists
+// in the embedded SQLite schema (schema/sqlite/sqlite.sql), using an in-memory
+// database. No external database is required.
+func TestSchemaDrift_SQLite(t *testing.T) {
+	assertEntityColumns(t, context.Background(), newSQLiteSchemaDB(t), sqliteColumns)
+}
+
+// TestSchemaDrift_MaterializedSQLite checks that every column the materialization
+// projects exists in the embedded SQLite materialized active tables.
+func TestSchemaDrift_MaterializedSQLite(t *testing.T) {
+	assertMaterializedColumns(t, context.Background(), newSQLiteSchemaDB(t), sqliteColumns, false)
+}
+
+// newSQLiteSchemaDB opens an in-memory SQLite database and applies the embedded schema.
+func newSQLiteSchemaDB(t *testing.T) tldb.Ext {
+	adapter := &sqlite.SQLiteAdapter{DBURL: "sqlite3://:memory:"}
+	require.NoError(t, adapter.Open())
+	t.Cleanup(func() { adapter.Close() })
+	require.NoError(t, adapter.Create())
+	return adapter.DBX()
+}
+
+// sqliteColumns returns the set of column names for a table via the
+// pragma_table_info table-valued function with a bound argument.
+func sqliteColumns(ctx context.Context, db tldb.Ext, table string) (map[string]bool, error) {
+	rows, err := db.QueryContext(ctx, "SELECT name FROM pragma_table_info(?)", table)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	cols := map[string]bool{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		cols[name] = true
+	}
+	return cols, rows.Err()
+}

--- a/tldb/schema_drift_test.go
+++ b/tldb/schema_drift_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/interline-io/transitland-lib/gtfs"
+	"github.com/interline-io/transitland-lib/internal/feedstate"
 	"github.com/interline-io/transitland-lib/tldb"
 	"github.com/interline-io/transitland-lib/tldb/sqlite"
 	"github.com/stretchr/testify/assert"
@@ -52,6 +53,36 @@ func TestSchemaDrift_SQLite(t *testing.T) {
 			for _, col := range want {
 				assert.Containsf(t, got, col,
 					"%T: db column %q is missing from sqlite table %q (add it to schema/sqlite/sqlite.sql)", ent, col, table)
+			}
+		})
+	}
+}
+
+// TestSchemaDrift_MaterializedSQLite asserts that every destination column the
+// materialization projection writes exists in the corresponding materialized
+// active table in the embedded SQLite schema.
+//
+// The source of truth is feedstate.MaterializedTableFields — the same
+// destination-column set MaterializeFeedVersion inserts. If a projection gains a
+// column but the table doesn't (the cEMV / stop_access class of bug), the
+// materialization INSERT would fail; this catches it without a live DB. The
+// spatial flag does not change the destination column set, so false is used.
+func TestSchemaDrift_MaterializedSQLite(t *testing.T) {
+	ctx := context.Background()
+	adapter := &sqlite.SQLiteAdapter{DBURL: "sqlite3://:memory:"}
+	require.NoError(t, adapter.Open())
+	defer adapter.Close()
+	require.NoError(t, adapter.Create())
+	db := adapter.DBX()
+
+	for table, fields := range feedstate.MaterializedTableFields(false) {
+		t.Run(table, func(t *testing.T) {
+			got, err := sqliteColumns(ctx, db, table)
+			require.NoError(t, err)
+			require.NotEmptyf(t, got, "materialized table %q is missing from schema/sqlite/sqlite.sql", table)
+			for col := range fields {
+				assert.Containsf(t, got, col,
+					"materialization projects column %q but it is missing from %q (add it to schema/sqlite/sqlite.sql and the postgres migration)", col, table)
 			}
 		})
 	}

--- a/tldb/schema_drift_test.go
+++ b/tldb/schema_drift_test.go
@@ -1,0 +1,78 @@
+//go:build cgo
+
+package tldb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/interline-io/transitland-lib/gtfs"
+	"github.com/interline-io/transitland-lib/tldb"
+	"github.com/interline-io/transitland-lib/tldb/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSchemaDrift_SQLite asserts that every database column the writer expects
+// for each GTFS entity actually exists in the embedded SQLite schema
+// (schema/sqlite/sqlite.sql).
+//
+// The "expected" set is tldb.MapperCache.GetHeader(ent) — the exact column
+// header the insert path builds from the struct's `db` tags. That means
+// `db:"-"` fields and CSV-only fields are already excluded, and the embedded
+// tt.BaseEntity bookkeeping columns (id, feed_version_id, ...) are included. If
+// a struct gains a field but the schema doesn't, the writer's INSERT would fail
+// at runtime; this moves that failure to a fast, DB-less CI check.
+//
+// This is deliberately a forward (subset) check: a table may legitimately carry
+// extra bookkeeping columns the struct doesn't model, so we only assert that
+// struct columns are a subset of table columns, not equality. Entities without
+// a TableName (e.g. Shape, whose points are aggregated into gtfs_shapes via a
+// separate DB representation) are skipped.
+func TestSchemaDrift_SQLite(t *testing.T) {
+	ctx := context.Background()
+	adapter := &sqlite.SQLiteAdapter{DBURL: "sqlite3://:memory:"}
+	require.NoError(t, adapter.Open())
+	defer adapter.Close()
+	require.NoError(t, adapter.Create())
+	db := adapter.DBX()
+
+	for _, ent := range gtfs.AllEntities() {
+		tn, ok := ent.(tldb.HasTableName)
+		if !ok {
+			continue
+		}
+		table := tn.TableName()
+		t.Run(table, func(t *testing.T) {
+			want, err := tldb.MapperCache.GetHeader(ent)
+			require.NoError(t, err)
+			got, err := sqliteColumns(ctx, db, table)
+			require.NoError(t, err)
+			require.NotEmptyf(t, got, "table %q has no columns; is it missing from schema/sqlite/sqlite.sql?", table)
+			for _, col := range want {
+				assert.Containsf(t, got, col,
+					"%T: db column %q is missing from sqlite table %q (add it to schema/sqlite/sqlite.sql)", ent, col, table)
+			}
+		})
+	}
+}
+
+// sqliteColumns returns the set of column names for a table. It uses the
+// pragma_table_info table-valued function with a bound argument, so the table
+// name is passed as a parameter rather than interpolated.
+func sqliteColumns(ctx context.Context, db tldb.Ext, table string) (map[string]bool, error) {
+	rows, err := db.QueryContext(ctx, "SELECT name FROM pragma_table_info(?)", table)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	cols := map[string]bool{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		cols[name] = true
+	}
+	return cols, rows.Err()
+}

--- a/tldb/schema_drift_test.go
+++ b/tldb/schema_drift_test.go
@@ -1,43 +1,37 @@
-//go:build cgo
-
 package tldb_test
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/interline-io/transitland-lib/gtfs"
 	"github.com/interline-io/transitland-lib/internal/feedstate"
 	"github.com/interline-io/transitland-lib/tldb"
-	"github.com/interline-io/transitland-lib/tldb/sqlite"
+	"github.com/interline-io/transitland-lib/tldb/postgres"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestSchemaDrift_SQLite asserts that every database column the writer expects
-// for each GTFS entity actually exists in the embedded SQLite schema
-// (schema/sqlite/sqlite.sql).
-//
-// The "expected" set is tldb.MapperCache.GetHeader(ent) — the exact column
-// header the insert path builds from the struct's `db` tags. That means
-// `db:"-"` fields and CSV-only fields are already excluded, and the embedded
-// tt.BaseEntity bookkeeping columns (id, feed_version_id, ...) are included. If
-// a struct gains a field but the schema doesn't, the writer's INSERT would fail
-// at runtime; this moves that failure to a fast, DB-less CI check.
-//
-// This is deliberately a forward (subset) check: a table may legitimately carry
-// extra bookkeeping columns the struct doesn't model, so we only assert that
-// struct columns are a subset of table columns, not equality. Entities without
-// a TableName (e.g. Shape, whose points are aggregated into gtfs_shapes via a
-// separate DB representation) are skipped.
-func TestSchemaDrift_SQLite(t *testing.T) {
-	ctx := context.Background()
-	adapter := &sqlite.SQLiteAdapter{DBURL: "sqlite3://:memory:"}
-	require.NoError(t, adapter.Open())
-	defer adapter.Close()
-	require.NoError(t, adapter.Create())
-	db := adapter.DBX()
+// These tests guard against schema drift: every database column the writer
+// expects for a GTFS entity, and every column the materialization projects, must
+// exist in the live schema. The SQLite variants (cgo-gated, in-memory, in
+// schema_drift_sqlite_test.go) run everywhere; the Postgres variants below run
+// against the migrated test database when TL_TEST_DATABASE_URL is set (CI, or
+// locally via testdata/test_setup.sh).
 
+// columnLister returns the set of column names for a table from a live schema,
+// abstracting over the SQLite (pragma) and Postgres (information_schema) sources.
+type columnLister func(ctx context.Context, db tldb.Ext, table string) (map[string]bool, error)
+
+// assertEntityColumns checks that every db column each GTFS entity writes exists
+// in its table. The expected set is tldb.MapperCache.GetHeader(ent) — the exact
+// header the insert path builds from the struct's `db` tags, so `db:"-"` and
+// CSV-only fields are excluded and the embedded BaseEntity columns are included.
+// It is a forward subset check; a table may carry extra bookkeeping columns the
+// struct doesn't model. Entities without a TableName (e.g. Shape, aggregated into
+// gtfs_shapes via a separate representation) are skipped.
+func assertEntityColumns(t *testing.T, ctx context.Context, db tldb.Ext, cols columnLister) {
 	for _, ent := range gtfs.AllEntities() {
 		tn, ok := ent.(tldb.HasTableName)
 		if !ok {
@@ -47,52 +41,57 @@ func TestSchemaDrift_SQLite(t *testing.T) {
 		t.Run(table, func(t *testing.T) {
 			want, err := tldb.MapperCache.GetHeader(ent)
 			require.NoError(t, err)
-			got, err := sqliteColumns(ctx, db, table)
+			got, err := cols(ctx, db, table)
 			require.NoError(t, err)
-			require.NotEmptyf(t, got, "table %q has no columns; is it missing from schema/sqlite/sqlite.sql?", table)
+			require.NotEmptyf(t, got, "table %q is missing from the schema", table)
 			for _, col := range want {
-				assert.Containsf(t, got, col,
-					"%T: db column %q is missing from sqlite table %q (add it to schema/sqlite/sqlite.sql)", ent, col, table)
+				assert.Containsf(t, got, col, "%T: db column %q is missing from table %q", ent, col, table)
 			}
 		})
 	}
 }
 
-// TestSchemaDrift_MaterializedSQLite asserts that every destination column the
-// materialization projection writes exists in the corresponding materialized
-// active table in the embedded SQLite schema.
-//
-// The source of truth is feedstate.MaterializedTableFields — the same
-// destination-column set MaterializeFeedVersion inserts. If a projection gains a
-// column but the table doesn't (the cEMV / stop_access class of bug), the
-// materialization INSERT would fail; this catches it without a live DB. The
-// spatial flag does not change the destination column set, so false is used.
-func TestSchemaDrift_MaterializedSQLite(t *testing.T) {
+// assertMaterializedColumns checks that every column the materialization projects
+// exists in the materialized active table. The source of truth is
+// feedstate.MaterializedTableFields — the same destination columns
+// MaterializeFeedVersion inserts.
+func assertMaterializedColumns(t *testing.T, ctx context.Context, db tldb.Ext, cols columnLister, spatial bool) {
+	for table, fields := range feedstate.MaterializedTableFields(spatial) {
+		t.Run(table, func(t *testing.T) {
+			got, err := cols(ctx, db, table)
+			require.NoError(t, err)
+			require.NotEmptyf(t, got, "materialized table %q is missing from the schema", table)
+			for col := range fields {
+				assert.Containsf(t, got, col, "materialization projects column %q but it is missing from %q", col, table)
+			}
+		})
+	}
+}
+
+// TestSchemaDrift_Postgres runs both drift checks against the migrated Postgres
+// test database. It is skipped unless TL_TEST_DATABASE_URL is set. The Postgres
+// path materializes with the simplified geometry, so spatial=true is used; the
+// destination column set is identical regardless.
+func TestSchemaDrift_Postgres(t *testing.T) {
+	dburl := os.Getenv("TL_TEST_DATABASE_URL")
+	if dburl == "" {
+		t.Skip("TL_TEST_DATABASE_URL is not set")
+	}
 	ctx := context.Background()
-	adapter := &sqlite.SQLiteAdapter{DBURL: "sqlite3://:memory:"}
+	adapter := &postgres.PostgresAdapter{DBURL: dburl}
 	require.NoError(t, adapter.Open())
 	defer adapter.Close()
-	require.NoError(t, adapter.Create())
 	db := adapter.DBX()
-
-	for table, fields := range feedstate.MaterializedTableFields(false) {
-		t.Run(table, func(t *testing.T) {
-			got, err := sqliteColumns(ctx, db, table)
-			require.NoError(t, err)
-			require.NotEmptyf(t, got, "materialized table %q is missing from schema/sqlite/sqlite.sql", table)
-			for col := range fields {
-				assert.Containsf(t, got, col,
-					"materialization projects column %q but it is missing from %q (add it to schema/sqlite/sqlite.sql and the postgres migration)", col, table)
-			}
-		})
-	}
+	t.Run("entities", func(t *testing.T) { assertEntityColumns(t, ctx, db, postgresColumns) })
+	t.Run("materialized", func(t *testing.T) { assertMaterializedColumns(t, ctx, db, postgresColumns, true) })
 }
 
-// sqliteColumns returns the set of column names for a table. It uses the
-// pragma_table_info table-valued function with a bound argument, so the table
-// name is passed as a parameter rather than interpolated.
-func sqliteColumns(ctx context.Context, db tldb.Ext, table string) (map[string]bool, error) {
-	rows, err := db.QueryContext(ctx, "SELECT name FROM pragma_table_info(?)", table)
+// postgresColumns returns the set of column names for a table from
+// information_schema, with the table name passed as a bound parameter.
+func postgresColumns(ctx context.Context, db tldb.Ext, table string) (map[string]bool, error) {
+	rows, err := db.QueryContext(ctx,
+		"SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = $1",
+		table)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
Adds a lightweight schema-drift check that reflects over the GTFS entity models and asserts that every column the database writer expects exists in the live schema, for both the raw gtfs_* tables and the materialized active tables, against both SQLite and Postgres. The SQLite checks run everywhere against the embedded schema in an in-memory database; the Postgres checks run against the migrated test database when TL_TEST_DATABASE_URL is set. On its first run the SQLite check found four columns that had drifted out of schema/sqlite/sqlite.sql relative to the Postgres migrations, which this PR also fixes. To give the materialized-table checks a real source of truth, the three inline materialization projections in the feed-state manager are extracted into named functions plus an exported accessor.

### Schema drift checks
- Add a dialect-agnostic core: assertEntityColumns asserts that the column header the insert path builds from each entity's `db` tags (tldb.MapperCache.GetHeader, which honors `db:"-"`, excludes CSV-only fields, and includes the embedded BaseEntity columns) is a subset of the actual table columns, and assertMaterializedColumns asserts the same for the materialization projection's destination columns. Both take a columnLister so the introspection source can be swapped per dialect. The checks are forward subset assertions (a table may carry extra bookkeeping columns); entities without a TableName (e.g. Shape, aggregated into gtfs_shapes via a separate representation) are skipped.
- SQLite: an in-memory database is loaded from the embedded schema/sqlite/sqlite.sql and columns are read via the pragma_table_info(?) table-valued function. These checks need no external database and are cgo-gated like the rest of the SQLite suite (schema_drift_sqlite_test.go).
- Postgres: the migrated test database is introspected via information_schema.columns on the public schema. The Postgres test opens the Postgres adapter directly and is skipped unless TL_TEST_DATABASE_URL is set, so it runs in CI and in local environments configured by testdata/test_setup.sh. The shared helpers and the Postgres test are pure Go (no cgo), so they build and run without the SQLite driver.
- Both introspection queries are static string literals with the table name passed as a bound parameter.

### SQLite schema fixes
- Add four columns to schema/sqlite/sqlite.sql that existed in the Postgres migrations but had never been mirrored into the hand-maintained SQLite schema: from_timeframe_group_id, to_timeframe_group_id, and rule_priority on gtfs_fare_leg_rules, and filter_fare_product_id on gtfs_fare_transfer_rules.
- All four are live struct fields the writer emits, so before this fix a SQLite write of a feed using fare timeframes, leg-rule priority, or the transfer filter product would fail at insert or silently drop the value. The new check now guards against this class of regression in both dialects.

### Materialization projection refactor
- Extract the three inline map[string]string projections in MaterializeFeedVersion into routeMaterializeFields, stopMaterializeFields, and agencyMaterializeFields, and add an exported MaterializedTableFields(spatial bool) accessor that returns them keyed by table name. The refactor is behavior-preserving; the geometry expression still switches on spatial-function support, and the destination column set is unchanged.
- The drift checks consume MaterializedTableFields, so the projections are now a single source of truth shared by the materializer and the tests rather than a list duplicated across the codebase.

### Entity registry
- Add gtfs.AllEntities, returning a fresh instance of every GTFS entity type in roughly reference.md order, as a canonical enumeration for the drift checks and any future field-level tooling. fare_leg_join_rules.txt has no model and is intentionally absent.

## Test plan
- Run the SQLite checks with cgo enabled: `go test ./tldb -run TestSchemaDrift_SQLite` and `-run TestSchemaDrift_MaterializedSQLite`. Both pass with no external database.
- Run the Postgres checks against a migrated database: with TL_TEST_DATABASE_URL set, `go test ./tldb -run TestSchemaDrift_Postgres` passes for both the entity and materialized subtests; with it unset, the test skips.
- Confirm the checks actually catch drift: temporarily remove a column from a table in schema/sqlite/sqlite.sql (or add a tagged field to an entity without a column) and verify the relevant test fails naming the missing column and table.
- Confirm the materialization refactor is behavior-preserving by running the feed-state tests: `go test ./internal/feedstate`.
