### PR TITLE
Add FileInfos to ZipReaderAdapter

### DIFF
--- a/tlcsv/zipreaderadapter.go
+++ b/tlcsv/zipreaderadapter.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -89,6 +90,29 @@ func (adapter *ZipReaderAdapter) SHA1() (string, error) {
 
 func (adapter *ZipReaderAdapter) DirSHA1() (string, error) {
 	return dirSHA1InZip(adapter.zr.File, adapter.internalPrefix)
+}
+
+// FileInfos returns an os.FileInfo for each top-level .txt file (under the
+// internal feed-root prefix), so file-info stats can be computed straight from an
+// in-memory archive — mirroring ZipAdapter.FileInfos, but over the already-parsed
+// in-memory zip rather than reopening a file on disk. Call after Open so the
+// internal prefix is resolved.
+func (adapter *ZipReaderAdapter) FileInfos() ([]os.FileInfo, error) {
+	ret := []os.FileInfo{}
+	files := append([]*zip.File(nil), adapter.zr.File...)
+	sort.Slice(files, func(i, j int) bool { return files[i].Name < files[j].Name })
+	for _, zf := range files {
+		fi := zf.FileInfo()
+		fn := zf.Name
+		if adapter.internalPrefix != "" {
+			fn = strings.Replace(zf.Name, adapter.internalPrefix+"/", "", 1) // remove internalPrefix
+		}
+		if fi.IsDir() || strings.HasPrefix(fn, ".") || strings.Contains(fn, "/") {
+			continue
+		}
+		ret = append(ret, fi)
+	}
+	return ret, nil
 }
 
 // --- shared zip helpers (used by both ZipAdapter and ZipReaderAdapter) ---

--- a/tlcsv/zipreaderadapter_test.go
+++ b/tlcsv/zipreaderadapter_test.go
@@ -86,4 +86,27 @@ func TestZipReaderAdapter_NestedPrefix(t *testing.T) {
 	if err := adapter.OpenFile("missing.txt", func(io.Reader) {}); err == nil {
 		t.Error("OpenFile(missing.txt) should error")
 	}
+
+	// FileInfos reports the feed files by base name (prefix stripped), so file-info
+	// stats and OpenFile(fi.Name()) agree even when the feed is in a subdirectory.
+	fis, err := adapter.FileInfos()
+	if err != nil {
+		t.Fatalf("FileInfos: %v", err)
+	}
+	var names []string
+	for _, fi := range fis {
+		names = append(names, fi.Name())
+		if err := adapter.OpenFile(fi.Name(), func(io.Reader) {}); err != nil {
+			t.Errorf("OpenFile(%q) from FileInfos: %v", fi.Name(), err)
+		}
+	}
+	want := []string{"agency.txt", "routes.txt", "stops.txt"}
+	if len(names) != len(want) {
+		t.Fatalf("FileInfos names = %v, want %v", names, want)
+	}
+	for i, n := range want {
+		if names[i] != n {
+			t.Errorf("FileInfos[%d] = %q, want %q (got %v)", i, names[i], n, names)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Adds `FileInfos()` to `ZipReaderAdapter`, the in-memory (`io.ReaderAt`-backed) zip adapter added in #673, bringing it to parity with the disk-based `ZipAdapter`. `stats.NewFeedVersionFileInfosFromReader` only computes per-file stats when the reader's adapter satisfies the optional `canFileInfo` interface (`FileInfos() ([]os.FileInfo, error)`) — and `ZipReaderAdapter` didn't implement it, so file infos were silently skipped for any feed read from an in-memory archive. The consumers that benefit are the upload-validation path (`actions.ValidateUpload`, which reads the uploaded zip via `NewZipReaderAdapterFromBytes`) and in-memory/wasm finders, which previously lost the per-file stats (name, size, SHA1, CSV/row details) the on-disk path already produces.

### Behavior

- Returns one `os.FileInfo` per top-level feed file, by base name with the internal feed-root prefix stripped, sorted by name — matching `ZipAdapter.FileInfos`, so `OpenFile(fi.Name())` resolves correctly even when the feed is wrapped in a subdirectory.
- Excludes directories, dotfiles, and nested entries.
- Reads from the already-parsed in-memory `zip.Reader` (no reopening from disk). Call after `Open()` so the internal prefix is resolved.

## Test plan

- Extended `TestZipReaderAdapter_NestedPrefix` to assert `FileInfos()` returns `[agency.txt, routes.txt, stops.txt]` by base name for a feed nested under a subdirectory, and that `OpenFile(fi.Name())` succeeds for each — i.e. the prefix-stripped names round-trip back through `OpenFile`.
