### PR TITLE
Remove a dependency that brought in mongodb driver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.26
 	github.com/aws/aws-sdk-go-v2/service/location v1.51.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.103.3
-	github.com/deckarep/golang-set/v2 v2.9.0
 	github.com/dimchansky/utfbom v1.1.1
 	github.com/flopp/go-staticmaps v0.0.0-20260318105611-d3eb636a6468
 	github.com/getkin/kin-openapi v0.133.0
@@ -162,7 +161,6 @@ require (
 	github.com/urfave/cli/v3 v3.8.0 // indirect
 	github.com/woodsbury/decimal128 v1.3.0 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
-	go.mongodb.org/mongo-driver v1.17.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deckarep/golang-set/v2 v2.9.0 h1:prva4eP9UysWagLyKrtn074ughi0NnkIf0A4M5yOCKI=
-github.com/deckarep/golang-set/v2 v2.9.0/go.mod h1:EWknQXbs0mcFpat2QOoXV0Ee57cD+w6ZEN76BR2JVrM=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 h1:NMZiJj8QnKe1LgsbDayM4UoHwbvwDRwnI3hwNaAHRnc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
@@ -478,8 +476,6 @@ github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
-go.mongodb.org/mongo-driver v1.17.4 h1:jUorfmVzljjr0FLzYQsGP8cgN/qzzxlY9Vh0C9KFXVw=
-go.mongodb.org/mongo-driver v1.17.4/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 h1:CqXxU8VOmDefoh0+ztfGaymYbhdB/tT3zs79QaZTNGY=

--- a/internal/set/set.go
+++ b/internal/set/set.go
@@ -1,4 +1,4 @@
-// Package set provides a minimal generic set backed by a map.
+// Package set provides a minimal generic set.
 package set
 
 import "iter"

--- a/internal/set/set.go
+++ b/internal/set/set.go
@@ -1,0 +1,79 @@
+// Package set provides a minimal generic set backed by a map.
+package set
+
+import "iter"
+
+// Set is an unordered collection of unique values. It is not safe for concurrent use.
+type Set[T comparable] map[T]struct{}
+
+// New returns a set containing the given items.
+func New[T comparable](items ...T) Set[T] {
+	s := make(Set[T], len(items))
+	for _, item := range items {
+		s[item] = struct{}{}
+	}
+	return s
+}
+
+// Add inserts an item into the set.
+func (s Set[T]) Add(item T) {
+	s[item] = struct{}{}
+}
+
+// Contains reports whether the set contains item.
+func (s Set[T]) Contains(item T) bool {
+	_, ok := s[item]
+	return ok
+}
+
+// Cardinality returns the number of items in the set.
+func (s Set[T]) Cardinality() int {
+	return len(s)
+}
+
+// ToSlice returns the set's items in unspecified order.
+func (s Set[T]) ToSlice() []T {
+	items := make([]T, 0, len(s))
+	for item := range s {
+		items = append(items, item)
+	}
+	return items
+}
+
+// Intersect returns a new set of the items present in both s and other.
+func (s Set[T]) Intersect(other Set[T]) Set[T] {
+	// Iterate the smaller set to minimize lookups.
+	a, b := s, other
+	if len(b) < len(a) {
+		a, b = b, a
+	}
+	out := make(Set[T])
+	for item := range a {
+		if _, ok := b[item]; ok {
+			out[item] = struct{}{}
+		}
+	}
+	return out
+}
+
+// Difference returns a new set of the items in s that are not in other.
+func (s Set[T]) Difference(other Set[T]) Set[T] {
+	out := make(Set[T])
+	for item := range s {
+		if _, ok := other[item]; !ok {
+			out[item] = struct{}{}
+		}
+	}
+	return out
+}
+
+// Iter iterates over the set's items in unspecified order.
+func (s Set[T]) Iter() iter.Seq[T] {
+	return func(yield func(T) bool) {
+		for item := range s {
+			if !yield(item) {
+				return
+			}
+		}
+	}
+}

--- a/internal/set/set_test.go
+++ b/internal/set/set_test.go
@@ -1,0 +1,56 @@
+package set
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestSet(t *testing.T) {
+	s := New(1, 2, 2, 3)
+	if s.Cardinality() != 3 {
+		t.Fatalf("Cardinality = %d, want 3", s.Cardinality())
+	}
+	if !s.Contains(2) || s.Contains(9) {
+		t.Fatal("Contains mismatch")
+	}
+	s.Add(4)
+	s.Add(4)
+	if s.Cardinality() != 4 {
+		t.Fatalf("Cardinality after Add = %d, want 4", s.Cardinality())
+	}
+
+	a := New(1, 2, 3)
+	b := New(2, 3, 4)
+	if got := sortedSlice(a.Intersect(b)); !equal(got, []int{2, 3}) {
+		t.Fatalf("Intersect = %v, want [2 3]", got)
+	}
+	if got := sortedSlice(a.Difference(b)); !equal(got, []int{1}) {
+		t.Fatalf("Difference = %v, want [1]", got)
+	}
+
+	seen := New[int]()
+	for v := range a.Iter() {
+		seen.Add(v)
+	}
+	if !equal(sortedSlice(seen), []int{1, 2, 3}) {
+		t.Fatalf("Iter visited %v, want [1 2 3]", sortedSlice(seen))
+	}
+}
+
+func sortedSlice(s Set[int]) []int {
+	out := s.ToSlice()
+	sort.Ints(out)
+	return out
+}
+
+func equal(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/set/set_test.go
+++ b/internal/set/set_test.go
@@ -1,56 +1,28 @@
 package set
 
 import (
-	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSet(t *testing.T) {
 	s := New(1, 2, 2, 3)
-	if s.Cardinality() != 3 {
-		t.Fatalf("Cardinality = %d, want 3", s.Cardinality())
-	}
-	if !s.Contains(2) || s.Contains(9) {
-		t.Fatal("Contains mismatch")
-	}
+	assert.Equal(t, 3, s.Cardinality())
+	assert.True(t, s.Contains(2))
+	assert.False(t, s.Contains(9))
 	s.Add(4)
 	s.Add(4)
-	if s.Cardinality() != 4 {
-		t.Fatalf("Cardinality after Add = %d, want 4", s.Cardinality())
-	}
+	assert.Equal(t, 4, s.Cardinality())
 
 	a := New(1, 2, 3)
 	b := New(2, 3, 4)
-	if got := sortedSlice(a.Intersect(b)); !equal(got, []int{2, 3}) {
-		t.Fatalf("Intersect = %v, want [2 3]", got)
-	}
-	if got := sortedSlice(a.Difference(b)); !equal(got, []int{1}) {
-		t.Fatalf("Difference = %v, want [1]", got)
-	}
+	assert.ElementsMatch(t, []int{2, 3}, a.Intersect(b).ToSlice())
+	assert.ElementsMatch(t, []int{1}, a.Difference(b).ToSlice())
 
-	seen := New[int]()
+	var seen []int
 	for v := range a.Iter() {
-		seen.Add(v)
+		seen = append(seen, v)
 	}
-	if !equal(sortedSlice(seen), []int{1, 2, 3}) {
-		t.Fatalf("Iter visited %v, want [1 2 3]", sortedSlice(seen))
-	}
-}
-
-func sortedSlice(s Set[int]) []int {
-	out := s.ToSlice()
-	sort.Ints(out)
-	return out
-}
-
-func equal(a, b []int) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
+	assert.ElementsMatch(t, []int{1, 2, 3}, seen)
 }

--- a/rt/stats.go
+++ b/rt/stats.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"time"
 
-	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/interline-io/transitland-lib/internal/set"
 	"github.com/interline-io/transitland-lib/rt/pb"
 )
 
@@ -135,10 +135,10 @@ func (fi *Validator) compareTripSets(scheduledTrips []string, rtTrips []rtTripKe
 	var ret []RTTripStat
 	for _, k := range statAggSortedKeys {
 		v := statAgg[k]
-		scheduledSet := mapset.NewSet(v.TripScheduledIDs...)
-		updateSet := mapset.NewSet(v.TripRtIDs...)
-		updateNotFoundSet := mapset.NewSet(v.TripRtNotFoundIDs...)
-		updateAddedSet := mapset.NewSet(v.TripRtAddedIDs...)
+		scheduledSet := set.New(v.TripScheduledIDs...)
+		updateSet := set.New(v.TripRtIDs...)
+		updateNotFoundSet := set.New(v.TripRtNotFoundIDs...)
+		updateAddedSet := set.New(v.TripRtAddedIDs...)
 		tripScheduledMatched := scheduledSet.Intersect(updateSet)
 		tripScheduledNotMatched := scheduledSet.Difference(updateSet)
 		tripRtMatched := updateSet.Intersect(scheduledSet)

--- a/rt/validator_test.go
+++ b/rt/validator_test.go
@@ -7,11 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	mapset "github.com/deckarep/golang-set/v2"
-
 	"github.com/interline-io/transitland-lib/adapters"
 	"github.com/interline-io/transitland-lib/adapters/empty"
 	"github.com/interline-io/transitland-lib/copier"
+	"github.com/interline-io/transitland-lib/internal/set"
 	"github.com/interline-io/transitland-lib/internal/testpath"
 	"github.com/interline-io/transitland-lib/tlcsv"
 )
@@ -95,13 +94,6 @@ func TestValidatorErrors(t *testing.T) {
 		}
 		return b
 	}
-	// ms := func(vals ...int) mapset.Set[int] {
-	// 	a := mapset.NewSet[int]()
-	// 	for _, v := range vals {
-	// 		a.Add(v)
-	// 	}
-	// 	return a
-	// }
 
 	type match struct {
 		field string
@@ -160,7 +152,7 @@ func TestValidatorErrors(t *testing.T) {
 			rterrs := ex.ValidateFeedMessage(msg, nil)
 
 			// Check results
-			foundSet := mapset.NewSet[match]()
+			foundSet := set.New[match]()
 			for _, rterr := range rterrs {
 				if a, ok := rterr.(*RealtimeError); ok {
 					foundSet.Add(match{
@@ -175,7 +167,7 @@ func TestValidatorErrors(t *testing.T) {
 					})
 				}
 			}
-			expSet := mapset.NewSet[match]()
+			expSet := set.New[match]()
 			for _, m := range expMatches {
 				expSet.Add(m)
 			}

--- a/rules/rider_category_id_required.go
+++ b/rules/rider_category_id_required.go
@@ -1,14 +1,14 @@
 package rules
 
 import (
-	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/interline-io/transitland-lib/causes"
 	"github.com/interline-io/transitland-lib/gtfs"
+	"github.com/interline-io/transitland-lib/internal/set"
 	"github.com/interline-io/transitland-lib/tt"
 )
 
 type fareProductRiderCategories struct {
-	riderCategories mapset.Set[string]
+	riderCategories set.Set[string]
 }
 
 // FareProductRiderCategoryDefaultCheck checks if agency_id is missing when more than one agency is present.
@@ -35,7 +35,7 @@ func (e *FareProductRiderCategoryDefaultCheck) Validate(ent tt.Entity) []error {
 		fid := v.FareProductID.Val
 		a, ok := e.fareProductRiderCategories[fid]
 		if !ok {
-			a = fareProductRiderCategories{riderCategories: mapset.NewSet[string]()}
+			a = fareProductRiderCategories{riderCategories: set.New[string]()}
 		}
 
 		// Add the rider category to the set of rider categories for this fare product


### PR DESCRIPTION
## Summary

`github.com/deckarep/golang-set/v2` v2.9.0 added BSON marshal/unmarshal methods directly onto its core Set type, which hard-links `go.mongodb.org/mongo-driver/bson` into the compiled dependency set of every consumer of the library. This repository used the set library in only three places, and only for a handful of trivial operations, so rather than pin around the problem this replaces it with a small internal generic set and drops the dependency entirely. The result removes `golang-set` and its transitive `mongo-driver` requirement from go.mod and go.sum, and mongo no longer appears anywhere in the compiled dependency set.

### Add internal/set

- Add `internal/set`, a minimal generic `Set[T comparable]` backed by `map[T]struct{}`, providing exactly the operations that were in use: `New`, `Add`, `Contains`, `Cardinality`, `ToSlice`, `Intersect`, `Difference`, and `Iter` (returned as an `iter.Seq[T]` range-over-func).
- The set is not safe for concurrent use, which matches how it is used here (all call sites are single-goroutine); this avoids the mutex overhead of the previous thread-safe default.
- Add `internal/set/set_test.go` covering construction, membership, cardinality, the set-algebra operations, and iteration.

### Replace call sites and remove the dependency

- Swap the three usages over to `internal/set`: `rt/stats.go` (scheduled/RT trip comparison), `rules/rider_category_id_required.go` (rider-category accumulation), and `rt/validator_test.go` (expected/found error matching); also drop a stale commented-out block in the test that referenced the old API.
- Remove `github.com/deckarep/golang-set/v2` from go.mod, which drops the transitive `go.mongodb.org/mongo-driver` indirect requirement from go.mod and go.sum.

## Test plan

- `go test ./internal/set/... ./rt/... ./rules/...`
- Confirm the eviction: `go list -deps ./... | grep mongo` returns nothing (mongo is not compiled into any package), and `grep -E 'golang-set|mongo' go.mod go.sum` is empty.
