### PR TITLE
Feed fetch partition

### DIFF
--- a/internal/gbfs/fetch.go
+++ b/internal/gbfs/fetch.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/interline-io/log"
 	"github.com/interline-io/transitland-lib/dmfr"
@@ -23,6 +24,9 @@ type Result struct {
 
 func Fetch(ctx context.Context, atx tldb.Adapter, opts Options) ([]GbfsFeed, Result, error) {
 	result := Result{}
+	if opts.FetchedAt.IsZero() {
+		opts.FetchedAt = time.Now().UTC()
+	}
 	var reqOpts []request.RequestOption
 	if opts.AllowFTPFetch {
 		reqOpts = append(reqOpts, request.WithAllowFTP)

--- a/schema/postgres/migrations/20260624000002_feed_fetches_partition.up.pgsql
+++ b/schema/postgres/migrations/20260624000002_feed_fetches_partition.up.pgsql
@@ -1,0 +1,75 @@
+BEGIN;
+
+-- New partitioned feed_fetches, built alongside the existing table. The next migration
+-- (feed_fetches_changeover) swaps it in for feed_fetches.
+--
+-- Layout: LIST (url_type) at the top.
+--   static_*                 -> one leaf, kept forever, NOT time-partitioned.
+--   realtime_* / gbfs_*      -> one leaf each, sub-partitioned RANGE (fetched_at) monthly;
+--                               old months are dropped by the cull job.
+--   anything else            -> DEFAULT leaf, so an unexpected url_type can never fail to route.
+--
+-- fetched_at becomes NOT NULL here: it is a partition key and part of the primary key.
+-- The writer always sets it (RTFetch/StaticFetch default it to now); the backfill
+-- COALESCEs legacy NULLs to created_at.
+
+CREATE TABLE feed_fetches_new (
+    id                     bigint  NOT NULL DEFAULT nextval('feed_fetches_id_seq'::regclass),
+    feed_id                bigint  NOT NULL,
+    url_type               text    NOT NULL,
+    url                    text    NOT NULL,
+    success                boolean NOT NULL,
+    fetched_at             timestamp without time zone NOT NULL,
+    fetch_error            text,
+    response_size          integer,
+    response_code          integer,
+    response_sha1          text,
+    feed_version_id        bigint,
+    created_at             timestamp without time zone NOT NULL DEFAULT now(),
+    updated_at             timestamp without time zone NOT NULL DEFAULT now(),
+    response_ttfb_ms       integer,
+    response_time_ms       integer,
+    validation_duration_ms integer,
+    upload_duration_ms     integer,
+    storage_key            text,
+    -- A PK on a partitioned table must contain every partition-key column, at every level.
+    PRIMARY KEY (id, url_type, fetched_at),
+    FOREIGN KEY (feed_id)         REFERENCES current_feeds(id),
+    FOREIGN KEY (feed_version_id) REFERENCES feed_versions(id)
+) PARTITION BY LIST (url_type);
+
+-- Static: kept forever, one leaf for every static_* type.
+CREATE TABLE feed_fetches_static PARTITION OF feed_fetches_new
+    FOR VALUES IN ('static_current', 'static_planned', 'static_historic');
+
+-- Realtime + GBFS: month-partitioned; month leaves are created by feed_fetches_add_month().
+CREATE TABLE feed_fetches_alerts PARTITION OF feed_fetches_new
+    FOR VALUES IN ('realtime_alerts')             PARTITION BY RANGE (fetched_at);
+CREATE TABLE feed_fetches_trip_updates PARTITION OF feed_fetches_new
+    FOR VALUES IN ('realtime_trip_updates')       PARTITION BY RANGE (fetched_at);
+CREATE TABLE feed_fetches_vehicle_positions PARTITION OF feed_fetches_new
+    FOR VALUES IN ('realtime_vehicle_positions')  PARTITION BY RANGE (fetched_at);
+CREATE TABLE feed_fetches_gbfs PARTITION OF feed_fetches_new
+    FOR VALUES IN ('gbfs_auto_discovery')         PARTITION BY RANGE (fetched_at);
+
+-- LIST catch-all for unexpected/future url_types.
+CREATE TABLE feed_fetches_unknown PARTITION OF feed_fetches_new DEFAULT;
+
+-- RANGE backstop under each month-partitioned type: rows land here when no month
+-- partition covers their fetched_at (e.g. before the buffer is seeded). Keep these
+-- empty in production by seeding ahead, or the matching month partition can't be created.
+CREATE TABLE feed_fetches_alerts_default PARTITION OF feed_fetches_alerts DEFAULT;
+CREATE TABLE feed_fetches_trip_updates_default PARTITION OF feed_fetches_trip_updates DEFAULT;
+CREATE TABLE feed_fetches_vehicle_positions_default PARTITION OF feed_fetches_vehicle_positions DEFAULT;
+CREATE TABLE feed_fetches_gbfs_default PARTITION OF feed_fetches_gbfs DEFAULT;
+
+-- Indexes are declared on the parent and propagate to all current/future partitions.
+-- Primary per-feed recency access pattern (scheduler, latest-per-feed).
+CREATE INDEX ON feed_fetches_new (feed_id, fetched_at) INCLUDE (success);
+-- Feed-version lookups (dbfinder).
+CREATE INDEX ON feed_fetches_new (feed_version_id);
+-- Dropped vs. the old table: the standalone (fetched_at) and (success) indexes and the
+-- two partial (feed_id, fetched_at) WHERE success indexes. Range pruning plus the
+-- INCLUDE (success) composite above cover their cases; re-add if a plan regresses.
+
+COMMIT;

--- a/schema/postgres/migrations/20260624000002_feed_fetches_partition.up.pgsql
+++ b/schema/postgres/migrations/20260624000002_feed_fetches_partition.up.pgsql
@@ -5,8 +5,9 @@ BEGIN;
 --
 -- Layout: LIST (url_type) at the top.
 --   static_*                 -> one leaf, kept forever, NOT time-partitioned.
---   realtime_* / gbfs_*      -> one leaf each, sub-partitioned RANGE (fetched_at) monthly;
---                               old months are dropped by the cull job.
+--   the three realtime_*     -> feed_fetches_rt, sub-partitioned RANGE (fetched_at) monthly.
+--   gbfs_auto_discovery      -> feed_fetches_gbfs, sub-partitioned RANGE (fetched_at) monthly.
+--                               old months of both are dropped by the cull job.
 --   anything else            -> DEFAULT leaf, so an unexpected url_type can never fail to route.
 --
 -- fetched_at becomes NOT NULL here: it is a partition key and part of the primary key.
@@ -42,25 +43,21 @@ CREATE TABLE feed_fetches_new (
 CREATE TABLE feed_fetches_static PARTITION OF feed_fetches_new
     FOR VALUES IN ('static_current', 'static_planned', 'static_historic');
 
--- Realtime + GBFS: month-partitioned; month leaves are created by feed_fetches_add_month().
-CREATE TABLE feed_fetches_alerts PARTITION OF feed_fetches_new
-    FOR VALUES IN ('realtime_alerts')             PARTITION BY RANGE (fetched_at);
-CREATE TABLE feed_fetches_trip_updates PARTITION OF feed_fetches_new
-    FOR VALUES IN ('realtime_trip_updates')       PARTITION BY RANGE (fetched_at);
-CREATE TABLE feed_fetches_vehicle_positions PARTITION OF feed_fetches_new
-    FOR VALUES IN ('realtime_vehicle_positions')  PARTITION BY RANGE (fetched_at);
+-- Realtime (all three types) and GBFS: month-partitioned; month leaves are created
+-- by feed_fetches_add_month().
+CREATE TABLE feed_fetches_rt PARTITION OF feed_fetches_new
+    FOR VALUES IN ('realtime_alerts', 'realtime_trip_updates', 'realtime_vehicle_positions')
+    PARTITION BY RANGE (fetched_at);
 CREATE TABLE feed_fetches_gbfs PARTITION OF feed_fetches_new
-    FOR VALUES IN ('gbfs_auto_discovery')         PARTITION BY RANGE (fetched_at);
+    FOR VALUES IN ('gbfs_auto_discovery') PARTITION BY RANGE (fetched_at);
 
 -- LIST catch-all for unexpected/future url_types.
 CREATE TABLE feed_fetches_unknown PARTITION OF feed_fetches_new DEFAULT;
 
--- RANGE backstop under each month-partitioned type: rows land here when no month
+-- RANGE backstop under each month-partitioned subtree: rows land here when no month
 -- partition covers their fetched_at (e.g. before the buffer is seeded). Keep these
 -- empty in production by seeding ahead, or the matching month partition can't be created.
-CREATE TABLE feed_fetches_alerts_default PARTITION OF feed_fetches_alerts DEFAULT;
-CREATE TABLE feed_fetches_trip_updates_default PARTITION OF feed_fetches_trip_updates DEFAULT;
-CREATE TABLE feed_fetches_vehicle_positions_default PARTITION OF feed_fetches_vehicle_positions DEFAULT;
+CREATE TABLE feed_fetches_rt_default PARTITION OF feed_fetches_rt DEFAULT;
 CREATE TABLE feed_fetches_gbfs_default PARTITION OF feed_fetches_gbfs DEFAULT;
 
 -- Indexes are declared on the parent and propagate to all current/future partitions.

--- a/schema/postgres/migrations/20260624000003_feed_fetches_changeover.up.pgsql
+++ b/schema/postgres/migrations/20260624000003_feed_fetches_changeover.up.pgsql
@@ -19,15 +19,7 @@ ALTER TABLE feed_fetches_new RENAME TO feed_fetches;
 -- it never drops the sequence.
 ALTER SEQUENCE feed_fetches_id_seq OWNED BY feed_fetches.id;
 
--- Drop the old table only when it is empty. On a fresh/test database that is the empty
--- init table, so this leaves a partitioned feed_fetches everywhere. On production the
--- old table has rows, EXISTS short-circuits to true, and it is kept for the backfill
--- (ops/feed_fetches_partition/03_backfill.sql) and dropped manually afterward.
-DO $$
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM feed_fetches_old) THEN
-        DROP TABLE feed_fetches_old;
-    END IF;
-END $$;
-
+-- The old table is never auto-dropped. On production it is retained as the backfill
+-- source and dropped manually afterward (ops/feed_fetches_partition/03_backfill.sql);
+-- on fresh/test DBs it lingers empty as feed_fetches_old until dropped by hand.
 COMMIT;

--- a/schema/postgres/migrations/20260624000003_feed_fetches_changeover.up.pgsql
+++ b/schema/postgres/migrations/20260624000003_feed_fetches_changeover.up.pgsql
@@ -1,0 +1,33 @@
+BEGIN;
+
+-- Changeover: swap the partitioned feed_fetches_new in for feed_fetches.
+--
+-- Run manually (dbmigrate) with the fetch queue paused. The renames take a brief
+-- ACCESS EXCLUSIVE lock; with writers paused there is no contention, and nothing has
+-- landed in the new RANGE DEFAULT leaves yet — so the forward partitions can be seeded
+-- cleanly immediately afterward (ops/feed_fetches_partition/01_seed_partitions.sql).
+-- Do not resume the queue before seeding: once current-month realtime rows are in a
+-- DEFAULT leaf, that month's partition can no longer be created.
+--
+-- Owner/grant replay is a manual ops step (rename carries neither).
+
+ALTER TABLE feed_fetches     RENAME TO feed_fetches_old;
+ALTER TABLE feed_fetches_new RENAME TO feed_fetches;
+
+-- Same global sequence (its value is already past every existing id, so backfilled old
+-- ids never collide with new live ids). Reassign ownership off the old table so dropping
+-- it never drops the sequence.
+ALTER SEQUENCE feed_fetches_id_seq OWNED BY feed_fetches.id;
+
+-- Drop the old table only when it is empty. On a fresh/test database that is the empty
+-- init table, so this leaves a partitioned feed_fetches everywhere. On production the
+-- old table has rows, EXISTS short-circuits to true, and it is kept for the backfill
+-- (ops/feed_fetches_partition/03_backfill.sql) and dropped manually afterward.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM feed_fetches_old) THEN
+        DROP TABLE feed_fetches_old;
+    END IF;
+END $$;
+
+COMMIT;

--- a/schema/postgres/ops/feed_fetches_partition/01_seed_partitions.sql
+++ b/schema/postgres/ops/feed_fetches_partition/01_seed_partitions.sql
@@ -1,0 +1,69 @@
+-- Create the monthly partitions for the realtime/gbfs branches.
+--
+-- This is intentionally NOT in the migration: a fresh/test database relies on the
+-- RANGE DEFAULT leaves and needs no months, so migrations stay fast. Production runs
+-- this once right after the changeover migration, while the queue is still paused, so
+-- the DEFAULT leaves are empty and the current + forward months create cleanly; then
+-- the queue resumes and live rows land in real month partitions. The top-up worker calls
+-- feed_fetches_add_month() monthly to stay ahead. The function lives here, not in the
+-- migration: it is a persistent object installed by running this script, untracked by
+-- migrations so it can change freely. (The worker presumes it is installed, or can
+-- CREATE OR REPLACE it itself.)
+
+-- Create one monthly partition for a realtime/gbfs url_type. Idempotent.
+-- Bounds are [first-of-month, first-of-next-month): lower inclusive, upper exclusive.
+CREATE OR REPLACE FUNCTION feed_fetches_add_month(p_url_type text, p_month date)
+RETURNS text LANGUAGE plpgsql AS $$
+DECLARE
+    v_parent text;
+    v_child  text;
+    v_start  date := date_trunc('month', p_month)::date;
+    v_end    date := (date_trunc('month', p_month) + interval '1 month')::date;
+BEGIN
+    v_parent := CASE p_url_type
+        WHEN 'realtime_alerts'            THEN 'feed_fetches_alerts'
+        WHEN 'realtime_trip_updates'      THEN 'feed_fetches_trip_updates'
+        WHEN 'realtime_vehicle_positions' THEN 'feed_fetches_vehicle_positions'
+        WHEN 'gbfs_auto_discovery'        THEN 'feed_fetches_gbfs'
+        ELSE NULL
+    END;
+    IF v_parent IS NULL THEN
+        RAISE EXCEPTION 'feed_fetches_add_month: % is not a month-partitioned url_type', p_url_type;
+    END IF;
+    v_child := format('%s_%s', v_parent, to_char(v_start, 'YYYY_MM'));
+    EXECUTE format(
+        'CREATE TABLE IF NOT EXISTS %I PARTITION OF %I FOR VALUES FROM (%L) TO (%L)',
+        v_child, v_parent, v_start, v_end);
+    RETURN v_child;
+END;
+$$;
+
+-- One month, one type (idempotent):
+--   SELECT feed_fetches_add_month('realtime_trip_updates', date '2026-07-01');
+
+-- Seed a buffer: every month-partitioned type, from 3 months back through 3 years ahead.
+-- Backwards months only matter if you backfill recent realtime/gbfs (e.g. storage_key
+-- rows); pure-static backfill needs none. Adjust the range as desired.
+DO $$
+DECLARE
+    v_type  text;
+    v_month date;
+BEGIN
+    FOREACH v_type IN ARRAY ARRAY[
+        'realtime_alerts',
+        'realtime_trip_updates',
+        'realtime_vehicle_positions',
+        'gbfs_auto_discovery'
+    ] LOOP
+        v_month := date_trunc('month', now()) - interval '3 months';
+        WHILE v_month < date_trunc('month', now()) + interval '3 years' LOOP
+            PERFORM feed_fetches_add_month(v_type, v_month::date);
+            v_month := v_month + interval '1 month';
+        END LOOP;
+    END LOOP;
+END $$;
+
+-- Monthly top-up (what the worker runs): create the next month a bit ahead of time.
+--   SELECT feed_fetches_add_month(t, (date_trunc('month', now()) + interval '2 months')::date)
+--   FROM unnest(ARRAY['realtime_alerts','realtime_trip_updates',
+--                     'realtime_vehicle_positions','gbfs_auto_discovery']) AS t;

--- a/schema/postgres/ops/feed_fetches_partition/01_seed_partitions.sql
+++ b/schema/postgres/ops/feed_fetches_partition/01_seed_partitions.sql
@@ -33,7 +33,8 @@ $$;
 -- One month, one subtree (idempotent):
 --   SELECT feed_fetches_add_month('feed_fetches_rt', date '2026-07-01');
 
--- Seed a buffer: each month-partitioned subtree, from 3 months back through 3 years ahead.
+-- Seed a buffer: each month-partitioned subtree, from 3 months back through 1 year ahead.
+-- A maintenance worker (follow-up) keeps it topped up, so the forward window is modest.
 -- Backwards months only matter if you backfill recent realtime/gbfs (e.g. storage_key
 -- rows); pure-static backfill needs none. Adjust the range as desired.
 DO $$
@@ -43,7 +44,7 @@ DECLARE
 BEGIN
     FOREACH v_parent IN ARRAY ARRAY['feed_fetches_rt', 'feed_fetches_gbfs'] LOOP
         v_month := date_trunc('month', now()) - interval '3 months';
-        WHILE v_month < date_trunc('month', now()) + interval '3 years' LOOP
+        WHILE v_month < date_trunc('month', now()) + interval '1 year' LOOP
             PERFORM feed_fetches_add_month(v_parent, v_month::date);
             v_month := v_month + interval '1 month';
         END LOOP;

--- a/schema/postgres/ops/feed_fetches_partition/01_seed_partitions.sql
+++ b/schema/postgres/ops/feed_fetches_partition/01_seed_partitions.sql
@@ -10,60 +10,46 @@
 -- migrations so it can change freely. (The worker presumes it is installed, or can
 -- CREATE OR REPLACE it itself.)
 
--- Create one monthly partition for a realtime/gbfs url_type. Idempotent.
+-- Create one monthly partition under a month-partitioned subtree. Idempotent.
 -- Bounds are [first-of-month, first-of-next-month): lower inclusive, upper exclusive.
-CREATE OR REPLACE FUNCTION feed_fetches_add_month(p_url_type text, p_month date)
+CREATE OR REPLACE FUNCTION feed_fetches_add_month(p_parent text, p_month date)
 RETURNS text LANGUAGE plpgsql AS $$
 DECLARE
-    v_parent text;
-    v_child  text;
-    v_start  date := date_trunc('month', p_month)::date;
-    v_end    date := (date_trunc('month', p_month) + interval '1 month')::date;
+    v_child text;
+    v_start date := date_trunc('month', p_month)::date;
+    v_end   date := (date_trunc('month', p_month) + interval '1 month')::date;
 BEGIN
-    v_parent := CASE p_url_type
-        WHEN 'realtime_alerts'            THEN 'feed_fetches_alerts'
-        WHEN 'realtime_trip_updates'      THEN 'feed_fetches_trip_updates'
-        WHEN 'realtime_vehicle_positions' THEN 'feed_fetches_vehicle_positions'
-        WHEN 'gbfs_auto_discovery'        THEN 'feed_fetches_gbfs'
-        ELSE NULL
-    END;
-    IF v_parent IS NULL THEN
-        RAISE EXCEPTION 'feed_fetches_add_month: % is not a month-partitioned url_type', p_url_type;
+    IF p_parent NOT IN ('feed_fetches_rt', 'feed_fetches_gbfs') THEN
+        RAISE EXCEPTION 'feed_fetches_add_month: % is not a month-partitioned subtree', p_parent;
     END IF;
-    v_child := format('%s_%s', v_parent, to_char(v_start, 'YYYY_MM'));
+    v_child := format('%s_%s', p_parent, to_char(v_start, 'YYYY_MM'));
     EXECUTE format(
         'CREATE TABLE IF NOT EXISTS %I PARTITION OF %I FOR VALUES FROM (%L) TO (%L)',
-        v_child, v_parent, v_start, v_end);
+        v_child, p_parent, v_start, v_end);
     RETURN v_child;
 END;
 $$;
 
--- One month, one type (idempotent):
---   SELECT feed_fetches_add_month('realtime_trip_updates', date '2026-07-01');
+-- One month, one subtree (idempotent):
+--   SELECT feed_fetches_add_month('feed_fetches_rt', date '2026-07-01');
 
--- Seed a buffer: every month-partitioned type, from 3 months back through 3 years ahead.
+-- Seed a buffer: each month-partitioned subtree, from 3 months back through 3 years ahead.
 -- Backwards months only matter if you backfill recent realtime/gbfs (e.g. storage_key
 -- rows); pure-static backfill needs none. Adjust the range as desired.
 DO $$
 DECLARE
-    v_type  text;
-    v_month date;
+    v_parent text;
+    v_month  date;
 BEGIN
-    FOREACH v_type IN ARRAY ARRAY[
-        'realtime_alerts',
-        'realtime_trip_updates',
-        'realtime_vehicle_positions',
-        'gbfs_auto_discovery'
-    ] LOOP
+    FOREACH v_parent IN ARRAY ARRAY['feed_fetches_rt', 'feed_fetches_gbfs'] LOOP
         v_month := date_trunc('month', now()) - interval '3 months';
         WHILE v_month < date_trunc('month', now()) + interval '3 years' LOOP
-            PERFORM feed_fetches_add_month(v_type, v_month::date);
+            PERFORM feed_fetches_add_month(v_parent, v_month::date);
             v_month := v_month + interval '1 month';
         END LOOP;
     END LOOP;
 END $$;
 
 -- Monthly top-up (what the worker runs): create the next month a bit ahead of time.
---   SELECT feed_fetches_add_month(t, (date_trunc('month', now()) + interval '2 months')::date)
---   FROM unnest(ARRAY['realtime_alerts','realtime_trip_updates',
---                     'realtime_vehicle_positions','gbfs_auto_discovery']) AS t;
+--   SELECT feed_fetches_add_month(p, (date_trunc('month', now()) + interval '2 months')::date)
+--   FROM unnest(ARRAY['feed_fetches_rt','feed_fetches_gbfs']) AS p;

--- a/schema/postgres/ops/feed_fetches_partition/02_manual_steps.sql
+++ b/schema/postgres/ops/feed_fetches_partition/02_manual_steps.sql
@@ -1,0 +1,32 @@
+-- Manual steps around the changeover migration (20260624000003_feed_fetches_changeover).
+-- The swap itself is in that migration; these are the parts that don't belong in
+-- migration history (env-specific checks and permissions).
+
+-- BEFORE migrating ------------------------------------------------------------
+-- Views/matviews/functions bind to the table OID, not the name, so anything depending
+-- on feed_fetches would silently keep reading the old table after the rename. Expect
+-- zero rows; recreate any dependents found against the new table.
+--   SELECT DISTINCT dep.relname, dep.relkind
+--   FROM pg_depend d
+--   JOIN pg_rewrite r ON r.oid = d.objid
+--   JOIN pg_class  dep ON dep.oid = r.ev_class
+--   WHERE d.refobjid = 'feed_fetches'::regclass AND dep.relname <> 'feed_fetches';
+
+-- Capture existing grants so they can be replayed below:
+--   SELECT grantee, privilege_type
+--   FROM information_schema.role_table_grants WHERE table_name = 'feed_fetches';
+
+-- Run order (queue paused throughout):
+--   1. pause the fetch queue
+--   2. dbmigrate  -> applies the structure + changeover migrations (swap)
+--   3. 01_seed_partitions.sql  -> seed current + forward months (DEFAULT leaves empty -> no race)
+--   4. permission replay (below)
+--   5. 03_backfill.sql  -> backfill static + storage_key rows, verify, drop old
+--   6. resume the fetch queue
+
+-- AFTER migrating (production) -------------------------------------------------
+-- Replicate owner + grants the rename did not carry. Adjust to the roles captured above;
+-- example only:
+--   ALTER TABLE feed_fetches OWNER TO onestop;
+--   GRANT SELECT, INSERT, UPDATE, DELETE ON feed_fetches TO onestop;
+--   GRANT SELECT ON feed_fetches TO readonly;

--- a/schema/postgres/ops/feed_fetches_partition/03_backfill.sql
+++ b/schema/postgres/ops/feed_fetches_partition/03_backfill.sql
@@ -44,7 +44,10 @@ BEGIN
 END;
 $$;
 
--- CALL feed_fetches_backfill();
+-- Run in autocommit (e.g. plain psql), NOT inside a transaction block: the per-batch
+-- COMMIT above raises "invalid transaction termination" if CALL runs inside one. Avoid
+-- BEGIN/COMMIT wrappers, psql --single-transaction, and clients that auto-wrap statements.
+--   CALL feed_fetches_backfill();
 
 -- Verify before dropping (counts should match the keep-set):
 --   SELECT count(*) FROM feed_fetches_old WHERE url_type LIKE 'static_%' OR storage_key IS NOT NULL;

--- a/schema/postgres/ops/feed_fetches_partition/03_backfill.sql
+++ b/schema/postgres/ops/feed_fetches_partition/03_backfill.sql
@@ -1,0 +1,55 @@
+-- Backfill the keep-set from the retained old table into the new partitioned table,
+-- then drop the old table.
+--
+-- Keep-set: all static history, plus any row that points at an archived blob
+-- (storage_key IS NOT NULL) so the cull can never orphan the RT archive. Everything
+-- else in old (un-archived realtime/gbfs) is intentionally dropped with the old table.
+--
+-- Runs AFTER the changeover: it reads the old table's final committed state, so any
+-- stragglers that landed in old just after the swap are captured too. Batched with a
+-- per-batch COMMIT so it is online (bounded locks/WAL) and resumable; ON CONFLICT makes
+-- re-runs idempotent. The shared sequence guarantees old ids never collide with live ids.
+--
+-- fetched_at is COALESCEd to created_at because legacy rows may have NULL fetched_at and
+-- the new column is NOT NULL. Old static rows route to feed_fetches_static; old
+-- storage_key rows route to their month partition if seeded, else the type's DEFAULT leaf.
+
+CREATE OR REPLACE PROCEDURE feed_fetches_backfill(p_batch bigint DEFAULT 100000)
+LANGUAGE plpgsql AS $$
+DECLARE
+    v_id  bigint := 0;
+    v_max bigint;
+BEGIN
+    SELECT max(id) INTO v_max FROM feed_fetches_old;
+    WHILE v_id <= v_max LOOP
+        INSERT INTO feed_fetches (
+            id, feed_id, url_type, url, success, fetched_at, fetch_error,
+            response_size, response_code, response_sha1, feed_version_id,
+            created_at, updated_at, response_ttfb_ms, response_time_ms,
+            validation_duration_ms, upload_duration_ms, storage_key)
+        SELECT
+            id, feed_id, url_type, url, success,
+            COALESCE(fetched_at, created_at), fetch_error,
+            response_size, response_code, response_sha1, feed_version_id,
+            created_at, updated_at, response_ttfb_ms, response_time_ms,
+            validation_duration_ms, upload_duration_ms, storage_key
+        FROM feed_fetches_old
+        WHERE id > v_id AND id <= v_id + p_batch
+          AND (url_type LIKE 'static_%' OR storage_key IS NOT NULL)
+        ON CONFLICT DO NOTHING;
+
+        v_id := v_id + p_batch;
+        COMMIT;
+    END LOOP;
+END;
+$$;
+
+-- CALL feed_fetches_backfill();
+
+-- Verify before dropping (counts should match the keep-set):
+--   SELECT count(*) FROM feed_fetches_old WHERE url_type LIKE 'static_%' OR storage_key IS NOT NULL;
+--   SELECT count(*) FROM feed_fetches      WHERE url_type LIKE 'static_%' OR storage_key IS NOT NULL;
+
+-- Reclaim the ~500 GB. No inbound FKs reference feed_fetches, and the sequence ownership
+-- was already moved to the new table in the changeover, so this is clean.
+--   DROP TABLE feed_fetches_old;

--- a/testdata/test_setup.sh
+++ b/testdata/test_setup.sh
@@ -65,6 +65,7 @@ createdb "$PGDATABASE"
 transitland dbmigrate --dburl="$TL_TEST_DATABASE_URL" up
 transitland dbmigrate-natural-earth --dburl="$TL_TEST_DATABASE_URL"
 
+
 #########################
 # Migrate and init server database
 #########################
@@ -80,6 +81,20 @@ createdb "$PGDATABASE"
 # Run migrations
 transitland dbmigrate --dburl="$TL_TEST_SERVER_DATABASE_URL" up
 transitland dbmigrate-natural-earth --dburl="$TL_TEST_SERVER_DATABASE_URL"
+
+#########################
+# Seed feed_fetches partitions
+#########################
+
+# Create the month partitions against the populated server DB. The fetch/import steps
+# above already wrote their (static) feed_fetches rows, which route to feed_fetches_static,
+# so this leaves a realistically partitioned table for the test suite.
+psql -d "$TL_TEST_SERVER_DATABASE_URL" -f "$SCRIPTDIR/../schema/postgres/ops/feed_fetches_partition/01_seed_partitions.sql"
+
+
+#########################
+# Populate data
+#########################
 
 # Remove import files
 transitland sync --dburl="$TL_TEST_SERVER_DATABASE_URL" "$SCRIPTDIR/server/server-test.dmfr.json"
@@ -101,3 +116,4 @@ psql -d "$TL_TEST_SERVER_DATABASE_URL" -f "$SCRIPTDIR/server/test_supplement.pgs
 
 # Load census data
 psql -d "$TL_TEST_SERVER_DATABASE_URL" -f "$SCRIPTDIR/server/census/census.pgsql"
+


### PR DESCRIPTION
## Summary

Introduces a partitioned replacement for `feed_fetches`, the fetch-audit table that has grown to ~1.34B rows / ~531 GB and is ~97% realtime/GBFS by daily volume. The goal is cheap, bloat-free retention — drop aged realtime/GBFS data O(1) by dropping month partitions while keeping all static history forever — without changing the application. It is delivered as an inert "expand" structure migration plus a separate, non-destructive cutover migration, with operational SQL for seeding partitions and backfilling the keep-set. This implements the plan in interline-io/tlv2#199 and builds on the `storage_key` archive column from #677. No Go change is required for the fetch pipeline to run against the partitioned table; one small defensive fix to the GBFS writer is included.

### Partition layout — `20260624000002_feed_fetches_partition`

Creates `feed_fetches_new`, partitioned `LIST (url_type)`:

- `feed_fetches_static` — `static_current` / `static_planned` / `static_historic`, kept forever, not time-partitioned.
- `feed_fetches_rt` — the three `realtime_*` types, sub-partitioned `RANGE (fetched_at)` monthly.
- `feed_fetches_gbfs` — `gbfs_auto_discovery`, sub-partitioned `RANGE (fetched_at)` monthly.
- `feed_fetches_unknown` — LIST DEFAULT, so an unexpected or legacy url_type can never fail to route.
- `feed_fetches_rt_default` / `feed_fetches_gbfs_default` — RANGE DEFAULT backstops, so an insert succeeds even before its month partition is seeded.

Structural decisions: the primary key is `(id, url_type, fetched_at)` (a partitioned table's PK must contain every partition-key column; `id` stays leading and remains globally unique via the shared sequence); `fetched_at` becomes `NOT NULL` (it is now a partition key — every writer already sets it, and the backfill COALESCEs legacy NULLs to `created_at`); foreign keys to `current_feeds` / `feed_versions` are re-declared on the parent; and the index set is trimmed to `(feed_id, fetched_at) INCLUDE (success)` plus `(feed_version_id)`, dropping the standalone `fetched_at`/`success` indexes and the partial `WHERE success` indexes since range pruning and the covering composite cover their cases. Month partitions are intentionally not created here, so fresh/test databases stay fast and ride the DEFAULT leaves.

### Changeover — `20260624000003_feed_fetches_changeover`

Swaps the partitioned table in: renames `feed_fetches` → `feed_fetches_old` and `feed_fetches_new` → `feed_fetches`, and reassigns `feed_fetches_id_seq` ownership to the new table. The same global sequence is reused, so backfilled historical ids never collide with new live ids. It is deliberately non-destructive — it drops nothing, leaving `feed_fetches_old` as the backfill source on production and an empty leftover on fresh DBs. On a fresh/test DB it swaps out the empty init table so every environment ends up partitioned; on production it is run manually with the fetch queue paused. Owner/grant replay is a manual step (rename carries neither).

### Operations scripts — `schema/postgres/ops/feed_fetches_partition/`

- `01_seed_partitions.sql` — installs `feed_fetches_add_month(subtree, month)` (a persistent function kept out of migration history so it can change freely) and seeds a buffer of monthly partitions for `feed_fetches_rt` and `feed_fetches_gbfs`, 3 months back through 1 year ahead. Pre-seeding the buffer keeps partition creation off the fetch critical path; a follow-up top-up worker (in tlv2) keeps it topped up, and the LIST/RANGE DEFAULT leaves are the backstop if it ever falls behind.
- `02_manual_steps.sql` — the pre-flight check for dependent views (which bind to the table OID and would silently keep reading the old table after a rename), the owner/grant replay, and the full production run order.
- `03_backfill.sql` — a batched, resumable, online procedure copying the keep-set (`url_type LIKE 'static_%' OR storage_key IS NOT NULL`) from `feed_fetches_old` into the partitioned table, COALESCing legacy NULL `fetched_at`, with `ON CONFLICT DO NOTHING` for idempotency. The keep-set preserves all static history (~54M `static_current` rows) and any row pointing at an archived blob, so the cull can never orphan the RT archive; everything else — including ~9.8M rows of legacy/corrupt url_types (`alerts`, `trip_updates`, `alertvehicle_positionss`, `manual`) — is dropped with the old table, reclaiming ~510 GB. Ends with count-verification queries and the manual `DROP TABLE feed_fetches_old`.

### GBFS fetched_at guard

`gbfs.Fetch` now defaults `FetchedAt` to `time.Now().UTC()` when unset, matching `RTFetch` / `StaticFetch`. Production data shows historical year-0001 timestamps in both `gbfs_auto_discovery` and `static_current` rows from callers that left it zero; without partitioning those were merely bad audit timestamps, but under the new layout a zero `fetched_at` would route to a DEFAULT leaf. This makes the function self-protecting regardless of caller.

## Breaking changes

The partitioned table makes `fetched_at` `NOT NULL` and changes the primary key from `(id)` to `(id, url_type, fetched_at)`. These take effect only after the changeover migration runs — on fresh DBs immediately, on production at the manual swap. No application change is required: every writer already sets `fetched_at`, `feed_fetches` is append-only with no upsert-by-id or update paths, inserts route transparently, and `id` stays globally unique via the shared sequence so `INSERT ... RETURNING id` is unaffected.

## Production runbook

This PR contains no production cutover — that is a deliberate, separate operation. When run, with the fetch queue stopped throughout the swap and seed, the order is: stop the queue → `dbmigrate` (structure + changeover migrations) → `01_seed_partitions.sql` (current + forward months; DEFAULT leaves empty so they create cleanly) → owner/grant replay → resume the queue → `03_backfill.sql` (online, ~2–3 h since a full scan of the old table measures ~1h51m) → verify counts → manual `DROP TABLE feed_fetches_old`. Everything up to the swap is a no-op on the live table, and the swap itself is non-destructive and recoverable: history is retained in `feed_fetches_old`, and stray rows that land in a DEFAULT leaf are recoverable via the documented truncate/seed step.

## Not in scope / follow-ups

- The tlv2 lifecycle workers (interline-io/tlv2#199 Phase 2): a top-up worker calling `feed_fetches_add_month()` monthly, and a cull worker that DROPs aged `feed_fetches_rt`/`feed_fetches_gbfs` month partitions (O(1)) and DELETE-sweeps the DEFAULT leaves.
- The production backlog cutover (the runbook above), run manually.
- Wiring per-feed retention (`feed_states.rt_retention_period` from #677) into the cull, keeping row retention ≥ blob retention so `storage_key` pointers never dangle.
- Phase 3 schema slimming (drop `created_at` / `updated_at`).

## Test plan

- Apply both migrations to a fresh database; confirm `feed_fetches` is partitioned (`\d+ feed_fetches`), an empty `feed_fetches_old` remains, and the sequence is owned by the new table.
- With no month partitions present, insert one `realtime_*`, one `gbfs_auto_discovery`, and one `static_current` fetch; confirm each lands in the appropriate DEFAULT/static leaf without error. Run `01_seed_partitions.sql` and confirm subsequent inserts route into the month partitions.
- Insert an unenumerated `url_type`; confirm it lands in `feed_fetches_unknown` rather than failing.
- Run the existing fetch and GBFS test suites against the partitioned schema to confirm the pipeline is unchanged.
- Exercise `03_backfill.sql` on a small seeded dataset: confirm only `static_%` and `storage_key IS NOT NULL` rows copy over, legacy NULL `fetched_at` becomes `created_at`, and re-running is idempotent.
