### PR TITLE
Job and artifact soft delete

### DIFF
--- a/schema/postgres/migrations/20260702000001_job_artifacts_soft_delete.up.pgsql
+++ b/schema/postgres/migrations/20260702000001_job_artifacts_soft_delete.up.pgsql
@@ -1,0 +1,8 @@
+BEGIN;
+
+-- Soft-delete marker for job artifacts. Setting deleted_at hides the artifact from
+-- reads (the jobserver filters deleted_at IS NULL) without dropping the row or its
+-- stored bytes; a later blob-culling job reaps the bytes and the row. NULL = live.
+ALTER TABLE tl_job_artifacts ADD COLUMN deleted_at timestamp without time zone;
+
+COMMIT;

--- a/schema/sqlite/sqlite.sql
+++ b/schema/sqlite/sqlite.sql
@@ -1086,7 +1086,8 @@ CREATE TABLE tl_job_artifacts (
   "content_type" text not null default 'application/octet-stream',
   "size_bytes" integer not null default 0,
   "sha1" text not null default '',
-  "storage_key" text not null
+  "storage_key" text not null,
+  "deleted_at" datetime
 );
 CREATE INDEX idx_tl_job_artifacts_job_id ON "tl_job_artifacts"(job_id);
 CREATE INDEX idx_tl_job_artifacts_user_id ON "tl_job_artifacts"(user_id);

--- a/server/dbutil/db.go
+++ b/server/dbutil/db.go
@@ -114,6 +114,23 @@ func Get(ctx context.Context, db sqlx.Ext, q sq.SelectBuilder, dest interface{})
 	return err
 }
 
+// Update runs an update statement.
+func Update(ctx context.Context, db sqlx.Ext, q sq.UpdateBuilder) error {
+	q = q.PlaceholderFormat(sq.Dollar)
+	qstr, qargs, err := q.ToSql()
+	if err == nil {
+		if a, ok := db.(sqlx.ExecerContext); ok {
+			_, err = a.ExecContext(ctx, qstr, qargs...)
+		} else {
+			_, err = db.Exec(qstr, qargs...)
+		}
+	}
+	if err != nil {
+		log.Error().Err(err).Str("query", qstr).Interface("args", qargs).Msg("update failed")
+	}
+	return err
+}
+
 // EscapeLike escapes SQL LIKE/ILIKE wildcard characters (%, _, and \) in a string
 // and optionally adds prefix/suffix wildcards for pattern matching.
 func EscapeLike(s string, prefix bool, suffix bool) string {

--- a/server/dbutil/db.go
+++ b/server/dbutil/db.go
@@ -125,7 +125,9 @@ func Update(ctx context.Context, db sqlx.Ext, q sq.UpdateBuilder) error {
 			_, err = db.Exec(qstr, qargs...)
 		}
 	}
-	if err != nil {
+	if ctx.Err() == context.Canceled {
+		log.Trace().Err(err).Str("query", qstr).Interface("args", qargs).Msg("update canceled")
+	} else if err != nil {
 		log.Error().Err(err).Str("query", qstr).Interface("args", qargs).Msg("update failed")
 	}
 	return err

--- a/server/finders/artifactstore/artifactstore.go
+++ b/server/finders/artifactstore/artifactstore.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/interline-io/log"
@@ -39,6 +40,7 @@ type Store struct {
 
 var (
 	_ model.ArtifactStoreFactory = (*Store)(nil)
+	_ model.ArtifactDeleter      = (*Store)(nil)
 	_ model.ArtifactStore        = (*scoped)(nil)
 )
 
@@ -55,9 +57,10 @@ func (s *Store) For(jobID, userID, kind string) model.ArtifactStore {
 	return &scoped{store: s, jobID: jobID, userID: userID, kind: kind}
 }
 
-// ListByJob returns the artifacts produced by jobID, newest first.
+// ListByJob returns the live (not soft-deleted) artifacts produced by jobID,
+// newest first.
 func (s *Store) ListByJob(ctx context.Context, jobID string) ([]*model.JobArtifact, error) {
-	q := sq.Select("*").From("tl_job_artifacts").Where(sq.Eq{"job_id": jobID}).OrderBy("id desc")
+	q := sq.Select("*").From("tl_job_artifacts").Where(sq.Eq{"job_id": jobID, "deleted_at": nil}).OrderBy("id desc")
 	var ret []*model.JobArtifact
 	if err := dbutil.Select(ctx, s.dbx, q, &ret); err != nil {
 		return nil, err
@@ -65,9 +68,10 @@ func (s *Store) ListByJob(ctx context.Context, jobID string) ([]*model.JobArtifa
 	return ret, nil
 }
 
-// GetByID returns a single artifact row, or ErrArtifactNotFound.
+// GetByID returns a single live (not soft-deleted) artifact row, or
+// ErrArtifactNotFound.
 func (s *Store) GetByID(ctx context.Context, artifactID int) (*model.JobArtifact, error) {
-	q := sq.Select("*").From("tl_job_artifacts").Where(sq.Eq{"id": artifactID}).Limit(1)
+	q := sq.Select("*").From("tl_job_artifacts").Where(sq.Eq{"id": artifactID, "deleted_at": nil}).Limit(1)
 	var ret []*model.JobArtifact
 	if err := dbutil.Select(ctx, s.dbx, q, &ret); err != nil {
 		return nil, err
@@ -76,6 +80,16 @@ func (s *Store) GetByID(ctx context.Context, artifactID int) (*model.JobArtifact
 		return nil, model.ErrArtifactNotFound
 	}
 	return ret[0], nil
+}
+
+// SoftDelete flags an artifact row deleted (deleted_at = now()); its stored bytes
+// are left for a later blob-culling pass, and reads skip soft-deleted rows.
+// Deleting an already-deleted or missing row is a no-op.
+func (s *Store) SoftDelete(ctx context.Context, artifactID int) error {
+	q := sq.Update("tl_job_artifacts").
+		Set("deleted_at", time.Now().UTC()).
+		Where(sq.Eq{"id": artifactID, "deleted_at": nil})
+	return dbutil.Update(ctx, s.dbx, q)
 }
 
 // scoped is an ArtifactStore bound to one job's identity.

--- a/server/finders/artifactstore/artifactstore_test.go
+++ b/server/finders/artifactstore/artifactstore_test.go
@@ -50,6 +50,48 @@ func TestCreateWithoutStorageErrors(t *testing.T) {
 	assert.Contains(t, err.Error(), "no artifact storage configured")
 }
 
+// TestSoftDelete confirms a soft-deleted artifact is hidden from reads while its
+// row and blob are retained for a later culling pass. Requires a Postgres test DB;
+// skips otherwise.
+func TestSoftDelete(t *testing.T) {
+	if msg, ok := testutil.CheckTestDB(); !ok {
+		t.Skip(msg)
+	}
+	db := testutil.MustOpenTestDB(t)
+	ctx := context.Background()
+	store := NewStore(db, t.TempDir())
+
+	const jobID = "artifactstore-softdelete-job"
+	_, _ = db.ExecContext(ctx, "DELETE FROM tl_job_artifacts WHERE job_id = $1", jobID)
+	t.Cleanup(func() {
+		_, _ = db.ExecContext(context.Background(), "DELETE FROM tl_job_artifacts WHERE job_id = $1", jobID)
+	})
+
+	sc := store.For(jobID, "alice", "test")
+	keep, err := sc.CreateReader(ctx, model.ArtifactOpts{Filename: "keep.txt", ContentType: "text/plain"}, strings.NewReader("a"))
+	require.NoError(t, err)
+	gone, err := sc.CreateReader(ctx, model.ArtifactOpts{Filename: "gone.txt", ContentType: "text/plain"}, strings.NewReader("b"))
+	require.NoError(t, err)
+
+	require.NoError(t, store.SoftDelete(ctx, gone.ID))
+
+	// Hidden from both reads.
+	_, err = store.GetByID(ctx, gone.ID)
+	assert.ErrorIs(t, err, model.ErrArtifactNotFound)
+	list, err := store.ListByJob(ctx, jobID)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, keep.ID, list[0].ID)
+
+	// Retained: the blob is still on disk (a culling job removes it later).
+	blob, err := os.ReadFile(filepath.Join(store.storageURL, gone.StorageKey))
+	require.NoError(t, err)
+	assert.Equal(t, "b", string(blob))
+
+	// Idempotent: re-deleting an already-deleted row is a no-op.
+	require.NoError(t, store.SoftDelete(ctx, gone.ID))
+}
+
 // TestStoreRoundTrip exercises the full create -> storage + row -> read path.
 // Requires a Postgres test DB (with the tl_job_artifacts migration applied);
 // skips otherwise.

--- a/server/jobs/jobs.go
+++ b/server/jobs/jobs.go
@@ -52,6 +52,7 @@ func (s JobState) Terminal() bool {
 var (
 	ErrJobAccessDenied = errors.New("job access denied")
 	ErrJobNotFound     = errors.New("job not found")
+	ErrJobNotTerminal  = errors.New("job is not terminal")
 	ErrUnknownQueue    = errors.New("unknown queue")
 )
 
@@ -181,6 +182,16 @@ type StatusQueue interface {
 	Watch(context.Context, string) (<-chan JobEvent, error)
 	List(context.Context, ListOptions) (ListResult, error)
 	Cancel(context.Context, string) error
+}
+
+// DeletableQueue is the optional capability to remove a job's record from the
+// queue once it is terminal. Callers type-assert before use; backends that can't
+// remove jobs simply don't implement it. Delete removes only the queue's own
+// record — artifacts are stored and authorized independently and outlive the job
+// (see the artifact API), so Delete leaves them untouched.
+type DeletableQueue interface {
+	StatusQueue
+	Delete(ctx context.Context, jobId string) error
 }
 
 // PeriodicQueue is the optional capability for recurring jobs. cronTab

--- a/server/jobs/local/local_backend.go
+++ b/server/jobs/local/local_backend.go
@@ -29,10 +29,11 @@ const (
 )
 
 var (
-	_ jobs.Backend       = (*LocalBackend)(nil)
-	_ jobs.Queue         = (*localQueue)(nil)
-	_ jobs.StatusQueue   = (*localQueue)(nil)
-	_ jobs.PeriodicQueue = (*localQueue)(nil)
+	_ jobs.Backend        = (*LocalBackend)(nil)
+	_ jobs.Queue          = (*localQueue)(nil)
+	_ jobs.StatusQueue    = (*localQueue)(nil)
+	_ jobs.DeletableQueue = (*localQueue)(nil)
+	_ jobs.PeriodicQueue  = (*localQueue)(nil)
 )
 
 // LocalBackend is a development backend that runs jobs in-process via
@@ -457,6 +458,30 @@ func (q *localQueue) Cancel(ctx context.Context, jobId string) error {
 	if wasQueued {
 		q.updateStatus(jobId, jobs.JobStateCancelled, "cancelled")
 	}
+	return nil
+}
+
+// Delete removes a terminal job's record from the registry. Returns
+// ErrJobNotFound if unknown, ErrJobNotTerminal if the job is still queued or
+// running (cancel it first), or a policy error if the caller may not read the
+// job. Artifacts are stored separately and are left untouched.
+func (q *localQueue) Delete(ctx context.Context, jobId string) error {
+	entry := q.getEntry(jobId)
+	if entry == nil {
+		return jobs.ErrJobNotFound
+	}
+	entry.mu.Lock()
+	st := entry.status
+	entry.mu.Unlock()
+	if err := q.policy.CanRead(ctx, st); err != nil {
+		return err
+	}
+	if !st.State.Terminal() {
+		return jobs.ErrJobNotTerminal
+	}
+	q.registryMu.Lock()
+	delete(q.registry, jobId)
+	q.registryMu.Unlock()
 	return nil
 }
 

--- a/server/jobserver/artifacts.go
+++ b/server/jobserver/artifacts.go
@@ -194,3 +194,31 @@ func downloadArtifactRequest(w http.ResponseWriter, req *http.Request) {
 	// serveArtifact writes its own success/error response and logs failures.
 	serveArtifact(w, req, store, art)
 }
+
+// deleteArtifactRequest soft-deletes an artifact: the row is flagged deleted and
+// hidden from reads; the stored bytes are reaped later by a blob-culling pass.
+// Authorized as the artifact's owner (or admin), same as the read endpoints.
+func deleteArtifactRequest(w http.ResponseWriter, req *http.Request) {
+	jobID, ok := artifactPrecheck(w, req)
+	if !ok {
+		return
+	}
+	reader, ok := requireArtifactReader(w, req)
+	if !ok {
+		return
+	}
+	art, ok := loadArtifact(w, req, reader, jobID)
+	if !ok {
+		return
+	}
+	deleter, ok := reader.(model.ArtifactDeleter)
+	if !ok {
+		http.Error(w, "delete not supported", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := deleter.SoftDelete(req.Context(), art.ID); err != nil {
+		internalError(w, req, "artifact delete failed", err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/server/jobserver/artifacts_test.go
+++ b/server/jobserver/artifacts_test.go
@@ -49,6 +49,13 @@ func (f *fakeArtifactFactory) GetByID(ctx context.Context, id int) (*model.JobAr
 	return nil, model.ErrArtifactNotFound
 }
 
+// SoftDelete stands in for the real soft-delete by dropping the row from the read
+// map, so subsequent reads 404 — enough to exercise the endpoint.
+func (f *fakeArtifactFactory) SoftDelete(ctx context.Context, id int) error {
+	delete(f.byID, id)
+	return nil
+}
+
 func newArtifactTestServer(t *testing.T, factory model.ArtifactStoreFactory, storage string) (*httptest.Server, *localjobs.LocalBackend) {
 	t.Helper()
 	runner := jobs.NewRunner()
@@ -75,6 +82,43 @@ func newArtifactTestServer(t *testing.T, factory model.ArtifactStoreFactory, sto
 	srv := httptest.NewServer(testAuthMiddleware(model.AddConfig(cfg)(h)))
 	t.Cleanup(srv.Close)
 	return srv, backend
+}
+
+func TestArtifactDeleteEndpoint(t *testing.T) {
+	owner := authn.NewCtxUser("alice", "", "")
+	stranger := authn.NewCtxUser("bob", "", "")
+	dir := t.TempDir()
+
+	factory := &fakeArtifactFactory{byID: map[int]*model.JobArtifact{}}
+	srv, backend := newArtifactTestServer(t, factory, dir)
+
+	st := runOneAndStop(t, backend, authn.WithUser(context.Background(), owner),
+		jobs.Job{Kind: "test", Opts: jobs.JobOpts{UserID: "alice"}})
+	jobID := st.Job.ID
+
+	art := &model.JobArtifact{JobID: jobID, JobKind: "test", UserID: "alice", Filename: "out.svg", StorageKey: "k", SizeBytes: 1}
+	art.ID = 1
+	factory.byID[1] = art
+
+	url := srv.URL + "/queues/" + testQueue + "/jobs/" + jobID + "/artifacts/1"
+
+	// Stranger: 404, and the artifact is left untouched.
+	resp, err := http.DefaultClient.Do(authedRequest(t, http.MethodDelete, url, stranger))
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Contains(t, factory.byID, 1)
+
+	// Owner: 204, then it's gone from reads (GET 404).
+	resp, err = http.DefaultClient.Do(authedRequest(t, http.MethodDelete, url, owner))
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	resp, err = http.DefaultClient.Do(authedRequest(t, http.MethodGet, url, owner))
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
 
 func TestArtifactEndpoints(t *testing.T) {

--- a/server/jobserver/server.go
+++ b/server/jobserver/server.go
@@ -36,10 +36,12 @@ func NewServer() (http.Handler, error) {
 		r.Post("/", submitJobRequest)
 		r.Get("/", listJobsRequest)
 		r.Get("/{jobId}", statusJobRequest)
+		r.Delete("/{jobId}", deleteJobRequest)
 		r.Get("/{jobId}/watch", watchJobRequest)
 		r.Post("/{jobId}/cancel", cancelJobRequest)
 		r.Get("/{jobId}/artifacts", listArtifactsRequest)
 		r.Get("/{jobId}/artifacts/{artifactId}", artifactMetaRequest)
+		r.Delete("/{jobId}/artifacts/{artifactId}", deleteArtifactRequest)
 		r.Get("/{jobId}/artifacts/{artifactId}/download", downloadArtifactRequest)
 	})
 	return r, nil
@@ -193,6 +195,30 @@ func cancelJobRequest(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	if err := sq.Cancel(req.Context(), chi.URLParam(req, "jobId")); err != nil {
+		mapJobLookupError(w, req, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// deleteJobRequest removes a terminal job's record from the queue. Requires a
+// DeletableQueue (405 otherwise); a still-running job yields 409. Artifacts are
+// stored independently and are not affected.
+func deleteJobRequest(w http.ResponseWriter, req *http.Request) {
+	sq, ok := requireStatusQueue(w, req)
+	if !ok {
+		return
+	}
+	dq, ok := sq.(jobs.DeletableQueue)
+	if !ok {
+		http.Error(w, "delete not supported", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := dq.Delete(req.Context(), chi.URLParam(req, "jobId")); err != nil {
+		if errors.Is(err, jobs.ErrJobNotTerminal) {
+			http.Error(w, "job is not terminal; cancel it first", http.StatusConflict)
+			return
+		}
 		mapJobLookupError(w, req, err)
 		return
 	}

--- a/server/jobserver/server_test.go
+++ b/server/jobserver/server_test.go
@@ -165,6 +165,74 @@ func TestStatusEndpoint(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
 }
 
+func TestDeleteEndpoint(t *testing.T) {
+	srv, backend, _ := newTestServer(t)
+	owner := authn.NewCtxUser("alice", "", "")
+	stranger := authn.NewCtxUser("bob", "", "")
+
+	st := runOneAndStop(t, backend, authn.WithUser(context.Background(), owner), jobs.Job{Kind: "test", Opts: jobs.JobOpts{UserID: "alice"}})
+	url := srv.URL + "/queues/" + testQueue + "/jobs/" + st.Job.ID
+
+	// Stranger: 404 (no leak, and it stays put).
+	resp, err := http.DefaultClient.Do(authedRequest(t, http.MethodDelete, url, stranger))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+
+	// Unauthenticated: 403.
+	resp, err = http.DefaultClient.Do(authedRequest(t, http.MethodDelete, url, nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+	// Owner deletes the terminal job: 204, then it's gone (GET 404).
+	resp, err = http.DefaultClient.Do(authedRequest(t, http.MethodDelete, url, owner))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	resp, err = http.DefaultClient.Do(authedRequest(t, http.MethodGet, url, owner))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+
+	// Unknown id: 404.
+	resp, err = http.DefaultClient.Do(authedRequest(t, http.MethodDelete, srv.URL+"/queues/"+testQueue+"/jobs/does-not-exist", owner))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// A queued (non-terminal) job can't be deleted — the backend is never run here,
+// so the submitted job stays queued.
+func TestDeleteEndpointRejectsNonTerminal(t *testing.T) {
+	srv, backend, _ := newTestServer(t)
+	owner := authn.NewCtxUser("alice", "", "")
+
+	q, _ := backend.Queue(testQueue)
+	queued, err := q.Submit(authn.WithUser(context.Background(), owner), jobs.Job{Kind: "test", Opts: jobs.JobOpts{UserID: "alice"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.DefaultClient.Do(authedRequest(t, http.MethodDelete, srv.URL+"/queues/"+testQueue+"/jobs/"+queued.Job.ID, owner))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	assert.Equal(t, http.StatusConflict, resp.StatusCode)
+}
+
 func TestListEndpoint(t *testing.T) {
 	srv, backend, _ := newTestServer(t)
 	owner := authn.NewCtxUser("alice", "", "")

--- a/server/model/job_artifact.go
+++ b/server/model/job_artifact.go
@@ -23,9 +23,10 @@ type JobArtifact struct {
 	UserID      string `db:"user_id" json:"-"`
 	Filename    string `db:"filename" json:"filename"`
 	ContentType string `db:"content_type" json:"content_type"`
-	SizeBytes   int64  `db:"size_bytes" json:"size_bytes"`
-	SHA1        string `db:"sha1" json:"sha1,omitempty"`
-	StorageKey  string `db:"storage_key" json:"-"`
+	SizeBytes   int64   `db:"size_bytes" json:"size_bytes"`
+	SHA1        string  `db:"sha1" json:"sha1,omitempty"`
+	StorageKey  string  `db:"storage_key" json:"-"`
+	DeletedAt   tt.Time `db:"deleted_at" json:"-"`
 	tt.DatabaseEntity
 	tt.Timestamps
 }
@@ -65,4 +66,11 @@ type ArtifactReader interface {
 type ArtifactStoreFactory interface {
 	ArtifactReader
 	For(jobID, userID, kind string) ArtifactStore
+}
+
+// ArtifactDeleter is the optional capability to soft-delete an artifact: the row
+// is flagged (deleted_at) and hidden from reads, but its stored bytes are left for
+// a later blob-culling pass. Callers type-assert an ArtifactReader to it.
+type ArtifactDeleter interface {
+	SoftDelete(ctx context.Context, artifactID int) error
 }


### PR DESCRIPTION
## Summary

Adds two independent delete capabilities to the jobs system: removing a finished job's record from a queue, and soft-deleting a stored artifact. These are deliberately separate subsystems — a job record is ephemeral and authorized by live status, while artifacts are authorized by their row's owner and outlive the job — so job delete removes only the queue's own record and leaves artifacts in place. Both follow the existing optional-capability pattern (`StatusQueue`/`PeriodicQueue`): callers type-assert the new interface and get a clean 405 from backends that don't implement it, so River/Argo/Redis are untouched and only the local backend gains behavior here.

### Job delete

- `jobs.go`: new `DeletableQueue` optional interface (`StatusQueue` + `Delete(ctx, jobId)`) and an `ErrJobNotTerminal` sentinel.
- `local/local_backend.go`: `localQueue.Delete` — owner-gated via `policy.CanRead`, terminal-only (queued/running returns `ErrJobNotTerminal`), removes the registry entry and nothing else. Adds the `_ jobs.DeletableQueue` compile-time assertion.
- `jobserver`: `DELETE /queues/{queue}/jobs/{jobId}` and `deleteJobRequest`, which type-asserts `DeletableQueue` (405 if unsupported), maps `ErrJobNotTerminal` to 409, and reuses `mapJobLookupError` (404 for unknown or not-owner).

### Artifact soft-delete

- Migration `20260702000001_job_artifacts_soft_delete` adds a nullable `deleted_at` to `tl_job_artifacts` (plus the sqlite schema mirror). Setting it hides the row from reads without dropping the row or its stored bytes; a later blob-culling pass reaps the bytes. Blob deletion is intentionally out of scope here — `request.Store` gains no delete method in this PR.
- `model/job_artifact.go`: a `DeletedAt` field (so `SELECT *` scans cleanly after the migration) and a new `ArtifactDeleter` capability interface (`SoftDelete(ctx, artifactID)`).
- `artifactstore.go`: `Store.SoftDelete` (parameterized `UPDATE ... SET deleted_at = now()`, idempotent on an already-deleted or missing row), and `ListByJob`/`GetByID` now filter `deleted_at IS NULL`.
- `dbutil/db.go`: a small `Update` helper alongside the existing `Select`/`Get` for running squirrel update statements.
- `jobserver`: `DELETE /.../artifacts/{artifactId}` and `deleteArtifactRequest`, authorized identically to download via `loadArtifact` (owner-or-admin), type-asserting `ArtifactDeleter` (405 if unsupported).

### Tests

- jobserver: `TestDeleteEndpoint` (204 then gone; stranger 404; unauthenticated 403; unknown 404), `TestDeleteEndpointRejectsNonTerminal` (409 on a queued job), `TestArtifactDeleteEndpoint` (204 then hidden from reads; stranger 404, untouched).
- artifactstore: DB-backed `TestSoftDelete` — soft-deleted artifact disappears from `GetByID`/`ListByJob`, the blob remains on disk, and re-deleting is a no-op.

## Test plan

- The artifactstore DB test requires `TL_TEST_SERVER_DATABASE_URL` with the new migration applied (`dbmigrate up`), which the migration step exercises; the jobserver and local-backend tests need no DB.
- Manually against a running server: submit a job, let it finish, `DELETE /jobs/queues/{queue}/jobs/{id}` returns 204 and a subsequent `GET` returns 404; deleting a still-queued/running job returns 409.
- Create an artifact, then `DELETE /.../artifacts/{id}`: it returns 204, the artifact is absent from list/meta/download afterward, and the row still exists with `deleted_at` set (blob untouched on disk).
