### PR TITLE
Configurable RT archiving

### DIFF
--- a/dmfr/feed_fetch.go
+++ b/dmfr/feed_fetch.go
@@ -20,6 +20,7 @@ type FeedFetch struct {
 	FeedVersionID        tt.Int // optional field, don't use FeedVersionEntity
 	ValidationDurationMs tt.Int
 	UploadDurationMs     tt.Int
+	StorageKey           tt.String // object key where the fetched message was archived, if any
 	tt.Timestamps
 	tt.DatabaseEntity
 }

--- a/dmfr/feed_fetch.go
+++ b/dmfr/feed_fetch.go
@@ -20,7 +20,7 @@ type FeedFetch struct {
 	FeedVersionID        tt.Int // optional field, don't use FeedVersionEntity
 	ValidationDurationMs tt.Int
 	UploadDurationMs     tt.Int
-	StorageKey           tt.String // object key where the fetched message was archived, if any
+	StorageKey           tt.String // archive object key, if archived
 	tt.Timestamps
 	tt.DatabaseEntity
 }

--- a/dmfr/feed_state.go
+++ b/dmfr/feed_state.go
@@ -14,6 +14,7 @@ type FeedState struct {
 	FetchWait           tt.Int
 	FeedRealtimeEnabled bool
 	Public              bool
+	RTRetentionPeriod   int // days to retain archived RT messages for this feed (cf. feed_version_import_retention_period); 0 disables archiving
 	tt.DatabaseEntity
 	tt.Timestamps
 }

--- a/dmfr/feed_state.go
+++ b/dmfr/feed_state.go
@@ -14,7 +14,7 @@ type FeedState struct {
 	FetchWait           tt.Int
 	FeedRealtimeEnabled bool
 	Public              bool
-	RTRetentionPeriod   int // days to retain archived RT messages for this feed (cf. feed_version_import_retention_period); 0 disables archiving
+	RTRetentionPeriod   int // days to retain archived RT messages; 0 disables
 	tt.DatabaseEntity
 	tt.Timestamps
 }

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -117,12 +117,8 @@ func uploadFile(ctx context.Context, storage, fn, key string) (int, error) {
 	return int(time.Since(t).Milliseconds()), nil
 }
 
-// archiveKey builds the date-partitioned object key for an archived fetch message:
-//
-//	feed=<onestop_id>/url_type=<url_type>/date=<YYYY-MM-DD>/<YYYY-MM-DD-HH-MM-SS>.<ext>
-//
-// The Hive-style partitions let query engines prune by feed, url_type and date; the
-// timestamp (from FetchedAt, UTC) makes each fetch a distinct, sortable object.
+// archiveKey builds the archive object key; the feed/url_type/date partitions let
+// query engines prune by those columns.
 func archiveKey(onestopID, urlType string, fetchedAt time.Time, ext string) string {
 	t := fetchedAt.UTC()
 	return fmt.Sprintf("feed=%s/url_type=%s/date=%s/%s.%s",
@@ -130,7 +126,6 @@ func archiveKey(onestopID, urlType string, fetchedAt time.Time, ext string) stri
 }
 
 // recordFeedFetch writes the feed_fetch audit row for a completed attempt.
-// storageKey is the archive object key when the message was archived, else empty.
 func recordFeedFetch(ctx context.Context, fm feedmanager.FeedManager, feed *dmfr.Feed, opts Options, result Result, dur fetchDurations, storageKey string) error {
 	tlfetch := dmfr.FeedFetch{}
 	tlfetch.FeedID = feed.ID

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -117,12 +117,13 @@ func uploadFile(ctx context.Context, storage, fn, key string) (int, error) {
 	return int(time.Since(t).Milliseconds()), nil
 }
 
-// archiveKey builds the archive object key; the feed/url_type/date partitions let
-// query engines prune by those columns.
-func archiveKey(onestopID, urlType string, fetchedAt time.Time, ext string) string {
+// archiveKey builds the archive object key. The feed/url_type/date partitions let
+// query engines prune by those columns; the sha1 suffix keeps distinct messages at
+// distinct keys even when fetched within the same second.
+func archiveKey(onestopID, urlType, sha1 string, fetchedAt time.Time, ext string) string {
 	t := fetchedAt.UTC()
-	return fmt.Sprintf("feed=%s/url_type=%s/date=%s/%s.%s",
-		onestopID, urlType, t.Format("2006-01-02"), t.Format("2006-01-02-15-04-05"), ext)
+	return fmt.Sprintf("feed=%s/url_type=%s/date=%s/%s-%s.%s",
+		onestopID, urlType, t.Format("2006-01-02"), t.Format("2006-01-02-15-04-05"), sha1, ext)
 }
 
 // recordFeedFetch writes the feed_fetch audit row for a completed attempt.

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -3,6 +3,7 @@ package fetch
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/interline-io/transitland-lib/dmfr"
@@ -116,12 +117,28 @@ func uploadFile(ctx context.Context, storage, fn, key string) (int, error) {
 	return int(time.Since(t).Milliseconds()), nil
 }
 
+// archiveKey builds the date-partitioned object key for an archived fetch message:
+//
+//	feed=<onestop_id>/url_type=<url_type>/date=<YYYY-MM-DD>/<YYYY-MM-DD-HH-MM-SS>.<ext>
+//
+// The Hive-style partitions let query engines prune by feed, url_type and date; the
+// timestamp (from FetchedAt, UTC) makes each fetch a distinct, sortable object.
+func archiveKey(onestopID, urlType string, fetchedAt time.Time, ext string) string {
+	t := fetchedAt.UTC()
+	return fmt.Sprintf("feed=%s/url_type=%s/date=%s/%s.%s",
+		onestopID, urlType, t.Format("2006-01-02"), t.Format("2006-01-02-15-04-05"), ext)
+}
+
 // recordFeedFetch writes the feed_fetch audit row for a completed attempt.
-func recordFeedFetch(ctx context.Context, fm feedmanager.FeedManager, feed *dmfr.Feed, opts Options, result Result, dur fetchDurations) error {
+// storageKey is the archive object key when the message was archived, else empty.
+func recordFeedFetch(ctx context.Context, fm feedmanager.FeedManager, feed *dmfr.Feed, opts Options, result Result, dur fetchDurations, storageKey string) error {
 	tlfetch := dmfr.FeedFetch{}
 	tlfetch.FeedID = feed.ID
 	tlfetch.URLType = opts.URLType
 	tlfetch.FetchedAt.Set(opts.FetchedAt)
+	if storageKey != "" {
+		tlfetch.StorageKey.Set(storageKey)
+	}
 	if result.ResponseCode > 0 {
 		tlfetch.ResponseCode.SetInt(result.ResponseCode)
 	}

--- a/fetch/rt_fetch.go
+++ b/fetch/rt_fetch.go
@@ -47,9 +47,7 @@ func RTFetch(ctx context.Context, fm feedmanager.FeedManager, opts RTFetchOption
 		if err != nil {
 			out.FetchError = err
 		}
-		// Archive the protobuf to a date-partitioned key when storage is configured
-		// (the action only sets Storage when the feed opts into archiving). Upload
-		// even when parsing failed, matching the prior behavior.
+		// Archive to a partitioned key when storage is set, even on parse failure.
 		if opts.Storage != "" {
 			storageKey = archiveKey(feed.FeedID, opts.URLType, opts.FetchedAt, "pb")
 		}

--- a/fetch/rt_fetch.go
+++ b/fetch/rt_fetch.go
@@ -25,6 +25,9 @@ type RTFetchOptions struct {
 // failure; a 404 or parse error is on Result.FetchError.
 func RTFetch(ctx context.Context, fm feedmanager.FeedManager, opts RTFetchOptions) (RTFetchResult, error) {
 	out := RTFetchResult{}
+	if opts.FetchedAt.IsZero() {
+		opts.FetchedAt = time.Now().UTC()
+	}
 	feed, tmpfile, resp, fatal := download(ctx, fm, opts.Options)
 	if tmpfile != "" {
 		defer os.Remove(tmpfile)
@@ -49,7 +52,7 @@ func RTFetch(ctx context.Context, fm feedmanager.FeedManager, opts RTFetchOption
 		}
 		// Archive to a partitioned key when storage is set, even on parse failure.
 		if opts.Storage != "" {
-			storageKey = archiveKey(feed.FeedID, opts.URLType, opts.FetchedAt, "pb")
+			storageKey = archiveKey(feed.FeedID, opts.URLType, resp.ResponseSHA1, opts.FetchedAt, "pb")
 		}
 		uploadMs, uerr := uploadFile(ctx, opts.Storage, tmpfile, storageKey)
 		if uerr != nil {

--- a/fetch/rt_fetch.go
+++ b/fetch/rt_fetch.go
@@ -2,7 +2,6 @@ package fetch
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"time"
 
@@ -37,6 +36,7 @@ func RTFetch(ctx context.Context, fm feedmanager.FeedManager, opts RTFetchOption
 	}
 
 	var dur fetchDurations
+	var storageKey string
 	if out.FetchError == nil {
 		// The protobuf parse is the RT analogue of validation; record its duration
 		// on the feed_fetch row, as the pre-rewrite fetch did.
@@ -47,16 +47,20 @@ func RTFetch(ctx context.Context, fm feedmanager.FeedManager, opts RTFetchOption
 		if err != nil {
 			out.FetchError = err
 		}
-		// Upload the protobuf (content-addressed key); matches the prior behavior
-		// of uploading even when parsing failed.
-		uploadMs, uerr := uploadFile(ctx, opts.Storage, tmpfile, fmt.Sprintf("%s.pb", resp.ResponseSHA1))
+		// Archive the protobuf to a date-partitioned key when storage is configured
+		// (the action only sets Storage when the feed opts into archiving). Upload
+		// even when parsing failed, matching the prior behavior.
+		if opts.Storage != "" {
+			storageKey = archiveKey(feed.FeedID, opts.URLType, opts.FetchedAt, "pb")
+		}
+		uploadMs, uerr := uploadFile(ctx, opts.Storage, tmpfile, storageKey)
 		if uerr != nil {
 			log.For(ctx).Error().Err(uerr).Msg("fatal error during rt fetch")
 			return out, uerr
 		}
 		dur.uploadMs = uploadMs
 	}
-	if err := recordFeedFetch(ctx, fm, feed, opts.Options, out.Result, dur); err != nil {
+	if err := recordFeedFetch(ctx, fm, feed, opts.Options, out.Result, dur, storageKey); err != nil {
 		return out, err
 	}
 	return out, nil

--- a/fetch/rt_fetch_test.go
+++ b/fetch/rt_fetch_test.go
@@ -78,9 +78,7 @@ func TestRTFetch(t *testing.T) {
 				testdb.ShouldGet(t, atx, &tlff, `SELECT * FROM feed_fetches WHERE feed_id = ? ORDER BY id DESC LIMIT 1`, feed.ID)
 				assert.Equal(t, tc.responseCode, tlff.ResponseCode.Int(), "did not get expected feed_fetch response code")
 				assert.Equal(t, !tc.responseError, tlff.Success, "did not get expected feed_fetch success")
-				// Archive: a successful download (200) uploads to the partitioned key and
-				// records storage_key — even if the protobuf failed to parse. A failed
-				// download (404) archives nothing.
+				// 200 archives to the partitioned key (even on parse failure); 404 doesn't.
 				if tc.responseCode == 200 {
 					assert.True(t, strings.HasPrefix(tlff.StorageKey.Val, "feed="), "storage_key should be a partitioned key, got %q", tlff.StorageKey.Val)
 					if _, err := os.Stat(filepath.Join(tmpdir, tlff.StorageKey.Val)); err != nil {

--- a/fetch/rt_fetch_test.go
+++ b/fetch/rt_fetch_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/interline-io/transitland-lib/dmfr"
@@ -76,6 +78,17 @@ func TestRTFetch(t *testing.T) {
 				testdb.ShouldGet(t, atx, &tlff, `SELECT * FROM feed_fetches WHERE feed_id = ? ORDER BY id DESC LIMIT 1`, feed.ID)
 				assert.Equal(t, tc.responseCode, tlff.ResponseCode.Int(), "did not get expected feed_fetch response code")
 				assert.Equal(t, !tc.responseError, tlff.Success, "did not get expected feed_fetch success")
+				// Archive: a successful download (200) uploads to the partitioned key and
+				// records storage_key — even if the protobuf failed to parse. A failed
+				// download (404) archives nothing.
+				if tc.responseCode == 200 {
+					assert.True(t, strings.HasPrefix(tlff.StorageKey.Val, "feed="), "storage_key should be a partitioned key, got %q", tlff.StorageKey.Val)
+					if _, err := os.Stat(filepath.Join(tmpdir, tlff.StorageKey.Val)); err != nil {
+						t.Errorf("archived object not found at storage_key %q: %v", tlff.StorageKey.Val, err)
+					}
+				} else {
+					assert.Empty(t, tlff.StorageKey.Val, "expected no storage_key when nothing was archived")
+				}
 				return nil
 			})
 		})

--- a/fetch/rt_fetch_test.go
+++ b/fetch/rt_fetch_test.go
@@ -81,6 +81,7 @@ func TestRTFetch(t *testing.T) {
 				// 200 archives to the partitioned key (even on parse failure); 404 doesn't.
 				if tc.responseCode == 200 {
 					assert.True(t, strings.HasPrefix(tlff.StorageKey.Val, "feed="), "storage_key should be a partitioned key, got %q", tlff.StorageKey.Val)
+					assert.Contains(t, tlff.StorageKey.Val, tlff.ResponseSHA1.Val, "storage_key should embed the response sha1")
 					if _, err := os.Stat(filepath.Join(tmpdir, tlff.StorageKey.Val)); err != nil {
 						t.Errorf("archived object not found at storage_key %q: %v", tlff.StorageKey.Val, err)
 					}

--- a/fetch/static_fetch.go
+++ b/fetch/static_fetch.go
@@ -57,8 +57,7 @@ func StaticFetch(ctx context.Context, fm feedmanager.FeedManager, opts StaticFet
 			return out, err
 		}
 	}
-	// Static uploads stay content-addressed (<sha1>.zip, derivable from response_sha1),
-	// so no separate storage_key is recorded.
+	// Static uploads are content-addressed (<sha1>.zip), so no storage_key.
 	if err := recordFeedFetch(ctx, fm, feed, opts.Options, out.Result, dur, ""); err != nil {
 		return out, err
 	}

--- a/fetch/static_fetch.go
+++ b/fetch/static_fetch.go
@@ -57,7 +57,9 @@ func StaticFetch(ctx context.Context, fm feedmanager.FeedManager, opts StaticFet
 			return out, err
 		}
 	}
-	if err := recordFeedFetch(ctx, fm, feed, opts.Options, out.Result, dur); err != nil {
+	// Static uploads stay content-addressed (<sha1>.zip, derivable from response_sha1),
+	// so no separate storage_key is recorded.
+	if err := recordFeedFetch(ctx, fm, feed, opts.Options, out.Result, dur, ""); err != nil {
 		return out, err
 	}
 	return out, nil

--- a/fetch/static_fetch.go
+++ b/fetch/static_fetch.go
@@ -40,6 +40,9 @@ type StaticFetchOptions struct {
 // regular failure such as a 404 or strict-validation error is on Result.FetchError.
 func StaticFetch(ctx context.Context, fm feedmanager.FeedManager, opts StaticFetchOptions) (StaticFetchResult, error) {
 	out := StaticFetchResult{}
+	if opts.FetchedAt.IsZero() {
+		opts.FetchedAt = time.Now().UTC()
+	}
 	feed, tmpfile, resp, fatal := download(ctx, fm, opts.Options)
 	if tmpfile != "" {
 		defer os.Remove(tmpfile)

--- a/schema/postgres/migrations/20260624000001_add_rt_archive.up.pgsql
+++ b/schema/postgres/migrations/20260624000001_add_rt_archive.up.pgsql
@@ -1,9 +1,6 @@
 BEGIN;
 
--- RT message archive: per-feed retention period in days (0 disables archiving;
--- matches feed_version_import_retention_period) and the object key where each
--- fetched message was archived. Deletion is by date-prefix, so retention is
--- day-granular.
+-- Per-feed RT archive retention in days (0 disables) and the archived object key.
 ALTER TABLE public.feed_states ADD COLUMN rt_retention_period integer NOT NULL DEFAULT 0;
 ALTER TABLE public.feed_fetches ADD COLUMN storage_key text;
 

--- a/schema/postgres/migrations/20260624000001_add_rt_archive.up.pgsql
+++ b/schema/postgres/migrations/20260624000001_add_rt_archive.up.pgsql
@@ -1,0 +1,10 @@
+BEGIN;
+
+-- RT message archive: per-feed retention period in days (0 disables archiving;
+-- matches feed_version_import_retention_period) and the object key where each
+-- fetched message was archived. Deletion is by date-prefix, so retention is
+-- day-granular.
+ALTER TABLE public.feed_states ADD COLUMN rt_retention_period integer NOT NULL DEFAULT 0;
+ALTER TABLE public.feed_fetches ADD COLUMN storage_key text;
+
+COMMIT;

--- a/schema/sqlite/sqlite.sql
+++ b/schema/sqlite/sqlite.sql
@@ -213,6 +213,7 @@ CREATE TABLE IF NOT EXISTS "feed_states" (
   "public" bool not null,
   "feed_priority" integer,
   "fetch_wait" integer,
+  "rt_retention_period" integer not null default 0,
   "created_at" datetime DEFAULT CURRENT_TIMESTAMP,
   "updated_at" datetime DEFAULT CURRENT_TIMESTAMP,
   foreign key(feed_version_id) REFERENCES feed_versions(id),
@@ -630,6 +631,7 @@ CREATE TABLE feed_fetches (
   "validation_duration_ms" int,
   "upload_duration_ms" int,
   "feed_version_id" int,
+  "storage_key" text,
   "created_at" datetime DEFAULT CURRENT_TIMESTAMP,
   "updated_at" datetime DEFAULT CURRENT_TIMESTAMP,
   foreign key(feed_version_id) REFERENCES feed_versions(id)

--- a/server/finders/actions/feed_fetch.go
+++ b/server/finders/actions/feed_fetch.go
@@ -90,13 +90,25 @@ func RTFetch(ctx context.Context, target string, feedId string, feedUrl string, 
 		return nil
 	}
 
+	// Archive the fetched message to RTStorage only when this feed opts in via
+	// feed_states.rt_retention_period > 0. Leaving Storage empty makes the fetch skip
+	// the upload (and record no storage_key).
+	archiveStorage := ""
+	if cfg.RTStorage != "" {
+		if states, errs := cfg.Finder.FeedStatesByFeedIDs(ctx, []int{feed.ID}); len(errs) > 0 && errs[0] != nil {
+			log.For(ctx).Error().Err(errs[0]).Int("feed_id", feed.ID).Msg("rt-fetch: could not load feed state for archive policy; not archiving")
+		} else if len(states) > 0 && states[0] != nil && states[0].RTRetentionPeriod > 0 {
+			archiveStorage = cfg.RTStorage
+		}
+	}
+
 	// Prepare
 	fetchOpts := fetch.RTFetchOptions{
 		Options: fetch.Options{
 			FeedID:                   feed.ID,
 			URLType:                  urlType,
 			FeedURL:                  feedUrl,
-			Storage:                  cfg.RTStorage,
+			Storage:                  archiveStorage,
 			Secrets:                  cfg.Secrets,
 			FetchedAt:                time.Now().In(time.UTC),
 			AllowHTTPFetchUnfiltered: cfg.AllowHTTPFetchUnfiltered,

--- a/server/finders/actions/feed_fetch.go
+++ b/server/finders/actions/feed_fetch.go
@@ -90,9 +90,7 @@ func RTFetch(ctx context.Context, target string, feedId string, feedUrl string, 
 		return nil
 	}
 
-	// Archive the fetched message to RTStorage only when this feed opts in via
-	// feed_states.rt_retention_period > 0. Leaving Storage empty makes the fetch skip
-	// the upload (and record no storage_key).
+	// Archive to RTStorage only when this feed opts in (rt_retention_period > 0).
 	archiveStorage := ""
 	if cfg.RTStorage != "" {
 		if states, errs := cfg.Finder.FeedStatesByFeedIDs(ctx, []int{feed.ID}); len(errs) > 0 && errs[0] != nil {


### PR DESCRIPTION
## Summary

Adds opt-in, per-feed archiving of fetched GTFS-RT messages to a date-partitioned object store, recording the archive object key on each `feed_fetch` row. RT fetch's upload changes from a content-addressed `<sha1>.pb` key to a Hive-style partitioned key, gated per feed by a new `feed_states.rt_retention_period` (days; 0 disables). This is the write-and-record half of the feature; retention enforcement (a reaper) and GBFS archiving are follow-ups.

### Schema

- `feed_fetches.storage_key text` — the object key where the fetched message was archived, or null when it wasn't.
- `feed_states.rt_retention_period integer NOT NULL DEFAULT 0` — per-feed RT archive retention in days; `0` disables archiving. Named and unit-matched to the existing `feed_version_import_retention_period`. The `NOT NULL DEFAULT 0` backfills every existing feed to "off".
- Migration `20260624000001_add_rt_archive.up.pgsql` + the sqlite schema; `dmfr.FeedFetch.StorageKey` and `dmfr.FeedState.RTRetentionPeriod`.

### RT archive key + recording

- RT fetch now uploads the protobuf to a partitioned, content-suffixed key, replacing the prior `<sha1>.pb`:

  ```
  feed=<onestop_id>/url_type=<url_type>/date=<YYYY-MM-DD>/<YYYY-MM-DD-HH-MM-SS>-<response_sha1>.pb
  ```

  The Hive-style `feed`/`url_type`/`date` partitions let query engines prune by those columns; the timestamp (from `FetchedAt`, UTC) gives sort order; the `response_sha1` suffix keeps distinct messages at distinct keys (so a same-second concurrent fetch or retry can't overwrite), makes each object self-verifying, and exactly cross-references `feed_fetch.response_sha1`. The key is written to `feed_fetch.storage_key`.
- Upload still happens even when the protobuf fails to parse (raw bytes); a failed download (e.g. 404) archives nothing.
- `recordFeedFetch` gains a `storageKey` argument; static fetch passes empty (static stays content-addressed `<sha1>.zip`, correct there — real dedup, sha1-keyed feed versions).

### Per-feed opt-in gate

- `actions.RTFetch` reads the feed's `rt_retention_period` (via `FeedStatesByFeedIDs`) and only passes `RTStorage` into the fetch when it's `> 0`. With it `0` (the default) the fetch skips the upload and records no `storage_key`. So archiving is strictly opt-in per feed, and `RTStorage` being unset disables it globally regardless.

### FetchedAt default

- `RTFetch` and `StaticFetch` now default `opts.FetchedAt` to `time.Now().UTC()` when it's zero, matching the CLI's existing behavior. This keeps a missing/unset fetch time from writing a year-1 `date=0001-01-01/` archive partition or a year-1 `feed_fetches.fetched_at` audit row. Production callers already set it, so this only affects callers that omit it.

## Breaking changes

- **RT upload key scheme changed** (`<sha1>.pb` → partitioned key). Anything reading `<sha1>.pb` back from `RTStorage` would no longer find new objects — but `RTStorage` is write-only in transitland-lib (RT serving is cache-based through `rtfinder`, not storage reads), so there are no readers to break.
- **RT archiving is now default-off / opt-in.** Previously every RT fetch with `RTStorage` set uploaded a `<sha1>.pb`; now nothing is uploaded until a feed's `rt_retention_period` is set `> 0`. The migration leaves all feeds at `0`, so this is a safe default-off rollout, but it is a behavior change for any deployment that relied on the old unconditional upload.

## Not in scope (follow-ups)

- **Retention is recorded but not enforced** — nothing deletes yet. Phase 2 is a reaper that drops `date=` prefixes older than each feed's `rt_retention_period` (day-granular, matching the partition layout) and tidies `storage_key`.
- **GBFS archiving** (no upload path exists today) is phase 3.

## Test plan

- Extended `TestRTFetch`: a 200 writes the object under the `feed=…/url_type=…/date=…/…-<sha1>.pb` key, records `storage_key`, and the key embeds the response sha1 (including the parse-failure case); a 404 writes nothing and leaves `storage_key` empty. With `FetchedAt` omitted, the default-to-now keeps the key under a real date.
- DB-backed check (the per-feed gate isn't exercised by the sqlite fetch tests): against Postgres with the migration applied and `RTStorage` configured, set `feed_states.rt_retention_period > 0` for a feed, run an RT fetch, and confirm the object lands at the partitioned key and `feed_fetch.storage_key` is populated; set it back to `0` and confirm nothing is written.
