### PR TITLE
dbmigrate check

### DIFF
--- a/doc/cli/transitland_dbmigrate.md
+++ b/doc/cli/transitland_dbmigrate.md
@@ -6,10 +6,10 @@ Perform database migrations
 
 Perform database migrations
 
-
+Subcommands: up (apply pending migrations); check (exit non-zero if the database is dirty or behind this binary's embedded migrations, for use as a deploy gate); reset-dirty (clear a dirty flag left by a failed migration so it can be retried).
 
 ```
-transitland dbmigrate [flags] <subcommand>
+transitland dbmigrate [flags] <up|check|reset-dirty>
 ```
 
 ### Options

--- a/doc/cli/transitland_dbmigrate.md
+++ b/doc/cli/transitland_dbmigrate.md
@@ -6,10 +6,10 @@ Perform database migrations
 
 Perform database migrations
 
-Subcommands: up (apply pending migrations); check (exit non-zero if the database is dirty or behind this binary's embedded migrations, for use as a deploy gate); reset-dirty (clear a dirty flag left by a failed migration so it can be retried).
+Subcommands: up (apply pending migrations); check (exit non-zero if the database is dirty or behind this binary's embedded migrations, for use as a deploy gate).
 
 ```
-transitland dbmigrate [flags] <up|check|reset-dirty>
+transitland dbmigrate [flags] <up|check>
 ```
 
 ### Options

--- a/schema/postgres/dbmigrate_cmd.go
+++ b/schema/postgres/dbmigrate_cmd.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/golang-migrate/migrate/v4"
 	migratepg "github.com/golang-migrate/migrate/v4/database/postgres"
+	"github.com/golang-migrate/migrate/v4/source"
 	"github.com/golang-migrate/migrate/v4/source/iofs"
 	"github.com/rs/zerolog"
 
@@ -31,11 +32,11 @@ type Command struct {
 }
 
 func (cmd *Command) HelpDesc() (string, string) {
-	return "Perform database migrations", ""
+	return "Perform database migrations", "Subcommands: up (apply pending migrations); check (exit non-zero if the database is dirty or behind this binary's embedded migrations, for use as a deploy gate); reset-dirty (clear a dirty flag left by a failed migration so it can be retried)."
 }
 
 func (cmd *Command) HelpArgs() string {
-	return "[flags] <subcommand>"
+	return "[flags] <up|check|reset-dirty>"
 }
 
 func (cmd *Command) AddFlags(fl *pflag.FlagSet) {
@@ -67,11 +68,11 @@ func (cmd *Command) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	source, err := iofs.New(EmbeddedMigrations, "migrations")
+	src, err := iofs.New(EmbeddedMigrations, "migrations")
 	if err != nil {
 		return err
 	}
-	m, err := migrate.NewWithInstance("iofs", source, "postgres", driver)
+	m, err := migrate.NewWithInstance("iofs", src, "postgres", driver)
 	if err != nil {
 		return err
 	}
@@ -90,12 +91,128 @@ func (cmd *Command) Run(ctx context.Context) error {
 			return nil
 		}
 		return err
+	case "check":
+		return checkMigrations(m, src)
+	case "reset-dirty":
+		return resetDirty(m, src)
 	case "natural-earth":
 		return errors.New("natural-earth has moved to its own command; use 'transitland dbmigrate-natural-earth' instead")
 	case "down":
 		return errors.New("unsupported command")
 	}
 	return fmt.Errorf("unknown subcommand: %s", cmd.Subcommand)
+}
+
+// checkMigrations returns an error (non-zero exit) when the database is dirty
+// or has migrations embedded in this binary that are not yet applied. Intended
+// as a deploy gate so new code is never rolled out ahead of its schema. A
+// database that is ahead of this binary (e.g. an image rollback) passes.
+func checkMigrations(m *migrate.Migrate, src source.Driver) error {
+	current, dirty, err := currentVersion(m)
+	if err != nil {
+		return err
+	}
+	available, err := availableVersions(src)
+	if err != nil {
+		return err
+	}
+	if dirty {
+		return fmt.Errorf("database is dirty at version %d; run 'dbmigrate reset-dirty' then 'dbmigrate up' before deploying", current)
+	}
+	if pending := pendingVersions(current, available); len(pending) > 0 {
+		applied := fmt.Sprintf("%d", current)
+		if current < 0 {
+			applied = "none"
+		}
+		return fmt.Errorf("database is behind: %d migration(s) pending (applied through %s, latest available %d)", len(pending), applied, available[len(available)-1])
+	}
+	log.Info().Msgf("Database schema is up to date (version %d)", current)
+	if len(available) > 0 && current > available[len(available)-1] {
+		log.Info().Msgf("Database version %d is ahead of this binary's latest embedded migration %d", current, available[len(available)-1])
+	}
+	return nil
+}
+
+// resetDirty clears a dirty flag left by a failed migration by stepping the
+// recorded version back to the preceding migration, so 'up' re-runs the failed
+// one. This is golang-migrate's Force in the backward (safe) direction; it never
+// records an unapplied migration as done. Idempotent: a no-op when not dirty.
+func resetDirty(m *migrate.Migrate, src source.Driver) error {
+	current, dirty, err := currentVersion(m)
+	if err != nil {
+		return err
+	}
+	if current < 0 {
+		log.Info().Msg("No migrations applied; nothing to reset")
+		return nil
+	}
+	if !dirty {
+		log.Info().Msgf("Database is not dirty (version %d); nothing to reset", current)
+		return nil
+	}
+	// Step back to the version before the dirty one. If it was the first
+	// migration, reset to NilVersion so 'up' re-runs from the start.
+	target := -1
+	if prev, err := src.Prev(uint(current)); err == nil {
+		target = int(prev)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	log.Info().Msgf("Database dirty at version %d; resetting recorded version to %d and clearing dirty flag", current, target)
+	if err := m.Force(target); err != nil {
+		return err
+	}
+	log.Info().Msgf("Dirty flag cleared. Re-run 'dbmigrate up' to retry migration %d. For non-transactional migrations (e.g. CREATE INDEX CONCURRENTLY) undo any partial effects first.", current)
+	return nil
+}
+
+// currentVersion reports the applied schema version and dirty flag, returning
+// -1 when no migration has been applied.
+func currentVersion(m *migrate.Migrate) (int, bool, error) {
+	v, dirty, err := m.Version()
+	if err != nil {
+		if errors.Is(err, migrate.ErrNilVersion) {
+			return -1, false, nil
+		}
+		return 0, false, err
+	}
+	return int(v), dirty, nil
+}
+
+// availableVersions returns the migration versions in the source, ascending.
+func availableVersions(src source.Driver) ([]int, error) {
+	first, err := src.First()
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	versions := []int{int(first)}
+	for cur := first; ; {
+		next, err := src.Next(cur)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				break
+			}
+			return nil, err
+		}
+		versions = append(versions, int(next))
+		cur = next
+	}
+	return versions, nil
+}
+
+// pendingVersions returns the available versions newer than current, which is
+// -1 when no migration has been applied. available must be ascending.
+func pendingVersions(current int, available []int) []int {
+	var pending []int
+	for _, v := range available {
+		if v > current {
+			pending = append(pending, v)
+		}
+	}
+	return pending
 }
 
 type migrationLogger struct {

--- a/schema/postgres/dbmigrate_cmd.go
+++ b/schema/postgres/dbmigrate_cmd.go
@@ -32,11 +32,11 @@ type Command struct {
 }
 
 func (cmd *Command) HelpDesc() (string, string) {
-	return "Perform database migrations", "Subcommands: up (apply pending migrations); check (exit non-zero if the database is dirty or behind this binary's embedded migrations, for use as a deploy gate); reset-dirty (clear a dirty flag left by a failed migration so it can be retried)."
+	return "Perform database migrations", "Subcommands: up (apply pending migrations); check (exit non-zero if the database is dirty or behind this binary's embedded migrations, for use as a deploy gate)."
 }
 
 func (cmd *Command) HelpArgs() string {
-	return "[flags] <up|check|reset-dirty>"
+	return "[flags] <up|check>"
 }
 
 func (cmd *Command) AddFlags(fl *pflag.FlagSet) {
@@ -93,8 +93,6 @@ func (cmd *Command) Run(ctx context.Context) error {
 		return err
 	case "check":
 		return checkMigrations(m, src)
-	case "reset-dirty":
-		return resetDirty(m, src)
 	case "natural-earth":
 		return errors.New("natural-earth has moved to its own command; use 'transitland dbmigrate-natural-earth' instead")
 	case "down":
@@ -117,7 +115,7 @@ func checkMigrations(m *migrate.Migrate, src source.Driver) error {
 		return err
 	}
 	if dirty {
-		return fmt.Errorf("database is dirty at version %d; run 'dbmigrate reset-dirty' then 'dbmigrate up' before deploying", current)
+		return fmt.Errorf("database is dirty at version %d: a previous migration failed and must be resolved before deploying", current)
 	}
 	if pending := pendingVersions(current, available); len(pending) > 0 {
 		applied := fmt.Sprintf("%d", current)
@@ -126,43 +124,11 @@ func checkMigrations(m *migrate.Migrate, src source.Driver) error {
 		}
 		return fmt.Errorf("database is behind: %d migration(s) pending (applied through %s, latest available %d)", len(pending), applied, available[len(available)-1])
 	}
-	log.Info().Msgf("Database schema is up to date (version %d)", current)
 	if len(available) > 0 && current > available[len(available)-1] {
-		log.Info().Msgf("Database version %d is ahead of this binary's latest embedded migration %d", current, available[len(available)-1])
+		log.Info().Msgf("Database schema is ahead of this binary (version %d, latest embedded migration %d)", current, available[len(available)-1])
+	} else {
+		log.Info().Msgf("Database schema is up to date (version %d)", current)
 	}
-	return nil
-}
-
-// resetDirty clears a dirty flag left by a failed migration by stepping the
-// recorded version back to the preceding migration, so 'up' re-runs the failed
-// one. This is golang-migrate's Force in the backward (safe) direction; it never
-// records an unapplied migration as done. Idempotent: a no-op when not dirty.
-func resetDirty(m *migrate.Migrate, src source.Driver) error {
-	current, dirty, err := currentVersion(m)
-	if err != nil {
-		return err
-	}
-	if current < 0 {
-		log.Info().Msg("No migrations applied; nothing to reset")
-		return nil
-	}
-	if !dirty {
-		log.Info().Msgf("Database is not dirty (version %d); nothing to reset", current)
-		return nil
-	}
-	// Step back to the version before the dirty one. If it was the first
-	// migration, reset to NilVersion so 'up' re-runs from the start.
-	target := -1
-	if prev, err := src.Prev(uint(current)); err == nil {
-		target = int(prev)
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return err
-	}
-	log.Info().Msgf("Database dirty at version %d; resetting recorded version to %d and clearing dirty flag", current, target)
-	if err := m.Force(target); err != nil {
-		return err
-	}
-	log.Info().Msgf("Dirty flag cleared. Re-run 'dbmigrate up' to retry migration %d. For non-transactional migrations (e.g. CREATE INDEX CONCURRENTLY) undo any partial effects first.", current)
 	return nil
 }
 

--- a/schema/postgres/dbmigrate_cmd_test.go
+++ b/schema/postgres/dbmigrate_cmd_test.go
@@ -1,0 +1,42 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/golang-migrate/migrate/v4/source/iofs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPendingVersions(t *testing.T) {
+	available := []int{100, 200, 300}
+	tcs := []struct {
+		name    string
+		current int
+		want    []int
+	}{
+		{"fresh database", -1, []int{100, 200, 300}},
+		{"partially applied", 100, []int{200, 300}},
+		{"one behind", 200, []int{300}},
+		{"up to date", 300, nil},
+		{"ahead of binary", 400, nil},
+		{"between versions", 250, []int{300}},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, pendingVersions(tc.current, available))
+		})
+	}
+	assert.Nil(t, pendingVersions(-1, nil), "no embedded migrations means never behind")
+}
+
+func TestAvailableVersions(t *testing.T) {
+	src, err := iofs.New(EmbeddedMigrations, "migrations")
+	require.NoError(t, err)
+	got, err := availableVersions(src)
+	require.NoError(t, err)
+	require.NotEmpty(t, got, "expected embedded migrations")
+	for i := 1; i < len(got); i++ {
+		assert.Greater(t, got[i], got[i-1], "versions must be strictly ascending and unique")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `check` subcommand to `dbmigrate`, alongside the existing `up`. `check` is a read-only status command that exits non-zero when the database is dirty or behind the migrations embedded in the binary, so it can be used as a pre-deploy gate that refuses to start new code against an un-migrated schema. It is a no-op with a zero exit when the schema is already up to date.

### `check` subcommand

- Read-only. Compares the applied schema version in `schema_migrations` against the migration versions embedded in the binary and reports whether any are unapplied.
- Exits non-zero when the database is dirty or has pending migrations; exits zero when the schema is up to date, and also when the database is ahead of the binary (e.g. running an older build), so it never blocks a rollback.
- The behind message reports the number of pending migrations, the highest applied version, and the latest available version. The dirty message reports the version a prior migration failed at, which is then resolved by hand before deploying.
- The comparison logic is factored into a pure `pendingVersions` helper so it is unit-testable without a database.

### Internals and tests

- Adds `currentVersion` and `availableVersions` helpers over the migrate instance and embedded source, and renames the local source variable to avoid shadowing the newly imported `source` package.
- New unit tests cover the pending, behind, up-to-date, and ahead cases and enumeration of the embedded migration source, both without requiring a database.

## Test plan

- `dbmigrate check` against a database missing one or more migrations exits non-zero and reports the pending count and versions.
- `dbmigrate check` against a fully migrated database exits zero and logs that the schema is up to date.
- `dbmigrate check` against a database whose applied version is ahead of the binary exits zero and logs that the schema is ahead.
- `dbmigrate up` continues to apply pending migrations and report "No migrations to run" when none are pending.
