### PR TITLE
Queries should check fv import state

### DIFF
--- a/server/finders/dbfinder/agency.go
+++ b/server/finders/dbfinder/agency.go
@@ -242,6 +242,7 @@ func agencySelect(limit *int, after *model.Cursor, ids []int, useActive *UseActi
 	}
 
 	// Handle permissions
+	q = joinImported(q)
 	q = pfJoinCheckFv(q, permFilter)
 	return q
 }
@@ -296,6 +297,7 @@ func placeSelect(_ *int, _ *model.Cursor, _ []int, level *model.PlaceAggregation
 	}
 
 	// Handle permissions
+	q = joinImported(q)
 	q = pfJoinCheckFv(q, permFilter)
 	return q
 }

--- a/server/finders/dbfinder/finder.go
+++ b/server/finders/dbfinder/finder.go
@@ -200,8 +200,8 @@ func escapeWordsWithSuffix(v string, sfx string) []string {
 }
 
 // joinImported restricts a select over imported entity rows to feed versions whose import
-// completed. It must be applied to every select that reads a table in
-// dmfr.GetFeedVersionTables().ImportedTables().
+// completed. It is applied to the entity selects: agency, place, route, stop, trip, shape and
+// pathway.
 //
 // Excluded: an import still running (in_progress), and an import that failed and left rows
 // behind (success = false). Both columns are load-bearing and neither implies the other -- a
@@ -213,13 +213,27 @@ func escapeWordsWithSuffix(v string, sfx string) []string {
 // than a no-op: it is what will keep those states unreachable once they stop being
 // transactional, which is why it has to be deployed first.
 //
-// Keyed off feed_versions.id rather than the entity table, so one clause covers every
-// table: each of these selects already inner joins feed_versions on its feed_version_id.
-// Applied unconditionally, including on the active path -- a feed version being active does
-// not by itself mean its data is intact.
+// Keyed off feed_versions.id rather than the entity table, so one clause covers every table:
+// each of these selects already inner joins feed_versions on its feed_version_id. Applied
+// unconditionally, including on the active path -- a feed version being active does not by
+// itself mean its data is intact.
 //
-// Feed version and validation report selects deliberately do not use this -- they describe
-// the import itself, and must still see failed and in-progress ones.
+// Feed version and validation report selects deliberately do not use this: they describe the
+// import itself, and must still see failed and in-progress ones.
+//
+// Not yet applied everywhere it needs to be. These still read tables in
+// dmfr.GetFeedVersionTables().ImportedTables() without a gate, and must be closed before the
+// import and unimport stop being transactional:
+//
+//   - The FeedVersion child resolvers -- geometry, feed_infos, locations, location_groups,
+//     booking_rules -- and the stop_times reachable under locations. They hang off the
+//     feed version select, which is ungated by design, so nothing upstream covers them.
+//   - The operator and feed spatial filters, and the census stop buffer, which reach
+//     imported tables through feed_states or by raw entity id. These cannot use this helper
+//     as written: it keys off feed_versions.id, which is not in scope for them.
+//
+// Everything else that reads those tables is keyed by ids that can only have come from one of
+// the gated selects above.
 func joinImported(q sq.SelectBuilder) sq.SelectBuilder {
 	return q.Join("feed_version_gtfs_imports fvgi on fvgi.feed_version_id = feed_versions.id and fvgi.success and not fvgi.in_progress")
 }

--- a/server/finders/dbfinder/finder.go
+++ b/server/finders/dbfinder/finder.go
@@ -199,6 +199,31 @@ func escapeWordsWithSuffix(v string, sfx string) []string {
 	return ret
 }
 
+// joinImported restricts a select over imported entity rows to feed versions whose import
+// completed. It must be applied to every select that reads a table in
+// dmfr.GetFeedVersionTables().ImportedTables().
+//
+// Excluded: an import still running (in_progress), and an import that failed and left rows
+// behind (success = false). Both columns are load-bearing and neither implies the other -- a
+// failed import ends with in_progress = false, and an unimport runs against a feed version
+// that still has success = true.
+//
+// Today the import and unimport each run in one transaction, so their partial states are
+// already invisible and this mostly restates that guarantee. It is a prerequisite rather
+// than a no-op: it is what will keep those states unreachable once they stop being
+// transactional, which is why it has to be deployed first.
+//
+// Keyed off feed_versions.id rather than the entity table, so one clause covers every
+// table: each of these selects already inner joins feed_versions on its feed_version_id.
+// Applied unconditionally, including on the active path -- a feed version being active does
+// not by itself mean its data is intact.
+//
+// Feed version and validation report selects deliberately do not use this -- they describe
+// the import itself, and must still see failed and in-progress ones.
+func joinImported(q sq.SelectBuilder) sq.SelectBuilder {
+	return q.Join("feed_version_gtfs_imports fvgi on fvgi.feed_version_id = feed_versions.id and fvgi.success and not fvgi.in_progress")
+}
+
 func pfJoinCheck(q sq.SelectBuilder, permFilter *model.PermFilter) sq.SelectBuilder {
 	q = q.Join("feed_states fsp on fsp.feed_id = current_feeds.id").
 		Where(sq.Eq{"current_feeds.deleted_at": nil})

--- a/server/finders/dbfinder/finder_import_gate_test.go
+++ b/server/finders/dbfinder/finder_import_gate_test.go
@@ -1,0 +1,88 @@
+package dbfinder
+
+import (
+	"context"
+	"testing"
+
+	"github.com/interline-io/transitland-lib/server/dbutil"
+	"github.com/interline-io/transitland-lib/server/model"
+	"github.com/interline-io/transitland-lib/server/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A feed version whose import is incomplete must not return entities, whatever state its rows
+// happen to be in. This is the guarantee that will let import and unimport write without an
+// enclosing transaction: flipping in_progress makes their rows unreachable immediately.
+func TestFinder_ImportGate(t *testing.T) {
+	ctx := context.Background()
+
+	// Runs in a transaction that is always rolled back. The import record has to be mutated
+	// to test the gate, and the test database is shared with the other server packages that
+	// go test runs concurrently -- hiding BART from them for the duration is not an option.
+	db := testutil.MustOpenTestDB(t)
+	tx, err := db.Beginx()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback() })
+	f := NewFinder(dbutil.WithQueryLogger(tx, false, 0))
+
+	// BART, from the standard test fixtures.
+	sha1 := "e535eb2b3b9ac3ef15d82c56575e914575e732e0"
+	fvs, err := f.FindFeedVersions(ctx, nil, nil, nil, &model.FeedVersionFilter{Sha1: &sha1})
+	require.NoError(t, err)
+	require.Len(t, fvs, 1, "expected the bart test feed version")
+	fvid := fvs[0].ID
+
+	setImport := func(t *testing.T, success bool, inProgress bool) {
+		t.Helper()
+		_, err := tx.ExecContext(ctx,
+			`UPDATE feed_version_gtfs_imports SET success = $1, in_progress = $2 WHERE feed_version_id = $3`,
+			success, inProgress, fvid)
+		require.NoError(t, err)
+	}
+
+	// counts returns the entities visible for this feed version across the finders that read
+	// raw imported tables.
+	counts := func(t *testing.T) map[string]int {
+		t.Helper()
+		out := map[string]int{}
+		stops, err := f.FindStops(ctx, nil, nil, nil, &model.StopFilter{FeedVersionSha1: &sha1})
+		require.NoError(t, err)
+		out["stops"] = len(stops)
+		routes, err := f.FindRoutes(ctx, nil, nil, nil, &model.RouteFilter{FeedVersionSha1: &sha1})
+		require.NoError(t, err)
+		out["routes"] = len(routes)
+		trips, err := f.FindTrips(ctx, nil, nil, nil, &model.TripFilter{FeedVersionSha1: &sha1})
+		require.NoError(t, err)
+		out["trips"] = len(trips)
+		agencies, err := f.FindAgencies(ctx, nil, nil, nil, &model.AgencyFilter{FeedVersionSha1: &sha1})
+		require.NoError(t, err)
+		out["agencies"] = len(agencies)
+		return out
+	}
+
+	// Baseline: a completed import is visible.
+	setImport(t, true, false)
+	for k, v := range counts(t) {
+		assert.Greater(t, v, 0, "%s should be visible for a completed import", k)
+	}
+
+	// Both columns are load-bearing, and neither subsumes the other: a feed version being
+	// unimported still has success = true, and a failed import has in_progress = false.
+	for _, tc := range []struct {
+		name       string
+		success    bool
+		inProgress bool
+	}{
+		{"import in flight", false, true},
+		{"unimport in flight", true, true},
+		{"import failed", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setImport(t, tc.success, tc.inProgress)
+			for k, v := range counts(t) {
+				assert.Equal(t, 0, v, "%s must be hidden while: %s", k, tc.name)
+			}
+		})
+	}
+}

--- a/server/finders/dbfinder/pathway.go
+++ b/server/finders/dbfinder/pathway.go
@@ -124,6 +124,7 @@ func pathwaySelect(limit *int, after *model.Cursor, ids []int, permFilter *model
 	}
 
 	// Handle permissions
+	q = joinImported(q)
 	q = pfJoinCheckFv(q, permFilter)
 	return q
 }

--- a/server/finders/dbfinder/route.go
+++ b/server/finders/dbfinder/route.go
@@ -385,6 +385,7 @@ func routeSelect(limit *int, after *model.Cursor, ids []int, useActive *UseActiv
 	}
 
 	// Handle permissions
+	q = joinImported(q)
 	q = pfJoinCheckFv(q, permFilter)
 	return q
 }

--- a/server/finders/dbfinder/shape.go
+++ b/server/finders/dbfinder/shape.go
@@ -51,6 +51,7 @@ func shapeSelect(limit *int, after *model.Cursor, fvid int, permFilter *model.Pe
 			))
 		}
 	}
+	q = joinImported(q)
 	q = pfJoinCheckFv(q, permFilter)
 	return q
 }

--- a/server/finders/dbfinder/stop.go
+++ b/server/finders/dbfinder/stop.go
@@ -568,6 +568,7 @@ func stopSelect(limit *int, after *model.Cursor, ids []int, useActive *UseActive
 	}
 
 	// Handle permissions
+	q = joinImported(q)
 	q = pfJoinCheckFv(q, permFilter)
 	return q
 }

--- a/server/finders/dbfinder/trip.go
+++ b/server/finders/dbfinder/trip.go
@@ -276,6 +276,7 @@ func tripSelect(limit *int, after *model.Cursor, ids []int, active bool, permFil
 	}
 
 	// Handle permissions
+	q = joinImported(q)
 	q = pfJoinCheckFv(q, permFilter)
 	return q, nil
 }


### PR DESCRIPTION
## Summary

Adds an import gate to the entity queries: every select that reads a table written by the GTFS import now joins `feed_version_gtfs_imports` and requires `success AND NOT in_progress`. A feed version whose import is still running, or that failed and left rows behind, no longer returns stops, routes, trips, agencies, shapes, pathways or places.

This is a prerequisite, not a fix. Import and unimport each run inside a single transaction today, so their partial states are already invisible and this largely restates a guarantee that already holds. It becomes load-bearing in #695, which removes those transactions — at that point this gate is the only thing keeping partial imports and half-finished unimports unreachable. It ships separately so it can be deployed and observed on its own, and so the ordering is enforced rather than implicit: the gate has to be live before any non-transactional import runs.

### The gate

`joinImported` is applied to the seven selects that read tables in `dmfr.GetFeedVersionTables().ImportedTables()`: `agencySelect`, `placeSelect`, `routeSelect`, `stopSelect`, `tripSelect`, `shapeSelect` and `pathwaySelect`.

It is keyed off `feed_versions.id` rather than each entity table, so one clause covers every table — all seven selects already inner join `feed_versions`. Both columns are needed and neither implies the other: a failed import ends with `in_progress = false`, and an unimport runs against a feed version that still has `success = true`.

It is applied unconditionally, including on the active path. Being active does not by itself mean a feed version's data is intact, since the unimport deactivates last.

Feed version and validation report selects deliberately do not use this. They describe the import itself and must still see failed and in-progress ones — gating them would hide exactly the records you look at when an import goes wrong.

## Test plan

`TestFinder_ImportGate` drives a feed version's import record through all three unsafe states — in-flight import, in-flight unimport, and failed import — and asserts stops, routes, trips and agencies all return zero, with a baseline assertion that they are non-zero for a completed import so it cannot pass trivially.

Before deploying, confirm the gate hides nothing currently being served. An inner join fails closed and silently, so this should return zero against production:

    SELECT count(*)
    FROM feed_versions fv
    JOIN LATERAL (SELECT 1 FROM gtfs_stops WHERE feed_version_id = fv.id LIMIT 1) s ON true
    LEFT JOIN feed_version_gtfs_imports fvgi ON fvgi.feed_version_id = fv.id
    WHERE fvgi.id IS NULL OR NOT fvgi.success OR fvgi.in_progress;

Anything it counts is data being served today that this PR will stop serving.

Worth an `EXPLAIN` on the hottest `stops(where:{near:...})` query as well, since the planner gains a new relation it could choose to drive from.

