### PR TITLE
Add in-memory zip adapter; validate uploads without temp files

### DIFF
--- a/server/finders/actions/fv.go
+++ b/server/finders/actions/fv.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"io"
 	"net/url"
-	"os"
 
+	"github.com/interline-io/log"
 	"github.com/interline-io/transitland-lib/adapters"
 	"github.com/interline-io/transitland-lib/copier"
 	"github.com/interline-io/transitland-lib/dmfr"
@@ -133,18 +133,24 @@ func ValidateUpload(ctx context.Context, src io.Reader, feedURL *string, rturls 
 	result := model.ValidationReport{}
 	var reader adapters.Reader
 	if src != nil {
-		// Prepare reader
-		var err error
-		tmpfile, err := os.CreateTemp("", "validator-upload")
+		// Read the upload into memory and read it as a zip directly — no temp file,
+		// so this works where there is no usable filesystem (e.g. js/wasm). This
+		// buffers the whole upload in memory; a future enhancement could spill to a
+		// temp file when a filesystem IS available, to cut memory in server processes.
+		b, err := io.ReadAll(src)
 		if err != nil {
 			// This should result in a failed request
 			return nil, err
 		}
-		io.Copy(tmpfile, src)
-		tmpfile.Close()
-		defer os.Remove(tmpfile.Name())
-		reader, err = tlcsv.NewReader(tmpfile.Name())
+		za, err := tlcsv.NewZipReaderAdapterFromBytes(b)
 		if err != nil {
+			log.For(ctx).Error().Err(err).Msg("validate: could not open uploaded zip")
+			result.FailureReason = strptr("Could not read file")
+			return &result, nil
+		}
+		reader, err = tlcsv.NewReaderFromAdapter(za)
+		if err != nil {
+			log.For(ctx).Error().Err(err).Msg("validate: could not create reader")
 			result.FailureReason = strptr("Could not read file")
 			return &result, nil
 		}
@@ -165,6 +171,7 @@ func ValidateUpload(ctx context.Context, src io.Reader, feedURL *string, rturls 
 	}
 
 	if err := reader.Open(); err != nil {
+		log.For(ctx).Error().Err(err).Msg("validate: could not open feed reader")
 		result.FailureReason = strptr("Could not read file")
 		return &result, nil
 	}
@@ -190,11 +197,13 @@ func ValidateUpload(ctx context.Context, src io.Reader, feedURL *string, rturls 
 
 	vt, err := validator.NewValidator(reader, opts)
 	if err != nil {
+		log.For(ctx).Error().Err(err).Msg("validate: could not create validator")
 		result.FailureReason = strptr("Could not validate file")
 		return &result, nil
 	}
 	r, err := vt.Validate(ctx)
 	if err != nil {
+		log.For(ctx).Error().Err(err).Msg("validate: validation failed")
 		result.FailureReason = strptr("Could not validate file")
 		return &result, nil
 	}

--- a/server/finders/actions/test/actions_test.go
+++ b/server/finders/actions/test/actions_test.go
@@ -268,3 +268,30 @@ func TestValidateUpload(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateUploadFile exercises the file-upload path (src != nil), which reads
+// the archive into memory and validates it via an in-memory zip reader, with no
+// temp file.
+func TestValidateUploadFile(t *testing.T) {
+	testconfig.ConfigTxRollback(t, testconfig.Options{AllowAll: true}, func(cfg model.Config) {
+		ctx := model.WithConfig(context.Background(), cfg)
+		f, err := os.Open(testdata.Path() + "/server/gtfs/caltrain.zip")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+		result, err := actions.ValidateUpload(ctx, f, nil, nil)
+		if err != nil {
+			t.Fatal("unexpected error", err)
+		}
+		if result == nil || result.Details == nil {
+			t.Fatal("no validation report details")
+		}
+		if result.FailureReason != nil {
+			t.Errorf("validation failed: %s", *result.FailureReason)
+		}
+		if result.Details.Sha1 == "" {
+			t.Error("expected a sha1 in the report")
+		}
+	})
+}

--- a/server/gql/server.go
+++ b/server/gql/server.go
@@ -27,8 +27,9 @@ const maxMultipartMemory int64 = 32 << 20 // 32 MiB
 // serverConfig holds NewServer settings populated by ServerOptions before the
 // gqlgen server is constructed.
 type serverConfig struct {
-	maxUploadSize int64
-	extensions    []graphql.HandlerExtension
+	maxUploadSize      int64
+	maxMultipartMemory int64
+	extensions         []graphql.HandlerExtension
 }
 
 // ServerOption configures the gqlgen server instance
@@ -49,9 +50,19 @@ func WithMaxUploadSize(n int64) ServerOption {
 	}
 }
 
+// WithMaxMultipartMemory sets the per-part threshold above which gqlgen spills an
+// upload to a temp file. Environments without a usable filesystem (js/wasm) must
+// raise this to at least the upload size so nothing spills to disk.
+func WithMaxMultipartMemory(n int64) ServerOption {
+	return func(c *serverConfig) {
+		c.maxMultipartMemory = n
+	}
+}
+
 func NewServer(opts ...ServerOption) (http.Handler, error) {
 	cfg := serverConfig{
-		maxUploadSize: DefaultMaxUploadSize,
+		maxUploadSize:      DefaultMaxUploadSize,
+		maxMultipartMemory: maxMultipartMemory,
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -75,7 +86,7 @@ func NewServer(opts ...ServerOption) (http.Handler, error) {
 	srv.AddTransport(transport.POST{})
 	srv.AddTransport(transport.MultipartForm{
 		MaxUploadSize: cfg.maxUploadSize,
-		MaxMemory:     maxMultipartMemory,
+		MaxMemory:     cfg.maxMultipartMemory,
 	})
 	srv.SetQueryCache(lru.New[*ast.QueryDocument](1000))
 	srv.Use(extension.Introspection{})

--- a/server/model/unimplemented_finder.go
+++ b/server/model/unimplemented_finder.go
@@ -3,6 +3,9 @@ package model
 import (
 	"context"
 	"errors"
+	"fmt"
+	"runtime"
+	"strings"
 
 	"github.com/interline-io/transitland-lib/tldb"
 	"github.com/interline-io/transitland-lib/tt"
@@ -25,12 +28,31 @@ var _ Finder = UnimplementedFinder{}
 // unwrapResult), so a per-key error surfaces an unimplemented loader clearly
 // rather than as an opaque length-mismatch or a misleading "not found".
 func notImplBatch[T any, K any](keys []K) ([]T, []error) {
+	err := finderUnimpl(2)
 	data := make([]T, len(keys))
 	errs := make([]error, len(keys))
 	for i := range errs {
-		errs[i] = ErrNotImplemented
+		errs[i] = err
 	}
 	return data, errs
+}
+
+// notImplErr is the not-implemented return for a non-batched stub.
+func notImplErr() error {
+	return finderUnimpl(2)
+}
+
+// finderUnimpl builds the not-implemented error for the Finder method `up` frames
+// above it, naming it (e.g. "not implemented: RouteGeometriesByRouteIDs") so an
+// unimplemented loader identifies itself rather than surfacing a bare "not
+// implemented". It wraps ErrNotImplemented so errors.Is still matches.
+func finderUnimpl(up int) error {
+	name := "unknown"
+	if pc, _, _, ok := runtime.Caller(up); ok {
+		full := runtime.FuncForPC(pc).Name()
+		name = full[strings.LastIndex(full, ".")+1:]
+	}
+	return fmt.Errorf("%w: %s", ErrNotImplemented, name)
 }
 
 // PermFinder
@@ -40,65 +62,65 @@ func (UnimplementedFinder) PermFilter(context.Context) *PermFilter { return nil 
 // EntityFinder
 
 func (UnimplementedFinder) FindAgencies(context.Context, *int, *Cursor, []int, *AgencyFilter) ([]*Agency, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) FindRoutes(context.Context, *int, *Cursor, []int, *RouteFilter) ([]*Route, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) FindStops(context.Context, *int, *Cursor, []int, *StopFilter) ([]*Stop, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) FindTrips(context.Context, *int, *Cursor, []int, *TripFilter) ([]*Trip, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) FindFeedVersions(context.Context, *int, *Cursor, []int, *FeedVersionFilter) ([]*FeedVersion, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) FindFeeds(context.Context, *int, *Cursor, []int, *FeedFilter) ([]*Feed, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) FindOperators(context.Context, *int, *Cursor, []int, *OperatorFilter) ([]*Operator, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) FindPlaces(context.Context, *int, *Cursor, []int, *PlaceAggregationLevel, *PlaceFilter) ([]*Place, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) FindCensusDatasets(context.Context, *int, *Cursor, []int, *CensusDatasetFilter) ([]*CensusDataset, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) FindCensusValuesByDatasetID(context.Context, *int, CensusCursor, int, *CensusDatasetValueFilter) ([]*CensusValue, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) RouteStopBuffer(context.Context, *int, *float64, int) ([]*RouteStopBuffer, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) FindFeedVersionServiceWindow(context.Context, int) (*ServiceWindow, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) DBX() tldb.Ext { return nil }
 
 // EntityLoader
 
 func (UnimplementedFinder) AgenciesByFeedVersionIDs(context.Context, *int, *AgencyFilter, []int) ([][]*Agency, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) AgenciesByIDs(_ context.Context, ids []int) ([]*Agency, []error) {
 	return notImplBatch[*Agency](ids)
 }
 func (UnimplementedFinder) AgenciesByOnestopIDs(context.Context, *int, *AgencyFilter, []string) ([][]*Agency, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) AgencyPlacesByAgencyIDs(context.Context, *int, *AgencyPlaceFilter, []int) ([][]*AgencyPlace, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) BookingRulesByFeedVersionIDs(context.Context, *int, *BookingRuleFilter, []int) ([][]*BookingRule, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) BookingRulesByIDs(_ context.Context, ids []int) ([]*BookingRule, []error) {
 	return notImplBatch[*BookingRule](ids)
 }
 func (UnimplementedFinder) CalendarDatesByServiceIDs(context.Context, *int, *CalendarDateFilter, []int) ([][]*CalendarDate, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) CalendarsByIDs(_ context.Context, ids []int) ([]*Calendar, []error) {
 	return notImplBatch[*Calendar](ids)
@@ -107,19 +129,19 @@ func (UnimplementedFinder) CensusDatasetLayersByDatasetIDs(_ context.Context, id
 	return notImplBatch[[]*CensusLayer](ids)
 }
 func (UnimplementedFinder) CensusFieldsByTableIDs(context.Context, *int, []int) ([][]*CensusField, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) CensusGeographiesByDatasetIDs(context.Context, *int, *CensusDatasetGeographyFilter, []int) ([][]*CensusGeography, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) CensusGeographiesByEntityIDs(context.Context, *int, *CensusGeographyFilter, string, []int) ([][]*CensusGeography, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) CensusGeographiesByLayerIDs(context.Context, *int, *CensusSourceGeographyFilter, []int) ([][]*CensusGeography, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) CensusGeographiesBySourceIDs(context.Context, *int, *CensusSourceGeographyFilter, []int) ([][]*CensusGeography, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) CensusLayersByIDs(_ context.Context, ids []int) ([]*CensusLayer, []error) {
 	return notImplBatch[*CensusLayer](ids)
@@ -131,34 +153,34 @@ func (UnimplementedFinder) CensusSourceLayersBySourceIDs(_ context.Context, ids 
 	return notImplBatch[[]*CensusLayer](ids)
 }
 func (UnimplementedFinder) CensusSourcesByDatasetIDs(context.Context, *int, *CensusSourceFilter, []int) ([][]*CensusSource, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) CensusTablesByDatasetIDs(context.Context, *int, *CensusTableFilter, []int) ([][]*CensusTable, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) CensusTableByIDs(_ context.Context, ids []int) ([]*CensusTable, []error) {
 	return notImplBatch[*CensusTable](ids)
 }
 func (UnimplementedFinder) CensusValuesByGeographyIDs(context.Context, *int, string, []string, []string) ([][]*CensusValue, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) FeedFetchesByFeedIDs(context.Context, *int, *FeedFetchFilter, []int) ([][]*FeedFetch, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) FeedInfosByFeedVersionIDs(context.Context, *int, []int) ([][]*FeedInfo, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) FeedsByIDs(_ context.Context, ids []int) ([]*Feed, []error) {
 	return notImplBatch[*Feed](ids)
 }
 func (UnimplementedFinder) FeedsByOperatorOnestopIDs(context.Context, *int, *FeedFilter, []string) ([][]*Feed, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) FeedStatesByFeedIDs(_ context.Context, ids []int) ([]*FeedState, []error) {
 	return notImplBatch[*FeedState](ids)
 }
 func (UnimplementedFinder) FeedVersionFileInfosByFeedVersionIDs(context.Context, *int, []int) ([][]*FeedVersionFileInfo, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) FeedVersionGeometryByIDs(_ context.Context, ids []int) ([]*tt.Polygon, []error) {
 	return notImplBatch[*tt.Polygon](ids)
@@ -167,49 +189,49 @@ func (UnimplementedFinder) FeedVersionGtfsImportByFeedVersionIDs(_ context.Conte
 	return notImplBatch[*FeedVersionGtfsImport](ids)
 }
 func (UnimplementedFinder) FeedVersionsByFeedIDs(context.Context, *int, *FeedVersionFilter, []int) ([][]*FeedVersion, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) FeedVersionsByIDs(_ context.Context, ids []int) ([]*FeedVersion, []error) {
 	return notImplBatch[*FeedVersion](ids)
 }
 func (UnimplementedFinder) FeedVersionServiceLevelsByFeedVersionIDs(context.Context, *int, *FeedVersionServiceLevelFilter, []int) ([][]*FeedVersionServiceLevel, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) FeedVersionServiceWindowByFeedVersionIDs(_ context.Context, ids []int) ([]*FeedVersionServiceWindow, []error) {
 	return notImplBatch[*FeedVersionServiceWindow](ids)
 }
 func (UnimplementedFinder) FlexStopTimesByStopIDs(context.Context, *int, *StopTimeFilter, []FVPair) ([][]*FlexStopTime, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) FlexStopTimesByLocationIDs(context.Context, *int, *StopTimeFilter, []FVPair) ([][]*FlexStopTime, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) FlexStopTimesByLocationGroupIDs(context.Context, *int, *StopTimeFilter, []FVPair) ([][]*FlexStopTime, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) FlexStopTimesByTripIDs(context.Context, *int, *TripStopTimeFilter, []FVPair) ([][]*FlexStopTime, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) FrequenciesByTripIDs(context.Context, *int, []int) ([][]*Frequency, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) LevelsByIDs(_ context.Context, ids []int) ([]*Level, []error) {
 	return notImplBatch[*Level](ids)
 }
 func (UnimplementedFinder) LevelsByParentStationIDs(context.Context, *int, []int) ([][]*Level, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) LocationGroupsByFeedVersionIDs(context.Context, *int, *LocationGroupFilter, []int) ([][]*LocationGroup, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) LocationGroupsByIDs(_ context.Context, ids []int) ([]*LocationGroup, []error) {
 	return notImplBatch[*LocationGroup](ids)
 }
 func (UnimplementedFinder) LocationGroupsByStopIDs(context.Context, *int, []int) ([][]*LocationGroup, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) LocationsByFeedVersionIDs(context.Context, *int, *LocationFilter, []int) ([][]*Location, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) LocationsByIDs(_ context.Context, ids []int) ([]*Location, []error) {
 	return notImplBatch[*Location](ids)
@@ -221,58 +243,58 @@ func (UnimplementedFinder) OperatorsByCOIFs(_ context.Context, ids []int) ([]*Op
 	return notImplBatch[*Operator](ids)
 }
 func (UnimplementedFinder) OperatorsByFeedIDs(context.Context, *int, *OperatorFilter, []int) ([][]*Operator, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) PathwaysByFromStopIDs(context.Context, *int, *PathwayFilter, []int) ([][]*Pathway, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) PathwaysByIDs(_ context.Context, ids []int) ([]*Pathway, []error) {
 	return notImplBatch[*Pathway](ids)
 }
 func (UnimplementedFinder) PathwaysByToStopIDs(context.Context, *int, *PathwayFilter, []int) ([][]*Pathway, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) RouteAttributesByRouteIDs(_ context.Context, ids []int) ([]*RouteAttribute, []error) {
 	return notImplBatch[*RouteAttribute](ids)
 }
 func (UnimplementedFinder) RouteGeometriesByRouteIDs(context.Context, *int, []int) ([][]*RouteGeometry, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) RouteHeadwaysByRouteIDs(context.Context, *int, []int) ([][]*RouteHeadway, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) RoutesByAgencyIDs(context.Context, *int, *RouteFilter, []int) ([][]*Route, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) RoutesByFeedVersionIDs(context.Context, *int, *RouteFilter, []int) ([][]*Route, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) RoutesByIDs(_ context.Context, ids []int) ([]*Route, []error) {
 	return notImplBatch[*Route](ids)
 }
 func (UnimplementedFinder) RouteStopPatternsByRouteIDs(context.Context, *int, []int) ([][]*RouteStopPattern, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) RouteStopsByRouteIDs(context.Context, *int, []int) ([][]*RouteStop, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) RouteStopsByStopIDs(context.Context, *int, []int) ([][]*RouteStop, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) SegmentPatternsByRouteIDs(context.Context, *int, *SegmentPatternFilter, []int) ([][]*SegmentPattern, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) SegmentPatternsBySegmentIDs(context.Context, *int, *SegmentPatternFilter, []int) ([][]*SegmentPattern, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) SegmentsByFeedVersionIDs(context.Context, *int, *SegmentFilter, []int) ([][]*Segment, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) SegmentsByIDs(_ context.Context, ids []int) ([]*Segment, []error) {
 	return notImplBatch[*Segment](ids)
 }
 func (UnimplementedFinder) SegmentsByRouteIDs(context.Context, *int, *SegmentFilter, []int) ([][]*Segment, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) ShapesByIDs(_ context.Context, ids []int) ([]*Shape, []error) {
 	return notImplBatch[*Shape](ids)
@@ -281,77 +303,77 @@ func (UnimplementedFinder) StopExternalReferencesByStopIDs(_ context.Context, id
 	return notImplBatch[*StopExternalReference](ids)
 }
 func (UnimplementedFinder) StopObservationsByStopIDs(context.Context, *int, *StopObservationFilter, []int) ([][]*StopObservation, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) StopPlacesByStopID(_ context.Context, keys []StopPlaceParam) ([]*StopPlace, []error) {
 	return notImplBatch[*StopPlace](keys)
 }
 func (UnimplementedFinder) StopsByFeedVersionIDs(context.Context, *int, *StopFilter, []int) ([][]*Stop, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) StopsByIDs(_ context.Context, ids []int) ([]*Stop, []error) {
 	return notImplBatch[*Stop](ids)
 }
 func (UnimplementedFinder) StopsByLevelIDs(context.Context, *int, *StopFilter, []int) ([][]*Stop, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) StopsByLocationGroupIDs(context.Context, *int, []int) ([][]*Stop, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) StopsByParentStopIDs(context.Context, *int, *StopFilter, []int) ([][]*Stop, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) StopsByRouteIDs(context.Context, *int, *StopFilter, []int) ([][]*Stop, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) StopTimesByStopIDs(context.Context, *int, *StopTimeFilter, []FVPair) ([][]*StopTime, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) StopTimesByTripIDs(context.Context, *int, *TripStopTimeFilter, []FVPair) ([][]*StopTime, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) TargetStopsByStopIDs(_ context.Context, ids []int) ([]*Stop, []error) {
 	return notImplBatch[*Stop](ids)
 }
 func (UnimplementedFinder) TripsByFeedVersionIDs(context.Context, *int, *TripFilter, []int) ([][]*Trip, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) TripsByIDs(_ context.Context, ids []int) ([]*Trip, []error) {
 	return notImplBatch[*Trip](ids)
 }
 func (UnimplementedFinder) TripsByRouteIDs(context.Context, *int, *TripFilter, []FVPair) ([][]*Trip, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) ValidationReportErrorExemplarsByValidationReportErrorGroupIDs(context.Context, *int, []int) ([][]*ValidationReportError, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) ValidationReportErrorGroupsByValidationReportIDs(context.Context, *int, []int) ([][]*ValidationReportErrorGroup, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 func (UnimplementedFinder) ValidationReportsByFeedVersionIDs(context.Context, *int, *ValidationReportFilter, []int) ([][]*ValidationReport, error) {
-	return nil, ErrNotImplemented
+	return nil, notImplErr()
 }
 
 // EntityMutator
 
 func (UnimplementedFinder) StopCreate(context.Context, StopSetInput) (int, error) {
-	return 0, ErrNotImplemented
+	return 0, notImplErr()
 }
 func (UnimplementedFinder) StopUpdate(context.Context, StopSetInput) (int, error) {
-	return 0, ErrNotImplemented
+	return 0, notImplErr()
 }
-func (UnimplementedFinder) StopDelete(context.Context, int) error { return ErrNotImplemented }
+func (UnimplementedFinder) StopDelete(context.Context, int) error { return notImplErr() }
 func (UnimplementedFinder) PathwayCreate(context.Context, PathwaySetInput) (int, error) {
-	return 0, ErrNotImplemented
+	return 0, notImplErr()
 }
 func (UnimplementedFinder) PathwayUpdate(context.Context, PathwaySetInput) (int, error) {
-	return 0, ErrNotImplemented
+	return 0, notImplErr()
 }
 func (UnimplementedFinder) PathwayDelete(context.Context, int) error { return ErrNotImplemented }
 func (UnimplementedFinder) LevelCreate(context.Context, LevelSetInput) (int, error) {
-	return 0, ErrNotImplemented
+	return 0, notImplErr()
 }
 func (UnimplementedFinder) LevelUpdate(context.Context, LevelSetInput) (int, error) {
-	return 0, ErrNotImplemented
+	return 0, notImplErr()
 }
 func (UnimplementedFinder) LevelDelete(context.Context, int) error { return ErrNotImplemented }

--- a/server/model/unimplemented_finder.go
+++ b/server/model/unimplemented_finder.go
@@ -369,11 +369,11 @@ func (UnimplementedFinder) PathwayCreate(context.Context, PathwaySetInput) (int,
 func (UnimplementedFinder) PathwayUpdate(context.Context, PathwaySetInput) (int, error) {
 	return 0, notImplErr()
 }
-func (UnimplementedFinder) PathwayDelete(context.Context, int) error { return ErrNotImplemented }
+func (UnimplementedFinder) PathwayDelete(context.Context, int) error { return notImplErr() }
 func (UnimplementedFinder) LevelCreate(context.Context, LevelSetInput) (int, error) {
 	return 0, notImplErr()
 }
 func (UnimplementedFinder) LevelUpdate(context.Context, LevelSetInput) (int, error) {
 	return 0, notImplErr()
 }
-func (UnimplementedFinder) LevelDelete(context.Context, int) error { return ErrNotImplemented }
+func (UnimplementedFinder) LevelDelete(context.Context, int) error { return notImplErr() }

--- a/server/model/unimplemented_finder.go
+++ b/server/model/unimplemented_finder.go
@@ -49,8 +49,12 @@ func notImplErr() error {
 func finderUnimpl(up int) error {
 	name := "unknown"
 	if pc, _, _, ok := runtime.Caller(up); ok {
-		full := runtime.FuncForPC(pc).Name()
-		name = full[strings.LastIndex(full, ".")+1:]
+		// FuncForPC may return nil; a panic here would turn a graceful
+		// "not implemented" stub into a server crash.
+		if fn := runtime.FuncForPC(pc); fn != nil {
+			full := fn.Name()
+			name = full[strings.LastIndex(full, ".")+1:]
+		}
 	}
 	return fmt.Errorf("%w: %s", ErrNotImplemented, name)
 }

--- a/server/model/unimplemented_finder_test.go
+++ b/server/model/unimplemented_finder_test.go
@@ -1,0 +1,49 @@
+package model
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestUnimplementedFinderNaming locks the two invariants of the self-naming
+// stubs: the returned error still matches ErrNotImplemented (so errors.Is keeps
+// working), and it names the calling Finder method (so an unimplemented loader
+// identifies itself). The name comes from runtime.Caller frame math in
+// finderUnimpl, which is sensitive to refactors/inlining — this guards it.
+func TestUnimplementedFinderNaming(t *testing.T) {
+	var f UnimplementedFinder
+	ctx := context.Background()
+
+	// Non-batched stub (notImplErr path).
+	_, err := f.FindAgencies(ctx, nil, nil, nil, nil)
+	assertNamed(t, err, "FindAgencies")
+
+	// Batched stub (notImplBatch path): every per-key error is named.
+	_, errs := f.AgenciesByIDs(ctx, []int{1, 2})
+	if len(errs) != 2 {
+		t.Fatalf("AgenciesByIDs returned %d errors, want 2", len(errs))
+	}
+	for _, e := range errs {
+		assertNamed(t, e, "AgenciesByIDs")
+	}
+
+	// Mutator stub returning a bare error (the case PathwayDelete/LevelDelete
+	// previously got wrong).
+	assertNamed(t, f.PathwayDelete(ctx, 1), "PathwayDelete")
+	assertNamed(t, f.LevelDelete(ctx, 1), "LevelDelete")
+}
+
+func assertNamed(t *testing.T, err error, method string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("%s: expected an error", method)
+	}
+	if !errors.Is(err, ErrNotImplemented) {
+		t.Errorf("%s: errors.Is(err, ErrNotImplemented) = false (err=%v)", method, err)
+	}
+	if !strings.Contains(err.Error(), method) {
+		t.Errorf("%s: error %q does not name the method", method, err.Error())
+	}
+}

--- a/tlcsv/adapter.go
+++ b/tlcsv/adapter.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/interline-io/log"
 	"github.com/interline-io/transitland-lib/adapters"
-	"github.com/interline-io/transitland-lib/causes"
 	"github.com/interline-io/transitland-lib/internal/tags"
 	"github.com/interline-io/transitland-lib/request"
 	"github.com/twpayne/go-geom/encoding/geojson"
@@ -256,24 +255,7 @@ func (adapter *ZipAdapter) OpenFile(filename string, cb func(io.Reader)) error {
 		return err
 	}
 	defer r.Close()
-	var inFile *zip.File
-	for _, f := range r.File {
-		if f.Name != filepath.Join(adapter.internalPrefix, filename) {
-			continue
-		}
-		inFile = f
-	}
-	if inFile == nil {
-		return causes.NewFileNotPresentError(filename)
-	}
-	//
-	in, err := inFile.Open()
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-	cb(in)
-	return nil
+	return openFileInZip(r.File, adapter.internalPrefix, filename, cb)
 }
 
 // ReadRows opens the specified file and runs the callback on each Row. An error is returned if the file cannot be read.
@@ -308,32 +290,7 @@ func (adapter *ZipAdapter) DirSHA1() (string, error) {
 		return "", err
 	}
 	defer r.Close()
-	// Sort the files
-	sort.Slice(r.File, func(i, j int) bool { return r.File[i].Name < r.File[j].Name })
-	// Generate SHA1
-	h := sha1.New()
-	for _, zf := range r.File {
-		fi := zf.FileInfo()
-		fn := zf.Name
-		if adapter.internalPrefix != "" {
-			fn = strings.Replace(zf.Name, adapter.internalPrefix+"/", "", 1) // remove internalPrefix
-		}
-		// Ignore directories, subdirs, dot files
-		if fi.IsDir() || strings.HasPrefix(fn, ".") || strings.Contains(fn, "/") {
-			continue
-		}
-		// Only generate stats for files with lowercase names that end with .txt
-		if fi.Name() != strings.ToLower(fi.Name()) || !strings.HasSuffix(fi.Name(), ".txt") {
-			continue
-		}
-		f, err := zf.Open()
-		if err != nil {
-			return "", err
-		}
-		defer f.Close()
-		io.Copy(h, f)
-	}
-	return fmt.Sprintf("%x", h.Sum(nil)), nil
+	return dirSHA1InZip(r.File, adapter.internalPrefix)
 }
 
 // FileInfos returns a list of os.FileInfo for all .txt files.
@@ -364,28 +321,8 @@ func (adapter *ZipAdapter) findInternalPrefix() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	prefixes := []string{}
 	defer r.Close()
-	for _, zf := range r.File {
-		fi := zf.FileInfo()
-		fn := zf.Name
-		if fi.IsDir() || strings.HasPrefix(fn, ".") {
-			continue
-		}
-		if filepath.Base(fn) == "stops.txt" {
-			prefixes = append(prefixes, filepath.Dir(fn))
-		}
-	}
-	if len(prefixes) > 1 {
-		return "", errors.New("more than one valid prefix found")
-	} else if len(prefixes) == 1 {
-		pfx := prefixes[0]
-		if pfx == "." {
-			pfx = ""
-		}
-		return pfx, nil
-	}
-	return "", nil
+	return findInternalPrefixInZip(r.File)
 }
 
 /////////////////////

--- a/tlcsv/zipreaderadapter.go
+++ b/tlcsv/zipreaderadapter.go
@@ -1,0 +1,171 @@
+package tlcsv
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha1"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/interline-io/transitland-lib/causes"
+)
+
+// ZipReaderAdapter reads a GTFS zip from memory (any io.ReaderAt) instead of a
+// path on disk, decompressing each file on demand. Use it when the archive bytes
+// are already in memory (e.g. an upload) and there is no usable filesystem —
+// notably under js/wasm, where the path-based ZipAdapter cannot create temp files.
+type ZipReaderAdapter struct {
+	r              io.ReaderAt
+	size           int64
+	zr             *zip.Reader
+	internalPrefix string
+}
+
+var _ Adapter = (*ZipReaderAdapter)(nil)
+
+// NewZipReaderAdapter builds an adapter over a zip read from r (size bytes). The
+// source must stay valid for the adapter's lifetime (it is read lazily).
+func NewZipReaderAdapter(r io.ReaderAt, size int64) (*ZipReaderAdapter, error) {
+	zr, err := zip.NewReader(r, size)
+	if err != nil {
+		return nil, err
+	}
+	return &ZipReaderAdapter{r: r, size: size, zr: zr}, nil
+}
+
+// NewZipReaderAdapterFromBytes builds an adapter over raw zip bytes. The slice is
+// retained (read lazily), so the caller must not mutate it.
+func NewZipReaderAdapterFromBytes(b []byte) (*ZipReaderAdapter, error) {
+	return NewZipReaderAdapter(bytes.NewReader(b), int64(len(b)))
+}
+
+func (adapter *ZipReaderAdapter) String() string { return "memory.zip" }
+func (adapter *ZipReaderAdapter) Path() string   { return "memory.zip" }
+func (adapter *ZipReaderAdapter) Close() error   { return nil }
+
+// Exists reports whether the archive parsed and holds any entries.
+func (adapter *ZipReaderAdapter) Exists() bool {
+	return adapter.zr != nil && len(adapter.zr.File) > 0
+}
+
+// Open auto-discovers the internal feed-root prefix (the directory containing
+// stops.txt), mirroring ZipAdapter.
+func (adapter *ZipReaderAdapter) Open() error {
+	if !adapter.Exists() {
+		return errors.New("file does not exist or invalid data")
+	}
+	if adapter.internalPrefix == "" {
+		pfx, err := findInternalPrefixInZip(adapter.zr.File)
+		if err != nil {
+			return err
+		}
+		adapter.internalPrefix = pfx
+	}
+	return nil
+}
+
+// OpenFile streams the named entry's decompressed bytes to cb, decompressing on
+// demand. Each call opens a fresh reader, so a file may be read multiple times.
+func (adapter *ZipReaderAdapter) OpenFile(filename string, cb func(io.Reader)) error {
+	return openFileInZip(adapter.zr.File, adapter.internalPrefix, filename, cb)
+}
+
+func (adapter *ZipReaderAdapter) ReadRows(filename string, cb func(Row)) error {
+	return adapter.OpenFile(filename, func(in io.Reader) { ReadRows(in, cb) })
+}
+
+// SHA1 hashes the whole archive, streamed from the source.
+func (adapter *ZipReaderAdapter) SHA1() (string, error) {
+	h := sha1.New()
+	if _, err := io.Copy(h, io.NewSectionReader(adapter.r, 0, adapter.size)); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+func (adapter *ZipReaderAdapter) DirSHA1() (string, error) {
+	return dirSHA1InZip(adapter.zr.File, adapter.internalPrefix)
+}
+
+// --- shared zip helpers (used by both ZipAdapter and ZipReaderAdapter) ---
+
+// openFileInZip finds filename (under internalPrefix) among the zip entries and
+// streams its decompressed bytes to cb; a missing file is an error and cb is not
+// called.
+func openFileInZip(files []*zip.File, internalPrefix, filename string, cb func(io.Reader)) error {
+	want := filepath.Join(internalPrefix, filename)
+	for _, f := range files {
+		if f.Name != want {
+			continue
+		}
+		in, err := f.Open()
+		if err != nil {
+			return err
+		}
+		defer in.Close()
+		cb(in)
+		return nil
+	}
+	return causes.NewFileNotPresentError(filename)
+}
+
+// findInternalPrefixInZip returns the directory containing stops.txt (the feed
+// root); "" for a flat archive, an error if more than one candidate is found.
+func findInternalPrefixInZip(files []*zip.File) (string, error) {
+	prefixes := []string{}
+	for _, zf := range files {
+		fi := zf.FileInfo()
+		fn := zf.Name
+		if fi.IsDir() || strings.HasPrefix(fn, ".") {
+			continue
+		}
+		if filepath.Base(fn) == "stops.txt" {
+			prefixes = append(prefixes, filepath.Dir(fn))
+		}
+	}
+	if len(prefixes) > 1 {
+		return "", errors.New("more than one valid prefix found")
+	} else if len(prefixes) == 1 {
+		pfx := prefixes[0]
+		if pfx == "." {
+			pfx = ""
+		}
+		return pfx, nil
+	}
+	return "", nil
+}
+
+// dirSHA1InZip hashes the sorted, concatenated top-level lowercase .txt entries
+// (under internalPrefix), matching ZipAdapter/DirAdapter.
+func dirSHA1InZip(files []*zip.File, internalPrefix string) (string, error) {
+	sorted := append([]*zip.File(nil), files...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+	h := sha1.New()
+	for _, zf := range sorted {
+		fi := zf.FileInfo()
+		fn := zf.Name
+		if internalPrefix != "" {
+			fn = strings.Replace(zf.Name, internalPrefix+"/", "", 1)
+		}
+		if fi.IsDir() || strings.HasPrefix(fn, ".") || strings.Contains(fn, "/") {
+			continue
+		}
+		if fi.Name() != strings.ToLower(fi.Name()) || !strings.HasSuffix(fi.Name(), ".txt") {
+			continue
+		}
+		f, err := zf.Open()
+		if err != nil {
+			return "", err
+		}
+		_, err = io.Copy(h, f)
+		f.Close()
+		if err != nil {
+			return "", err
+		}
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}

--- a/tlcsv/zipreaderadapter_test.go
+++ b/tlcsv/zipreaderadapter_test.go
@@ -27,11 +27,19 @@ func TestZipReaderAdapter(t *testing.T) {
 	}
 	// Parity with the path-based ZipAdapter: the known whole-archive and per-dir
 	// checksums for example.zip.
-	if got, _ := adapter.SHA1(); got != "ce0a38dd6d4cfdac6aebe003181b6b915390a3b8" {
-		t.Errorf("SHA1 = %s, want ce0a38dd...", got)
+	sha1, err := adapter.SHA1()
+	if err != nil {
+		t.Fatalf("SHA1: %v", err)
 	}
-	if got, _ := adapter.DirSHA1(); got != "7a5c69b5466746213eb3cb6d907a7004073eca4d" {
-		t.Errorf("DirSHA1 = %s, want 7a5c69b5...", got)
+	if sha1 != "ce0a38dd6d4cfdac6aebe003181b6b915390a3b8" {
+		t.Errorf("SHA1 = %s, want ce0a38dd...", sha1)
+	}
+	dirSHA1, err := adapter.DirSHA1()
+	if err != nil {
+		t.Fatalf("DirSHA1: %v", err)
+	}
+	if dirSHA1 != "7a5c69b5466746213eb3cb6d907a7004073eca4d" {
+		t.Errorf("DirSHA1 = %s, want 7a5c69b5...", dirSHA1)
 	}
 	reader, err := NewReaderFromAdapter(adapter)
 	if err != nil {

--- a/tlcsv/zipreaderadapter_test.go
+++ b/tlcsv/zipreaderadapter_test.go
@@ -1,0 +1,81 @@
+package tlcsv
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/interline-io/transitland-lib/internal/testpath"
+)
+
+func TestZipReaderAdapter(t *testing.T) {
+	b, err := os.ReadFile(testpath.RelPath("testdata/gtfs-examples/example.zip"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter, err := NewZipReaderAdapterFromBytes(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := adapter.Open(); err != nil {
+		t.Fatal(err)
+	}
+	if !adapter.Exists() {
+		t.Fatal("Exists() = false")
+	}
+	// Parity with the path-based ZipAdapter: the known whole-archive and per-dir
+	// checksums for example.zip.
+	if got, _ := adapter.SHA1(); got != "ce0a38dd6d4cfdac6aebe003181b6b915390a3b8" {
+		t.Errorf("SHA1 = %s, want ce0a38dd...", got)
+	}
+	if got, _ := adapter.DirSHA1(); got != "7a5c69b5466746213eb3cb6d907a7004073eca4d" {
+		t.Errorf("DirSHA1 = %s, want 7a5c69b5...", got)
+	}
+	reader, err := NewReaderFromAdapter(adapter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if errs := reader.ValidateStructure(); len(errs) > 0 {
+		t.Errorf("ValidateStructure: %v", errs)
+	}
+	rows := 0
+	if err := adapter.ReadRows("stops.txt", func(Row) { rows++ }); err != nil {
+		t.Fatal(err)
+	}
+	if rows == 0 {
+		t.Error("stops.txt streamed 0 rows")
+	}
+}
+
+func TestZipReaderAdapter_NestedPrefix(t *testing.T) {
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for _, name := range []string{"feed/agency.txt", "feed/stops.txt", "feed/routes.txt"} {
+		w, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte("id\nx\n")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	adapter, err := NewZipReaderAdapterFromBytes(buf.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := adapter.Open(); err != nil {
+		t.Fatal(err)
+	}
+	// The feed root "feed/" is auto-discovered, so flat names resolve under it.
+	if err := adapter.OpenFile("stops.txt", func(io.Reader) {}); err != nil {
+		t.Errorf("OpenFile(stops.txt) under nested prefix: %v", err)
+	}
+	if err := adapter.OpenFile("missing.txt", func(io.Reader) {}); err == nil {
+		t.Error("OpenFile(missing.txt) should error")
+	}
+}


### PR DESCRIPTION
## Summary

Lets the on-demand GTFS validator run in an environment with no usable filesystem — specifically js/wasm, for in-browser Feed QA — by reading uploaded archives entirely in memory instead of staging them to a temp file. Adds a memory-backed `tlcsv` zip adapter, a server option to keep multipart uploads out of gqlgen's disk spill, and (incidentally) makes the `UnimplementedFinder` stubs name themselves so a partial Finder implementation reports *which* loader is missing rather than a bare "not implemented". Behavior on a normal filesystem is unchanged.

### In-memory zip reading (`tlcsv`)

- New `ZipReaderAdapter` reads a GTFS zip from any `io.ReaderAt` / `[]byte` (`NewZipReaderAdapter`, `NewZipReaderAdapterFromBytes`), decompressing each entry on demand with no temp file. It implements the full `Adapter` interface (`Open`/`OpenFile`/`ReadRows`/`SHA1`/`DirSHA1`/`Exists`/…) and auto-discovers the internal feed-root prefix exactly like the path-based `ZipAdapter`.
- The zip-entry logic shared by both adapters is factored into unexported helpers (`openFileInZip`, `findInternalPrefixInZip`, `dirSHA1InZip`), and `ZipAdapter` now calls them. This refactor is behavior-preserving with three incidental fixes folded in: `DirSHA1` no longer sorts the `zip.Reader`'s file slice in place (it sorts a copy), closes each entry as it goes instead of deferring every close to function return, and propagates the `io.Copy` error it previously dropped.

### Validate uploads without a temp file (`server/finders/actions`)

- `ValidateUpload` now buffers the upload with `io.ReadAll` and validates it through `ZipReaderAdapter` instead of `os.CreateTemp` + `tlcsv.NewReader`, so it works where there is no writable filesystem. In a server this is bounded upstream by the multipart transport's `MaxUploadSize`; the in-memory tradeoff (and a possible future spill-to-disk-when-available optimization) is noted in a comment.
- Each previously-silent failure point (open zip, build reader, open feed, construct validator, run validation) now logs via `log.For(ctx)` with context, so a failed validation is diagnosable from server logs rather than just surfacing a generic failure reason.

### Configurable multipart memory (`server/gql`)

- New `WithMaxMultipartMemory(n)` server option sets gqlgen's `MultipartForm.MaxMemory` (the per-part threshold above which an upload spills to a temp file). Defaults to the existing 32 MiB constant, so behavior is unchanged unless set; a wasm host raises it above the upload size so nothing ever touches disk.

### Self-naming unimplemented Finder stubs (`server/model`)

- `UnimplementedFinder`'s stubs now wrap `ErrNotImplemented` with the calling method's name (e.g. `not implemented: RouteGeometriesByRouteIDs`), resolved via `runtime.Caller`, so an in-memory or partial Finder that hits an unimplemented loader identifies it instead of returning an anonymous error. `errors.Is(err, ErrNotImplemented)` still matches. This makes diagnosing a partial Finder (such as the in-browser memfinder) self-service.

## Breaking changes

None. All changes are additive or internal. The `ZipAdapter` refactor preserves its observable behavior, `WithMaxMultipartMemory` defaults to the prior 32 MiB, and the unimplemented errors continue to satisfy `errors.Is(…, ErrNotImplemented)`.

## Test plan

- `tlcsv`: `TestZipReaderAdapter` checks the in-memory adapter against `example.zip` for whole-archive `SHA1` and `DirSHA1` parity with the path-based adapter, validates structure, and streams `stops.txt`; `TestZipReaderAdapter_NestedPrefix` covers feed-root auto-discovery and a missing-file error.
- `server/finders/actions`: `TestValidateUploadFile` runs the file-upload path end to end (in-memory zip → validator) on `caltrain.zip` and asserts a successful report with a sha1.
- `server/model`: `TestUnimplementedFinderNaming` asserts the non-batched, batched, and mutator stubs each both match `ErrNotImplemented` and name their method.
