### PR TITLE
Add --allow-partial flag

### DIFF
--- a/cmds/fetch_cmd.go
+++ b/cmds/fetch_cmd.go
@@ -81,6 +81,7 @@ func (cmd *FetchCommand) AddFlags(fl *pflag.FlagSet) {
 	fl.BoolVar(&cmd.Options.AllowHTTPFetchUnfiltered, "allow-http-fetch-unfiltered", false, "Disable SSRF protection for http(s) fetches; allow private/loopback/metadata IPs (use only for local CLI runs)")
 	fl.BoolVar(&cmd.Options.SaveValidationReport, "validation-report", false, "Save validation report")
 	fl.BoolVar(&cmd.Options.StrictValidation, "strict", false, "Reject feeds with validation errors")
+	fl.BoolVar(&cmd.Options.AllowPartial, "allow-partial", false, "Allow partial feeds missing normally-required files (agency, routes, trips, stop_times, calendar)")
 	fl.StringVar(&cmd.Options.FeedURL, "feed-url", "", "Manually fetch a single URL; you must specify exactly one feed_id")
 	fl.StringVar(&cmd.Options.Storage, "storage", ".", "Storage destination; can be s3://... az://... or path to a directory")
 	fl.StringVar(&cmd.Options.ValidationReportStorage, "validation-report-storage", "", "Storage path for saving validation report JSON")

--- a/cmds/import_cmd.go
+++ b/cmds/import_cmd.go
@@ -81,6 +81,7 @@ func (cmd *ImportCommand) AddFlags(fl *pflag.FlagSet) {
 	fl.BoolVar(&cmd.Options.SimplifyCalendars, "simplify-calendars", false, "Attempt to simplify CalendarDates into regular Calendars")
 	fl.BoolVar(&cmd.Options.NormalizeTimezones, "normalize-timezones", false, "Normalize timezones and apply default stop timezones based on agency and parent stops")
 	fl.StringSliceVar(&cmd.errorThresholds, "error-threshold", nil, "Fail import if file exceeds error percentage; format: 'filename:percent' or '*:percent' for default (e.g., 'stops.txt:5' or '*:10')")
+	fl.BoolVar(&cmd.Options.AllowPartial, "allow-partial", false, "Allow partial feeds missing normally-required files (agency, routes, trips, stop_times, calendar)")
 }
 
 // Parse command line flags

--- a/cmds/validator_cmd.go
+++ b/cmds/validator_cmd.go
@@ -81,6 +81,7 @@ func (cmd *ValidatorCommand) AddFlags(fl *pflag.FlagSet) {
 	fl.StringSliceVar(&cmd.rtFiles, "rt", nil, "Include GTFS-RT proto message in validation report")
 	fl.IntVar(&cmd.Options.ErrorLimit, "error-limit", 1000, "Max number of detailed errors per error group")
 	fl.StringSliceVar(&cmd.errorThresholds, "error-threshold", nil, "Fail validation if file exceeds error percentage; format: 'filename:percent' or '*:percent' for default (e.g., 'stops.txt:5' or '*:10')")
+	fl.BoolVar(&cmd.Options.AllowPartial, "allow-partial", false, "Allow partial feeds missing normally-required files (agency, routes, trips, stop_times, calendar)")
 	fl.StringVar(&cmd.SecretsFile, "secrets", "", "Path to DMFR Secrets file (requires --dmfr and --feed-id)")
 	fl.StringArrayVar(&cmd.SecretEnv, "secret-env", nil, "Specify secret from environment variable as feed_id:ENV_VAR or file.json:ENV_VAR (requires --dmfr and --feed-id)")
 	fl.StringVar(&cmd.DMFRFile, "dmfr", "", "DMFR file providing feed URL and authorization config; used with --feed-id")

--- a/cmds/validator_cmd.go
+++ b/cmds/validator_cmd.go
@@ -44,7 +44,12 @@ type ValidatorCommand struct {
 	AllowLocalFetch          bool
 	AllowS3Fetch             bool
 	AllowHTTPFetchUnfiltered bool
+	AllowPartial             bool
 	secrets                  []dmfr.Secret
+}
+
+type canSetAllowPartial interface {
+	SetAllowPartial(bool)
 }
 
 func (cmd *ValidatorCommand) HelpDesc() (string, string) {
@@ -81,7 +86,7 @@ func (cmd *ValidatorCommand) AddFlags(fl *pflag.FlagSet) {
 	fl.StringSliceVar(&cmd.rtFiles, "rt", nil, "Include GTFS-RT proto message in validation report")
 	fl.IntVar(&cmd.Options.ErrorLimit, "error-limit", 1000, "Max number of detailed errors per error group")
 	fl.StringSliceVar(&cmd.errorThresholds, "error-threshold", nil, "Fail validation if file exceeds error percentage; format: 'filename:percent' or '*:percent' for default (e.g., 'stops.txt:5' or '*:10')")
-	fl.BoolVar(&cmd.Options.AllowPartial, "allow-partial", false, "Allow partial feeds missing normally-required files (agency, routes, trips, stop_times, calendar)")
+	fl.BoolVar(&cmd.AllowPartial, "allow-partial", false, "Allow partial feeds missing normally-required files (agency, routes, trips, stop_times, calendar)")
 	fl.StringVar(&cmd.SecretsFile, "secrets", "", "Path to DMFR Secrets file (requires --dmfr and --feed-id)")
 	fl.StringArrayVar(&cmd.SecretEnv, "secret-env", nil, "Specify secret from environment variable as feed_id:ENV_VAR or file.json:ENV_VAR (requires --dmfr and --feed-id)")
 	fl.StringVar(&cmd.DMFRFile, "dmfr", "", "DMFR file providing feed URL and authorization config; used with --feed-id")
@@ -172,6 +177,9 @@ func (cmd *ValidatorCommand) Run(ctx context.Context) error {
 		return err
 	}
 	defer reader.Close()
+	if r, ok := reader.(canSetAllowPartial); ok {
+		r.SetAllowPartial(cmd.AllowPartial)
+	}
 	v, err := validator.NewValidator(reader, cmd.Options)
 	if err != nil {
 		return err

--- a/doc/cli/transitland_fetch.md
+++ b/doc/cli/transitland_fetch.md
@@ -18,6 +18,7 @@ transitland fetch [flags] [feeds...]
       --allow-ftp-fetch                    Allow fetching from FTP urls
       --allow-http-fetch-unfiltered        Disable SSRF protection for http(s) fetches; allow private/loopback/metadata IPs (use only for local CLI runs)
       --allow-local-fetch                  Allow fetching from filesystem directories/zip files
+      --allow-partial                      Allow partial feeds missing normally-required files (agency, routes, trips, stop_times, calendar)
       --allow-s3-fetch                     Allow fetching from S3 urls
       --create-feed                        Create feed record if not found
       --dburl string                       Database URL (default: $TL_DATABASE_URL)

--- a/doc/cli/transitland_import.md
+++ b/doc/cli/transitland_import.md
@@ -16,6 +16,7 @@ transitland import [flags] [feeds...]
 
 ```
       --activate                  Set as active feed version after import
+      --allow-partial             Allow partial feeds missing normally-required files (agency, routes, trips, stop_times, calendar)
       --create-missing-shapes     Create missing Shapes from Trip stop-to-stop geometries
       --dburl string              Database URL (default: $TL_DATABASE_URL)
       --deduplicate-stop-times    Deduplicate StopTimes using Journey Patterns

--- a/doc/cli/transitland_validate.md
+++ b/doc/cli/transitland_validate.md
@@ -26,6 +26,7 @@ transitland validate [flags] [<reader>]
       --allow-ftp-fetch                    Allow fetching from FTP urls when --dmfr is used
       --allow-http-fetch-unfiltered        Disable SSRF protection for http(s) fetches; allow private/loopback/metadata IPs (use only for local CLI runs)
       --allow-local-fetch                  Allow fetching from filesystem paths when --dmfr is used
+      --allow-partial                      Allow partial feeds missing normally-required files (agency, routes, trips, stop_times, calendar)
       --allow-s3-fetch                     Allow fetching from S3 urls when --dmfr is used
       --best-practices                     Include Best Practices validations
       --dmfr string                        DMFR file providing feed URL and authorization config; used with --feed-id

--- a/fetch/static_fetch.go
+++ b/fetch/static_fetch.go
@@ -31,9 +31,7 @@ type StaticFetchOptions struct {
 	CreatedBy               tt.String
 	Name                    tt.String
 	Description             tt.String
-	// AllowPartial fetches feeds missing the normally-required files
-	// (agency/routes/trips/stop_times/calendar), for feeds such as
-	// stops/levels/pathways only.
+	// AllowPartial fetches partial feeds missing the normally-required files.
 	AllowPartial bool
 	Options
 }
@@ -89,7 +87,7 @@ func staticProcess(ctx context.Context, fm feedmanager.FeedManager, fn string, o
 		out.FetchError = err
 		return nil
 	}
-	reader.AllowPartial = opts.AllowPartial
+	reader.SetAllowPartial(opts.AllowPartial)
 	if err := reader.Open(); err != nil {
 		out.FetchError = err
 		return nil
@@ -112,8 +110,7 @@ func staticProcess(ctx context.Context, fm feedmanager.FeedManager, fn string, o
 	if !opts.HideURL {
 		fv.URL = opts.FeedURL
 	}
-	// A partial feed may have no scheduled service and thus no calendar date range,
-	// but feed_versions requires one (NOT NULL). Fall back to the fetched date.
+	// Partial feeds may have no service dates, but feed_versions requires them (NOT NULL).
 	if !fv.EarliestCalendarDate.Valid || !fv.LatestCalendarDate.Valid {
 		d := tt.NewDate(opts.FetchedAt)
 		fv.EarliestCalendarDate = d
@@ -153,7 +150,6 @@ func staticProcess(ctx context.Context, fm feedmanager.FeedManager, fn string, o
 	validationStart := time.Now()
 	validatorOptions := opts.ValidatorOptions
 	validatorOptions.ErrorLimit = 10
-	validatorOptions.AllowPartial = opts.AllowPartial
 	v, err := validator.NewValidator(reader, validatorOptions)
 	if err != nil {
 		return err

--- a/fetch/static_fetch.go
+++ b/fetch/static_fetch.go
@@ -111,7 +111,7 @@ func staticProcess(ctx context.Context, fm feedmanager.FeedManager, fn string, o
 		fv.URL = opts.FeedURL
 	}
 	// Partial feeds may have no service dates, but feed_versions requires them (NOT NULL).
-	if !fv.EarliestCalendarDate.Valid || !fv.LatestCalendarDate.Valid {
+	if opts.AllowPartial && (!fv.EarliestCalendarDate.Valid || !fv.LatestCalendarDate.Valid) {
 		d := tt.NewDate(opts.FetchedAt)
 		fv.EarliestCalendarDate = d
 		fv.LatestCalendarDate = d

--- a/fetch/static_fetch.go
+++ b/fetch/static_fetch.go
@@ -31,6 +31,10 @@ type StaticFetchOptions struct {
 	CreatedBy               tt.String
 	Name                    tt.String
 	Description             tt.String
+	// AllowPartial fetches feeds missing the normally-required files
+	// (agency/routes/trips/stop_times/calendar), for feeds such as
+	// stops/levels/pathways only.
+	AllowPartial bool
 	Options
 }
 
@@ -85,6 +89,7 @@ func staticProcess(ctx context.Context, fm feedmanager.FeedManager, fn string, o
 		out.FetchError = err
 		return nil
 	}
+	reader.AllowPartial = opts.AllowPartial
 	if err := reader.Open(); err != nil {
 		out.FetchError = err
 		return nil
@@ -141,6 +146,7 @@ func staticProcess(ctx context.Context, fm feedmanager.FeedManager, fn string, o
 	validationStart := time.Now()
 	validatorOptions := opts.ValidatorOptions
 	validatorOptions.ErrorLimit = 10
+	validatorOptions.AllowPartial = opts.AllowPartial
 	v, err := validator.NewValidator(reader, validatorOptions)
 	if err != nil {
 		return err

--- a/fetch/static_fetch.go
+++ b/fetch/static_fetch.go
@@ -112,6 +112,13 @@ func staticProcess(ctx context.Context, fm feedmanager.FeedManager, fn string, o
 	if !opts.HideURL {
 		fv.URL = opts.FeedURL
 	}
+	// A partial feed may have no scheduled service and thus no calendar date range,
+	// but feed_versions requires one (NOT NULL). Fall back to the fetched date.
+	if !fv.EarliestCalendarDate.Valid || !fv.LatestCalendarDate.Valid {
+		d := tt.NewDate(opts.FetchedAt)
+		fv.EarliestCalendarDate = d
+		fv.LatestCalendarDate = d
+	}
 
 	// Skip the work if we already have this feed version.
 	if checkFv, err := fm.GetFeedVersionBySHA1(ctx, fv.SHA1, fv.SHA1Dir.Val); err != nil {

--- a/fetch/static_fetch_test.go
+++ b/fetch/static_fetch_test.go
@@ -1,7 +1,6 @@
 package fetch
 
 import (
-	"archive/zip"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +13,7 @@ import (
 	"github.com/interline-io/transitland-lib/internal/testdb"
 	"github.com/interline-io/transitland-lib/internal/testpath"
 	"github.com/interline-io/transitland-lib/internal/testreader"
+	"github.com/interline-io/transitland-lib/internal/testutil"
 	"github.com/interline-io/transitland-lib/tldb"
 	"github.com/stretchr/testify/assert"
 )
@@ -372,43 +372,6 @@ func TestStaticFetch_NestedTwoFeeds(t *testing.T) {
 // 	})
 // }
 
-// zipDirToTemp writes every regular file in dir into a new temp .zip and
-// returns its path. The flex fixtures are stored as directories so they remain
-// the single source of truth; we zip them on the fly for fetch tests.
-func zipDirToTemp(t *testing.T, dir string) string {
-	t.Helper()
-	tmp, err := os.CreateTemp("", "flexfeed-*.zip")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer tmp.Close()
-	zw := zip.NewWriter(tmp)
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		buf, err := os.ReadFile(filepath.Join(dir, e.Name()))
-		if err != nil {
-			t.Fatal(err)
-		}
-		f, err := zw.Create(e.Name())
-		if err != nil {
-			t.Fatal(err)
-		}
-		if _, err := f.Write(buf); err != nil {
-			t.Fatal(err)
-		}
-	}
-	if err := zw.Close(); err != nil {
-		t.Fatal(err)
-	}
-	return tmp.Name()
-}
-
 // TestStaticFetch_FlexNoStops is a regression test for GTFS-Flex feeds that
 // locate service via locations.geojson with an empty (header-only) stops.txt.
 // Before stops.txt was treated as conditionally required, ValidateStructure
@@ -416,7 +379,7 @@ func zipDirToTemp(t *testing.T, dir string) string {
 // fetch failed with "required file 'stops.txt' not present or could not be read"
 // and no feed version was ever created. This asserts the fetch now succeeds.
 func TestStaticFetch_FlexNoStops(t *testing.T) {
-	zipPath := zipDirToTemp(t, testpath.RelPath("testdata/flex/stops-header-only"))
+	zipPath := testutil.ZipDirToTemp(t, testpath.RelPath("testdata/flex/stops-header-only"))
 	defer os.Remove(zipPath)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		buf, err := os.ReadFile(zipPath)
@@ -447,6 +410,63 @@ func TestStaticFetch_FlexNoStops(t *testing.T) {
 		assert.Equal(t, 200, tlff.ResponseCode.Int(), "did not get expected feed_fetch response code")
 		assert.Equal(t, true, tlff.Success, "did not get expected feed_fetch success")
 		return nil
+	})
+}
+
+// TestStaticFetch_Partial covers --allow-partial: a feed of only
+// stops/levels/pathways (no agency/routes/trips/calendar) fails ValidateStructure
+// normally, but with AllowPartial it fetches successfully and — having no service —
+// gets a fallback calendar date range so the NOT NULL feed_versions columns hold.
+func TestStaticFetch_Partial(t *testing.T) {
+	zipPath := testutil.ZipDirToTemp(t, testpath.RelPath("testdata/gtfs-examples/example-partial"))
+	defer os.Remove(zipPath)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf, err := os.ReadFile(zipPath)
+		if err != nil {
+			t.Error(err)
+		}
+		w.Write(buf)
+	}))
+	defer ts.Close()
+	ctx := context.TODO()
+	doFetch := func(t *testing.T, allowPartial bool) StaticFetchResult {
+		var out StaticFetchResult
+		testdb.TempSqlite(func(atx tldb.Adapter) error {
+			feed := testdb.CreateTestFeed(atx, ts.URL)
+			fr, err := StaticFetch(ctx, feedmanager.NewDBFeedManager(atx), StaticFetchOptions{
+				AllowPartial: allowPartial,
+				Options:      Options{FeedID: feed.ID, FeedURL: feed.URLs.StaticCurrent, Storage: t.TempDir(), AllowHTTPFetchUnfiltered: true},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			out = fr
+			return nil
+		})
+		return out
+	}
+
+	t.Run("rejected without allow-partial", func(t *testing.T) {
+		fr := doFetch(t, false)
+		if fr.FetchError == nil {
+			t.Fatal("expected a fetch error for a feed missing required files")
+		}
+		if fr.FeedVersion != nil {
+			t.Fatal("expected no feed version to be created")
+		}
+	})
+
+	t.Run("accepted with allow-partial", func(t *testing.T) {
+		fr := doFetch(t, true)
+		if fr.FetchError != nil {
+			t.Fatalf("expected no fetch error, got: %s", fr.FetchError.Error())
+		}
+		if fr.FeedVersion == nil || fr.FeedVersion.ID == 0 {
+			t.Fatal("expected a feed version to be created")
+		}
+		if !fr.FeedVersion.EarliestCalendarDate.Valid || !fr.FeedVersion.LatestCalendarDate.Valid {
+			t.Error("expected fallback calendar dates to be set")
+		}
 	})
 }
 

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -28,9 +28,7 @@ type Options struct {
 	// If any file exceeds its threshold, the import is considered failed.
 	// Example: {"*": 10, "stops.txt": 5} means 10% default, 5% for stops.txt.
 	ErrorThreshold map[string]float64
-	// AllowPartial imports feeds missing the normally-required files
-	// (agency/routes/trips/stop_times/calendar) and skips the required
-	// minimum-entity check, for feeds such as stops/levels/pathways only.
+	// AllowPartial imports partial feeds and skips the required minimum-entity check.
 	AllowPartial bool
 	copier.Options
 }
@@ -121,6 +119,10 @@ func ImportFeedVersion(ctx context.Context, fm feedmanager.FeedManager, opts Opt
 	return Result{FeedVersionImport: fviresult}, nil
 }
 
+type canSetAllowPartial interface {
+	SetAllowPartial(bool)
+}
+
 // importFeedVersion runs the Copier from the feed version's reader into the
 // entity sink, both vended by the FeedManager (transaction-bound on a SQL
 // backend), returning the import counts.
@@ -132,10 +134,8 @@ func importFeedVersionTx(ctx context.Context, fm feedmanager.FeedManager, fv dmf
 	if err != nil {
 		return fvi, err
 	}
-	if opts.AllowPartial {
-		if pr, ok := reader.(interface{ SetAllowPartial(bool) }); ok {
-			pr.SetAllowPartial(true)
-		}
+	if r, ok := reader.(canSetAllowPartial); ok {
+		r.SetAllowPartial(opts.AllowPartial)
 	}
 	if err := reader.Open(); err != nil {
 		return fvi, err
@@ -181,27 +181,26 @@ func importFeedVersionTx(ctx context.Context, fm feedmanager.FeedManager, fv dmf
 		}
 	}
 
-	// Check required files have at least minimum entities
-	requiredMinEntities := map[string]int{"agency.txt": 1, "routes.txt": 1}
-	if opts.AllowPartial {
-		requiredMinEntities = nil
-	}
-	minEntitiesResult := cpResult.CheckRequiredMinEntities(requiredMinEntities)
-	if !minEntitiesResult.OK {
-		var failedFiles []string
-		for fn, detail := range minEntitiesResult.Details {
-			if !detail.OK {
-				log.For(ctx).Error().Str("filename", fn).Int("total_count", detail.TotalCount).Int("required", detail.Required).Msg("file did not meet required minimum entities")
-				failedFiles = append(failedFiles, fn)
+	// Check required files have at least minimum entities (skipped for partial feeds).
+	if !opts.AllowPartial {
+		requiredMinEntities := map[string]int{"agency.txt": 1, "routes.txt": 1}
+		minEntitiesResult := cpResult.CheckRequiredMinEntities(requiredMinEntities)
+		if !minEntitiesResult.OK {
+			var failedFiles []string
+			for fn, detail := range minEntitiesResult.Details {
+				if !detail.OK {
+					log.For(ctx).Error().Str("filename", fn).Int("total_count", detail.TotalCount).Int("required", detail.Required).Msg("file did not meet required minimum entities")
+					failedFiles = append(failedFiles, fn)
+				}
 			}
+			sort.Strings(failedFiles)
+			var errMsgs []string
+			for _, fn := range failedFiles {
+				detail := minEntitiesResult.Details[fn]
+				errMsgs = append(errMsgs, fmt.Sprintf("%s: %d entities (required: %d)", fn, detail.TotalCount, detail.Required))
+			}
+			return fvi, fmt.Errorf("required minimum entities not met: %s", strings.Join(errMsgs, "; "))
 		}
-		sort.Strings(failedFiles)
-		var errMsgs []string
-		for _, fn := range failedFiles {
-			detail := minEntitiesResult.Details[fn]
-			errMsgs = append(errMsgs, fmt.Sprintf("%s: %d entities (required: %d)", fn, detail.TotalCount, detail.Required))
-		}
-		return fvi, fmt.Errorf("required minimum entities not met: %s", strings.Join(errMsgs, "; "))
 	}
 
 	// Save feed version import

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -28,6 +28,10 @@ type Options struct {
 	// If any file exceeds its threshold, the import is considered failed.
 	// Example: {"*": 10, "stops.txt": 5} means 10% default, 5% for stops.txt.
 	ErrorThreshold map[string]float64
+	// AllowPartial imports feeds missing the normally-required files
+	// (agency/routes/trips/stop_times/calendar) and skips the required
+	// minimum-entity check, for feeds such as stops/levels/pathways only.
+	AllowPartial bool
 	copier.Options
 }
 
@@ -128,6 +132,11 @@ func importFeedVersionTx(ctx context.Context, fm feedmanager.FeedManager, fv dmf
 	if err != nil {
 		return fvi, err
 	}
+	if opts.AllowPartial {
+		if pr, ok := reader.(interface{ SetAllowPartial(bool) }); ok {
+			pr.SetAllowPartial(true)
+		}
+	}
 	if err := reader.Open(); err != nil {
 		return fvi, err
 	}
@@ -174,6 +183,9 @@ func importFeedVersionTx(ctx context.Context, fm feedmanager.FeedManager, fv dmf
 
 	// Check required files have at least minimum entities
 	requiredMinEntities := map[string]int{"agency.txt": 1, "routes.txt": 1}
+	if opts.AllowPartial {
+		requiredMinEntities = nil
+	}
 	minEntitiesResult := cpResult.CheckRequiredMinEntities(requiredMinEntities)
 	if !minEntitiesResult.OK {
 		var failedFiles []string

--- a/importer/importer_partial_test.go
+++ b/importer/importer_partial_test.go
@@ -1,0 +1,67 @@
+package importer
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/interline-io/transitland-lib/dmfr"
+	"github.com/interline-io/transitland-lib/feedmanager"
+	"github.com/interline-io/transitland-lib/internal/testdb"
+	"github.com/interline-io/transitland-lib/internal/testpath"
+	"github.com/interline-io/transitland-lib/internal/testutil"
+	"github.com/interline-io/transitland-lib/tldb"
+	"github.com/interline-io/transitland-lib/tt"
+)
+
+// TestImportFeedVersion_Partial covers --allow-partial: a feed of only
+// stops/levels/pathways fails the minimum-entity check normally, but imports
+// successfully with AllowPartial.
+func TestImportFeedVersion_Partial(t *testing.T) {
+	ctx := context.TODO()
+	zipPath := testutil.ZipDirToTemp(t, testpath.RelPath("testdata/gtfs-examples/example-partial"))
+	defer os.Remove(zipPath)
+	doImport := func(t *testing.T, allowPartial bool) (dmfr.FeedVersionImport, error) {
+		var fvi dmfr.FeedVersionImport
+		var runErr error
+		testdb.TempSqlite(func(atx tldb.Adapter) error {
+			fv := dmfr.FeedVersion{File: zipPath}
+			fv.EarliestCalendarDate = tt.NewDate(time.Now())
+			fv.LatestCalendarDate = tt.NewDate(time.Now())
+			fvid := testdb.ShouldInsert(t, atx, &fv)
+			atx2 := testdb.AdapterIgnoreTx{Adapter: atx}
+			res, err := ImportFeedVersion(ctx, feedmanager.NewDBFeedManager(&atx2), Options{
+				FeedVersionID: fvid, Storage: "/", AllowPartial: allowPartial,
+			})
+			fvi, runErr = res.FeedVersionImport, err
+			return nil
+		})
+		return fvi, runErr
+	}
+
+	t.Run("rejected without allow-partial", func(t *testing.T) {
+		if _, err := doImport(t, false); err == nil {
+			t.Fatal("expected import to fail the minimum-entity check")
+		}
+	})
+
+	t.Run("accepted with allow-partial", func(t *testing.T) {
+		fvi, err := doImport(t, true)
+		if err != nil {
+			t.Fatalf("expected import to succeed, got: %s", err.Error())
+		}
+		if !fvi.Success {
+			t.Error("expected import success")
+		}
+		if got := fvi.EntityCount["stops.txt"]; got != 4 {
+			t.Errorf("stops.txt: got %d, want 4", got)
+		}
+		if got := fvi.EntityCount["levels.txt"]; got != 2 {
+			t.Errorf("levels.txt: got %d, want 2", got)
+		}
+		if got := fvi.EntityCount["pathways.txt"]; got != 2 {
+			t.Errorf("pathways.txt: got %d, want 2", got)
+		}
+	})
+}

--- a/internal/testutil/zip.go
+++ b/internal/testutil/zip.go
@@ -1,0 +1,45 @@
+package testutil
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ZipDirToTemp writes every regular file in dir into a new temp .zip and returns
+// its path. Feed fixtures are stored as directories so they stay the single source
+// of truth; tests that need a zip (fetch, import) zip them on the fly.
+func ZipDirToTemp(t *testing.T, dir string) string {
+	t.Helper()
+	tmp, err := os.CreateTemp("", "gtfs-*.zip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tmp.Close()
+	zw := zip.NewWriter(tmp)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		buf, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		f, err := zw.Create(e.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.Write(buf); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return tmp.Name()
+}

--- a/stats/fv.go
+++ b/stats/fv.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/interline-io/transitland-lib/adapters"
 	"github.com/interline-io/transitland-lib/dmfr"
+	"github.com/interline-io/transitland-lib/tlcsv"
 	"github.com/interline-io/transitland-lib/tt"
 )
 
@@ -16,11 +17,12 @@ func NewFeedVersionFromReader(reader adapters.Reader) (dmfr.FeedVersion, error) 
 	if errs := reader.ValidateStructure(); len(errs) > 0 {
 		return fv, errs[0]
 	}
-	// Get service dates
+	// Get service dates. A partial feed may have no service (no calendar/trips);
+	// leave the calendar dates unset rather than failing.
 	if start, end, err := FeedVersionServiceBounds(reader); err == nil {
 		fv.EarliestCalendarDate.Set(start)
 		fv.LatestCalendarDate.Set(end)
-	} else {
+	} else if !readerAllowsPartial(reader) {
 		return fv, err
 	}
 	// Get path and sha1
@@ -38,6 +40,12 @@ func NewFeedVersionFromReader(reader adapters.Reader) (dmfr.FeedVersion, error) 
 		fv.File = s.Path()
 	}
 	return fv, nil
+}
+
+// readerAllowsPartial reports whether reader is a CSV reader in partial mode.
+func readerAllowsPartial(reader adapters.Reader) bool {
+	r, ok := reader.(*tlcsv.Reader)
+	return ok && r.AllowPartial
 }
 
 type canSHA1 interface {

--- a/stats/fv.go
+++ b/stats/fv.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/interline-io/transitland-lib/adapters"
 	"github.com/interline-io/transitland-lib/dmfr"
-	"github.com/interline-io/transitland-lib/tlcsv"
 	"github.com/interline-io/transitland-lib/tt"
 )
 
@@ -17,13 +16,14 @@ func NewFeedVersionFromReader(reader adapters.Reader) (dmfr.FeedVersion, error) 
 	if errs := reader.ValidateStructure(); len(errs) > 0 {
 		return fv, errs[0]
 	}
-	// Get service dates. A partial feed may have no service (no calendar/trips);
-	// leave the calendar dates unset rather than failing.
-	if start, end, err := FeedVersionServiceBounds(reader); err == nil {
+	// A partial feed may have no service; leave the calendar dates unset.
+	start, end, err := FeedVersionServiceBounds(reader)
+	if err != nil && !readerAllowsPartial(reader) {
+		return fv, err
+	}
+	if err == nil {
 		fv.EarliestCalendarDate.Set(start)
 		fv.LatestCalendarDate.Set(end)
-	} else if !readerAllowsPartial(reader) {
-		return fv, err
 	}
 	// Get path and sha1
 	if s, ok := reader.(canSHA1); ok {
@@ -42,10 +42,13 @@ func NewFeedVersionFromReader(reader adapters.Reader) (dmfr.FeedVersion, error) 
 	return fv, nil
 }
 
-// readerAllowsPartial reports whether reader is a CSV reader in partial mode.
+type canGetAllowPartial interface {
+	GetAllowPartial() bool
+}
+
 func readerAllowsPartial(reader adapters.Reader) bool {
-	r, ok := reader.(*tlcsv.Reader)
-	return ok && r.AllowPartial
+	r, ok := reader.(canGetAllowPartial)
+	return ok && r.GetAllowPartial()
 }
 
 type canSHA1 interface {

--- a/stats/fv.go
+++ b/stats/fv.go
@@ -17,8 +17,12 @@ func NewFeedVersionFromReader(reader adapters.Reader) (dmfr.FeedVersion, error) 
 		return fv, errs[0]
 	}
 	// A partial feed may have no service; leave the calendar dates unset.
+	allowPartial := false
+	if r, ok := reader.(canGetAllowPartial); ok {
+		allowPartial = r.GetAllowPartial()
+	}
 	start, end, err := FeedVersionServiceBounds(reader)
-	if err != nil && !readerAllowsPartial(reader) {
+	if err != nil && !allowPartial {
 		return fv, err
 	}
 	if err == nil {
@@ -44,11 +48,6 @@ func NewFeedVersionFromReader(reader adapters.Reader) (dmfr.FeedVersion, error) 
 
 type canGetAllowPartial interface {
 	GetAllowPartial() bool
-}
-
-func readerAllowsPartial(reader adapters.Reader) bool {
-	r, ok := reader.(canGetAllowPartial)
-	return ok && r.GetAllowPartial()
 }
 
 type canSHA1 interface {

--- a/testdata/gtfs-examples/example-partial/levels.txt
+++ b/testdata/gtfs-examples/example-partial/levels.txt
@@ -1,0 +1,3 @@
+level_id,level_index,level_name
+L0,0,Street
+L1,1,Platforms

--- a/testdata/gtfs-examples/example-partial/pathways.txt
+++ b/testdata/gtfs-examples/example-partial/pathways.txt
@@ -1,0 +1,3 @@
+pathway_id,from_stop_id,to_stop_id,pathway_mode,is_bidirectional
+PW1,ENT1,PLAT1,1,1
+PW2,ENT1,PLAT2,1,1

--- a/testdata/gtfs-examples/example-partial/stops.txt
+++ b/testdata/gtfs-examples/example-partial/stops.txt
@@ -1,0 +1,5 @@
+stop_id,stop_name,stop_lat,stop_lon,location_type,parent_station,level_id
+STATION,Test Station,40.0000,-74.0000,1,,
+PLAT1,Platform 1,40.0001,-74.0001,0,STATION,L1
+PLAT2,Platform 2,40.0002,-74.0002,0,STATION,L1
+ENT1,Main Entrance,40.0003,-74.0003,2,STATION,L0

--- a/tlcsv/reader.go
+++ b/tlcsv/reader.go
@@ -19,17 +19,14 @@ type s2D = [][]string
 // Reader reads GTFS entities from CSV files.
 type Reader struct {
 	Adapter
-	// AllowPartial relaxes the required-file structure check so a feed containing
-	// only a subset of files (e.g. stops/levels/pathways) passes validation without
-	// the normally-required agency/routes/trips/stop_times/calendar files.
-	AllowPartial bool
+	allowPartial bool
 }
 
-// SetAllowPartial sets AllowPartial. Provided so callers holding an adapters.Reader
-// can enable partial mode without a concrete type assertion.
-func (reader *Reader) SetAllowPartial(v bool) {
-	reader.AllowPartial = v
-}
+// SetAllowPartial enables partial mode: read what we can, skipping the required-files check.
+func (reader *Reader) SetAllowPartial(v bool) { reader.allowPartial = v }
+
+// GetAllowPartial reports whether partial mode is enabled.
+func (reader *Reader) GetAllowPartial() bool { return reader.allowPartial }
 
 func NewReaderFromAdapter(a Adapter) (*Reader, error) {
 	return &Reader{Adapter: a}, nil
@@ -77,12 +74,6 @@ func (reader *Reader) ReadEntities(c interface{}) error {
 // opens cleanly but hits a read error partway through is caught during the actual data
 // pass, not here.
 func (reader *Reader) ValidateStructure() []error {
-	// In partial mode, skip the structure check entirely so a feed containing only
-	// a subset of files (e.g. stops/levels/pathways) is accepted. A fundamentally
-	// unreadable archive is still caught by reader.Open() and the later data pass.
-	if reader.AllowPartial {
-		return nil
-	}
 	// Check if the archive can be opened
 	allerrs := []error{}
 	exists := reader.Adapter.Exists()
@@ -164,6 +155,16 @@ func (reader *Reader) ValidateStructure() []error {
 			fileerrs = append(fileerrs, causes.NewFileRequiredError(efn))
 		}
 		return fileerrs
+	}
+	// In partial mode, no file is required: validate the ones that are present and
+	// skip the rest. Everything else (headers, columns, duplicates) still applies.
+	if reader.allowPartial {
+		for _, ent := range []tt.Entity{&gtfs.Agency{}, &gtfs.Route{}, &gtfs.Stop{}, &gtfs.Trip{}, &gtfs.StopTime{}, &gtfs.Calendar{}, &gtfs.CalendarDate{}} {
+			if reader.ContainsFile(ent.Filename()) {
+				allerrs = append(allerrs, check(ent, false)...)
+			}
+		}
+		return allerrs
 	}
 	// stops.txt is conditionally required. It may be omitted entirely when the
 	// feed provides location-based service via locations.geojson or

--- a/tlcsv/reader.go
+++ b/tlcsv/reader.go
@@ -19,6 +19,16 @@ type s2D = [][]string
 // Reader reads GTFS entities from CSV files.
 type Reader struct {
 	Adapter
+	// AllowPartial relaxes the required-file structure check so a feed containing
+	// only a subset of files (e.g. stops/levels/pathways) passes validation without
+	// the normally-required agency/routes/trips/stop_times/calendar files.
+	AllowPartial bool
+}
+
+// SetAllowPartial sets AllowPartial. Provided so callers holding an adapters.Reader
+// can enable partial mode without a concrete type assertion.
+func (reader *Reader) SetAllowPartial(v bool) {
+	reader.AllowPartial = v
 }
 
 func NewReaderFromAdapter(a Adapter) (*Reader, error) {
@@ -67,6 +77,12 @@ func (reader *Reader) ReadEntities(c interface{}) error {
 // opens cleanly but hits a read error partway through is caught during the actual data
 // pass, not here.
 func (reader *Reader) ValidateStructure() []error {
+	// In partial mode, skip the structure check entirely so a feed containing only
+	// a subset of files (e.g. stops/levels/pathways) is accepted. A fundamentally
+	// unreadable archive is still caught by reader.Open() and the later data pass.
+	if reader.AllowPartial {
+		return nil
+	}
 	// Check if the archive can be opened
 	allerrs := []error{}
 	exists := reader.Adapter.Exists()

--- a/tlcsv/reader_test.go
+++ b/tlcsv/reader_test.go
@@ -1,6 +1,7 @@
 package tlcsv
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -407,4 +408,58 @@ func hasEntityLimitError(errs []error) bool {
 		}
 	}
 	return false
+}
+
+// TestValidateStructure_Partial pins the AllowPartial guarantee: missing required
+// files are not flagged, but a file that IS present is still fully validated.
+func TestValidateStructure_Partial(t *testing.T) {
+	// A partial feed: only a present-but-malformed stops.txt (no recognized
+	// columns) and none of the normally-required files.
+	dir := t.TempDir()
+	w := NewDirAdapter(dir)
+	if err := w.WriteRows("stops.txt", [][]string{{"foo", "bar"}, {"1", "2"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	fileRequired := func(errs []error, filename string) bool {
+		for _, err := range errs {
+			var fre *causes.FileRequiredError
+			if errors.As(err, &fre) && fre.Filename == filename {
+				return true
+			}
+		}
+		return false
+	}
+	validate := func(allowPartial bool) []error {
+		reader := &Reader{Adapter: NewDirAdapter(dir)}
+		reader.SetAllowPartial(allowPartial)
+		if err := reader.Open(); err != nil {
+			t.Fatal(err)
+		}
+		defer reader.Close()
+		return reader.ValidateStructure()
+	}
+
+	t.Run("without allow-partial the missing required files are flagged", func(t *testing.T) {
+		errs := validate(false)
+		if !fileRequired(errs, "agency.txt") || !fileRequired(errs, "routes.txt") {
+			t.Errorf("expected missing required files to be flagged, got: %v", errs)
+		}
+	})
+
+	t.Run("with allow-partial only present files are validated", func(t *testing.T) {
+		errs := validate(true)
+		// The present-but-malformed stops.txt is still flagged.
+		if !fileRequired(errs, "stops.txt") {
+			t.Errorf("expected present malformed stops.txt to be flagged, got: %v", errs)
+		}
+		// Missing required files are not flagged.
+		for _, fn := range []string{"agency.txt", "routes.txt", "trips.txt", "stop_times.txt"} {
+			if fileRequired(errs, fn) {
+				t.Errorf("did not expect %s to be flagged in partial mode, got: %v", fn, errs)
+			}
+		}
+	})
 }

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -57,6 +57,10 @@ type Options struct {
 	// If any file exceeds its threshold, the validation is considered failed.
 	// Example: {"*": 10, "stops.txt": 5} means 10% default, 5% for stops.txt.
 	ErrorThreshold map[string]float64
+	// AllowPartial validates feeds missing the normally-required files
+	// (agency/routes/trips/stop_times/calendar) and skips the required
+	// minimum-entity check, for feeds such as stops/levels/pathways only.
+	AllowPartial bool
 	copier.Options
 }
 
@@ -139,6 +143,7 @@ func (v *Validator) ValidateStatic(reader adapters.Reader, evaluateAt time.Time,
 	v.rtValidator = rt.NewValidator()
 	details := ResultDetails{}
 	if reader2, ok := reader.(*tlcsv.Reader); ok {
+		reader2.AllowPartial = v.Options.AllowPartial
 		result.IncludesStatic.Set(true)
 		fvfis, err := stats.NewFeedVersionFileInfosFromReader(reader2)
 		if err != nil {
@@ -270,6 +275,9 @@ func (v *Validator) ValidateStatic(reader adapters.Reader, evaluateAt time.Time,
 
 	// Check required files have at least minimum entities
 	requiredMinEntities := map[string]int{"agency.txt": 1, "routes.txt": 1}
+	if v.Options.AllowPartial {
+		requiredMinEntities = nil
+	}
 	minEntitiesResult := cpResult.CheckRequiredMinEntities(requiredMinEntities)
 	if !minEntitiesResult.OK {
 		var failedFiles []string

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -57,10 +57,6 @@ type Options struct {
 	// If any file exceeds its threshold, the validation is considered failed.
 	// Example: {"*": 10, "stops.txt": 5} means 10% default, 5% for stops.txt.
 	ErrorThreshold map[string]float64
-	// AllowPartial validates feeds missing the normally-required files
-	// (agency/routes/trips/stop_times/calendar) and skips the required
-	// minimum-entity check, for feeds such as stops/levels/pathways only.
-	AllowPartial bool
 	copier.Options
 }
 
@@ -143,7 +139,6 @@ func (v *Validator) ValidateStatic(reader adapters.Reader, evaluateAt time.Time,
 	v.rtValidator = rt.NewValidator()
 	details := ResultDetails{}
 	if reader2, ok := reader.(*tlcsv.Reader); ok {
-		reader2.AllowPartial = v.Options.AllowPartial
 		result.IncludesStatic.Set(true)
 		fvfis, err := stats.NewFeedVersionFileInfosFromReader(reader2)
 		if err != nil {
@@ -275,9 +270,6 @@ func (v *Validator) ValidateStatic(reader adapters.Reader, evaluateAt time.Time,
 
 	// Check required files have at least minimum entities
 	requiredMinEntities := map[string]int{"agency.txt": 1, "routes.txt": 1}
-	if v.Options.AllowPartial {
-		requiredMinEntities = nil
-	}
 	minEntitiesResult := cpResult.CheckRequiredMinEntities(requiredMinEntities)
 	if !minEntitiesResult.OK {
 		var failedFiles []string


### PR DESCRIPTION
## Summary
Adds an opt-in `--allow-partial` mode to the `fetch`, `import`, and `validate` commands for GTFS feeds that intentionally omit the normally-required files (`agency.txt`, `routes.txt`, `trips.txt`, `stop_times.txt`, `calendar.txt`/`calendar_dates.txt`) — for example station feeds made up of only `stops.txt`, `levels.txt`, and `pathways.txt` that are meant to be imported and then edited. In partial mode the reader reads whatever files are present and all normal validations still apply; the only relaxation is that missing required files are no longer treated as errors.

### Reader-level partial mode
- `tlcsv.Reader` gains an `AllowPartial` flag with `SetAllowPartial`/`GetAllowPartial` methods, so the setting travels with the reader: it is set once where the reader is created and read wherever the reader flows (validation, stats, copier), following the same optional capability-interface pattern already used for `SetFeedVersionID`.
- In partial mode `ValidateStructure` validates the files that are present — headers, required columns, and duplicate columns — and skips the missing-required-file check. A present-but-malformed file is still reported.

### CLI flags
- Adds `--allow-partial` to `transitland fetch`, `transitland import`, and `transitland validate`, with regenerated CLI docs.

### Import behavior
- The post-copy minimum-entity check (which requires at least one `agency.txt` and one `routes.txt` row) is skipped for partial imports.

### Service dates
- A partial feed can have no scheduled service, so `NewFeedVersionFromReader` no longer treats empty calendar bounds as fatal when the reader is in partial mode. Because `feed_versions.earliest_calendar_date` and `latest_calendar_date` are `NOT NULL`, `fetch` fills them with the fetched date when a feed has no service.

### Tests and fixtures
- Adds a directory-format fixture at `testdata/gtfs-examples/example-partial` containing only `stops.txt`, `levels.txt`, and `pathways.txt`.
- Adds `fetch` and `import` tests that zip the fixture and run it through an in-memory SQLite database, each asserting rejection without the flag and success with it (including the fetched-date fallback and expected entity counts).
- Adds a `ValidateStructure` test that confirms a present-but-malformed `stops.txt` is still flagged in partial mode while the missing required files are not.
- Extracts the directory-to-temp-zip test helper into `internal/testutil.ZipDirToTemp`, shared by the fetch and import tests (previously a local helper in the fetch tests).

## Test plan
- Run `transitland validate testdata/gtfs-examples/example-partial` and confirm it reports required-file errors for agency/routes/trips/stop_times/calendar; rerun with `--allow-partial` and confirm the report is clean.
- Point `--allow-partial` validation at a partial feed whose present `stops.txt` has unrecognized columns and confirm the `stops.txt` error is still reported.
- Fetch a stops/levels/pathways feed with `--allow-partial` into a database and confirm a feed version is created with a single-day service window at the fetched date; confirm the fetch is rejected without the flag.
- Import that feed version with `--allow-partial` and confirm it succeeds with the expected stop/level/pathway counts; confirm it fails the minimum-entity check without the flag.
