### PR TITLE
Build tags for WASM

### DIFF
--- a/request/az.go
+++ b/request/az.go
@@ -1,3 +1,5 @@
+//go:build !js
+
 package request
 
 import (

--- a/request/az_test.go
+++ b/request/az_test.go
@@ -1,3 +1,5 @@
+//go:build !js
+
 package request
 
 import (

--- a/request/cloud_stub_wasm.go
+++ b/request/cloud_stub_wasm.go
@@ -1,0 +1,19 @@
+//go:build js
+
+package request
+
+import "errors"
+
+// The s3/az stores depend on cloud SDKs (aws-sdk-go-v2, azure-sdk-for-go) that
+// don't build for js/wasm (memory-mapped buffers, etc.). They are excluded on
+// js/wasm; these stubs keep the scheme switches in GetStore/NewRequest building.
+// Returning a Store nil is fine — the call sites assign it to Store/Downloader
+// and surface the error.
+
+func NewS3FromUrl(string) (Store, error) {
+	return nil, errors.New("s3:// storage is not supported on js/wasm")
+}
+
+func NewAzFromUrl(string) (Store, error) {
+	return nil, errors.New("az:// storage is not supported on js/wasm")
+}

--- a/request/s3.go
+++ b/request/s3.go
@@ -1,3 +1,5 @@
+//go:build !js
+
 package request
 
 import (

--- a/request/s3_test.go
+++ b/request/s3_test.go
@@ -1,3 +1,5 @@
+//go:build !js
+
 package request
 
 import (


### PR DESCRIPTION
## Summary

Make the `request` package compile under `GOOS=js GOARCH=wasm`. The S3 and Azure blob stores depend on cloud SDKs (`aws-sdk-go-v2`, `azure-sdk-for-go`) that don't build for js/wasm, so they're excluded on that target and replaced with stubs.

## Changes

- Tag `request/s3.go` and `request/az.go` with `//go:build !js` so the cloud-SDK implementations are dropped from js/wasm builds.
- Add `request/cloud_stub_wasm.go` (`//go:build js`) with stub `NewS3FromUrl` / `NewAzFromUrl` that return an "unsupported on js/wasm" error. These keep the `s3://` / `az://` scheme switches in `GetStore` / `NewRequest` compiling; the call sites surface the error normally.

No behavior change on non-js targets — the build tags are inert there, and the existing S3/Azure code is unchanged.
