### PR TITLE
Remove long txn from import

### DIFF
--- a/cmds/import_cmd.go
+++ b/cmds/import_cmd.go
@@ -327,8 +327,8 @@ func dmfrImportWorker(ctx context.Context, adapter tldb.Adapter, dryrun bool, jo
 		result, err := importer.ImportFeedVersion(jobCtx, feedmanager.NewDBFeedManager(adapter), opts)
 		t2 := float64(time.Now().UnixNano()-t.UnixNano()) / 1e9 // 1000000000.0
 		if err != nil && result.FeedVersionImport.Success {
-			// The import itself committed and is visible; only activation failed. Telling the
-			// operator to unimport here would destroy a good import.
+			// Import committed and is visible; only activation failed -- an unimport here would
+			// destroy a good import.
 			jobLog.Error().Err(err).Float64("duration", t2).Msg("imported, but could not be activated; it is not the active feed version")
 		} else if err != nil {
 			jobLog.Error().Err(err).Float64("duration", t2).Msg("critical failure, partial state left hidden; unimport the feed version to remove it")

--- a/cmds/import_cmd.go
+++ b/cmds/import_cmd.go
@@ -326,8 +326,12 @@ func dmfrImportWorker(ctx context.Context, adapter tldb.Adapter, dryrun bool, jo
 		t := time.Now()
 		result, err := importer.ImportFeedVersion(jobCtx, feedmanager.NewDBFeedManager(adapter), opts)
 		t2 := float64(time.Now().UnixNano()-t.UnixNano()) / 1e9 // 1000000000.0
-		if err != nil {
-			jobLog.Error().Err(err).Float64("duration", t2).Msg("critical failure, rolled back")
+		if err != nil && result.FeedVersionImport.Success {
+			// The import itself committed and is visible; only activation failed. Telling the
+			// operator to unimport here would destroy a good import.
+			jobLog.Error().Err(err).Float64("duration", t2).Msg("imported, but could not be activated; it is not the active feed version")
+		} else if err != nil {
+			jobLog.Error().Err(err).Float64("duration", t2).Msg("critical failure, partial state left hidden; unimport the feed version to remove it")
 		} else if result.FeedVersionImport.Success {
 			jobLog.Info().
 				Float64("duration", t2).

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -127,7 +127,7 @@ func ImportFeedVersion(ctx context.Context, fm feedmanager.FeedManager, opts Opt
 	if opts.Activate {
 		log.For(ctx).Info().Msgf("Activating feed version")
 		if err := fm.ActivateFeedVersion(ctx, fv.ID); err != nil {
-			return Result{FeedVersionImport: fviresult}, fmt.Errorf("error activating feed version: %s", err.Error())
+			return Result{FeedVersionImport: fviresult}, fmt.Errorf("error activating feed version: %w", err)
 		}
 	}
 	return Result{FeedVersionImport: fviresult}, nil

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -113,8 +113,12 @@ func ImportFeedVersion(ctx context.Context, fm feedmanager.FeedManager, opts Opt
 	fviresult.InProgress = false
 	fviresult.ExceptionLog = ""
 	if err := fm.UpdateFeedVersionImport(finishCtx, &fviresult); err != nil {
-		// Serious error
+		// The finalize did not persist, so the record is still success=false, in_progress=true:
+		// the import stays hidden and needs an unimport. Report that state rather than the success
+		// we failed to write.
 		log.For(ctx).Error().Msgf("Error saving FeedVersionImport: %s", err.Error())
+		fviresult.Success = false
+		fviresult.InProgress = true
 		return Result{FeedVersionImport: fviresult}, err
 	}
 

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -43,9 +43,11 @@ func ActivateFeedVersion(ctx context.Context, atx tldb.Adapter, fvid int) error 
 	return feedmanager.NewDBFeedManager(atx).ActivateFeedVersion(ctx, fvid)
 }
 
-// ImportFeedVersion create FVI and run Copier inside a Tx. The FeedManager
-// supplies the metadata bookkeeping and entity-write sink; pass
+// ImportFeedVersion creates the import record and runs the Copier. Pass
 // feedmanager.NewDBFeedManager(adapter) for the database backend.
+//
+// The copy is not transactional; a failure leaves the rows the copier wrote, hidden behind a
+// failed import record. Activation, when requested, runs afterwards in its own transaction.
 func ImportFeedVersion(ctx context.Context, fm feedmanager.FeedManager, opts Options) (Result, error) {
 	// Get FV
 	importSource := opts.ImportSource
@@ -63,6 +65,8 @@ func ImportFeedVersion(ctx context.Context, fm feedmanager.FeedManager, opts Opt
 		// Serious error
 		return Result{FeedVersionImport: fvi}, err
 	} else if existing != nil {
+		// Any existing import record blocks a reimport -- including one left by a failed or
+		// crashed import -- so unimport must run first.
 		fvi.ExceptionLog = "FeedVersionImport record already exists, skipping"
 		return Result{FeedVersionImport: fvi}, nil
 	}
@@ -72,49 +76,55 @@ func ImportFeedVersion(ctx context.Context, fm feedmanager.FeedManager, opts Opt
 		log.For(ctx).Error().Msgf("Error creating FeedVersionImport: %s", err.Error())
 		return Result{FeedVersionImport: fvi}, err
 	}
-	// Import
-	fviresult := dmfr.FeedVersionImport{} // keep result
-	errImport := fm.WithTx(ctx, func(ctx context.Context, tx feedmanager.FeedManager) error {
-		var err error
-		fviresult, err = importFeedVersionTx(ctx, tx, *fv, opts)
-		if err != nil {
-			return err
-		}
-		// Update route_stops, agency_geometries, etc...
-		log.For(ctx).Info().Msgf("Finalizing import")
-		if opts.Activate {
-			log.For(ctx).Info().Msgf("Activating feed version")
-			if err := tx.ActivateFeedVersion(ctx, fv.ID); err != nil {
-				return fmt.Errorf("error activating feed version: %s", err.Error())
-			}
-		}
-		// Update FVI with results, inside tx
-		fviresult.ID = fvi.ID
-		fviresult.CreatedAt = fvi.CreatedAt
-		fviresult.FeedVersionID = fv.ID
-		fviresult.ImportSource = fvi.ImportSource
-		fviresult.ImportLevel = 4
-		fviresult.Success = true
-		fviresult.InProgress = false
-		fviresult.ExceptionLog = ""
-		if err := tx.UpdateFeedVersionImport(ctx, &fviresult); err != nil {
-			// Serious error
-			log.For(ctx).Error().Msgf("Error saving FeedVersionImport: %s", err.Error())
-			return err
-		}
-		return err
-	})
-	// FVI error handling has to be outside of above tx, which will have aborted
+	// No enclosing transaction: one spanning millions of entity rows would hold its snapshot
+	// open for the whole import, pinning the xmin horizon and stopping autovacuum from
+	// reclaiming dead tuples database-wide.
+	fviresult, errImport := importFeedVersion(ctx, fm, *fv, opts)
+
+	// The import record is what hides a partial import, so it has to be written even when ctx is
+	// already cancelled -- a client disconnecting mid-import is the common way that happens. On the
+	// cancelled ctx these updates would fail too, leaving the record marked in progress forever:
+	// invisible, and refused by unimport as an import still in flight.
+	finishCtx := context.WithoutCancel(ctx)
+
 	if errImport != nil {
+		// Rows the copier already wrote stay in place; recording the import as failed keeps them
+		// hidden from entity queries until an unimport removes them.
 		fvi.Success = false
 		fvi.InProgress = false
 		fvi.ExceptionLog = errImport.Error()
-		if err := fm.UpdateFeedVersionImport(ctx, &fvi); err != nil {
+		if err := fm.UpdateFeedVersionImport(finishCtx, &fvi); err != nil {
 			// Serious error
 			log.For(ctx).Error().Msgf("Error saving FeedVersionImport: %s", err.Error())
 			return Result{FeedVersionImport: fvi}, err
 		}
 		return Result{FeedVersionImport: fvi}, errImport
+	}
+
+	// This update sets success and clears in_progress, which is what makes this feed version's
+	// data visible.
+	log.For(ctx).Info().Msgf("Finalizing import")
+	fviresult.ID = fvi.ID
+	fviresult.CreatedAt = fvi.CreatedAt
+	fviresult.FeedVersionID = fv.ID
+	fviresult.ImportSource = fvi.ImportSource
+	fviresult.ImportLevel = 4
+	fviresult.Success = true
+	fviresult.InProgress = false
+	fviresult.ExceptionLog = ""
+	if err := fm.UpdateFeedVersionImport(finishCtx, &fviresult); err != nil {
+		// Serious error
+		log.For(ctx).Error().Msgf("Error saving FeedVersionImport: %s", err.Error())
+		return Result{FeedVersionImport: fviresult}, err
+	}
+
+	// Activation is its own transaction: a failure here leaves the feed version imported but not
+	// active, rather than undoing a good import.
+	if opts.Activate {
+		log.For(ctx).Info().Msgf("Activating feed version")
+		if err := fm.ActivateFeedVersion(ctx, fv.ID); err != nil {
+			return Result{FeedVersionImport: fviresult}, fmt.Errorf("error activating feed version: %s", err.Error())
+		}
 	}
 	return Result{FeedVersionImport: fviresult}, nil
 }
@@ -123,10 +133,9 @@ type canSetAllowPartial interface {
 	SetAllowPartial(bool)
 }
 
-// importFeedVersion runs the Copier from the feed version's reader into the
-// entity sink, both vended by the FeedManager (transaction-bound on a SQL
-// backend), returning the import counts.
-func importFeedVersionTx(ctx context.Context, fm feedmanager.FeedManager, fv dmfr.FeedVersion, opts Options) (dmfr.FeedVersionImport, error) {
+// importFeedVersion runs the Copier from the feed version's reader into the entity sink,
+// returning the import counts.
+func importFeedVersion(ctx context.Context, fm feedmanager.FeedManager, fv dmfr.FeedVersion, opts Options) (dmfr.FeedVersionImport, error) {
 	fvi := dmfr.FeedVersionImport{}
 	fvi.FeedVersionID = fv.ID
 	// Get Reader

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -65,8 +65,8 @@ func ImportFeedVersion(ctx context.Context, fm feedmanager.FeedManager, opts Opt
 		// Serious error
 		return Result{FeedVersionImport: fvi}, err
 	} else if existing != nil {
-		// Any existing import record blocks a reimport -- including one left by a failed or
-		// crashed import -- so unimport must run first.
+		// An existing record -- including one left by a failed or crashed import -- blocks reimport
+		// until an unimport clears it.
 		fvi.ExceptionLog = "FeedVersionImport record already exists, skipping"
 		return Result{FeedVersionImport: fvi}, nil
 	}
@@ -76,33 +76,27 @@ func ImportFeedVersion(ctx context.Context, fm feedmanager.FeedManager, opts Opt
 		log.For(ctx).Error().Msgf("Error creating FeedVersionImport: %s", err.Error())
 		return Result{FeedVersionImport: fvi}, err
 	}
-	// No enclosing transaction: one spanning millions of entity rows would hold its snapshot
-	// open for the whole import, pinning the xmin horizon and stopping autovacuum from
-	// reclaiming dead tuples database-wide.
+	// No enclosing transaction: one spanning the whole entity copy would pin the xmin horizon and
+	// stall autovacuum database-wide.
 	fviresult, errImport := importFeedVersion(ctx, fm, *fv, opts)
 
-	// The import record is what hides a partial import, so it has to be written even when ctx is
-	// already cancelled -- a client disconnecting mid-import is the common way that happens. On the
-	// cancelled ctx these updates would fail too, leaving the record marked in progress forever:
-	// invisible, and refused by unimport as an import still in flight.
+	// Finalize under WithoutCancel: a cancelled caller ctx (commonly a client disconnect) must not
+	// strand the record in_progress, which would leave it hidden and refused by unimport.
 	finishCtx := context.WithoutCancel(ctx)
 
 	if errImport != nil {
-		// Rows the copier already wrote stay in place; recording the import as failed keeps them
-		// hidden from entity queries until an unimport removes them.
+		// A failed record keeps the copied rows hidden until an unimport removes them.
 		fvi.Success = false
 		fvi.InProgress = false
 		fvi.ExceptionLog = errImport.Error()
 		if err := fm.UpdateFeedVersionImport(finishCtx, &fvi); err != nil {
-			// Serious error
 			log.For(ctx).Error().Msgf("Error saving FeedVersionImport: %s", err.Error())
 			return Result{FeedVersionImport: fvi}, err
 		}
 		return Result{FeedVersionImport: fvi}, errImport
 	}
 
-	// This update sets success and clears in_progress, which is what makes this feed version's
-	// data visible.
+	// success and cleared in_progress is what makes the feed version's data visible.
 	log.For(ctx).Info().Msgf("Finalizing import")
 	fviresult.ID = fvi.ID
 	fviresult.CreatedAt = fvi.CreatedAt
@@ -113,16 +107,15 @@ func ImportFeedVersion(ctx context.Context, fm feedmanager.FeedManager, opts Opt
 	fviresult.InProgress = false
 	fviresult.ExceptionLog = ""
 	if err := fm.UpdateFeedVersionImport(finishCtx, &fviresult); err != nil {
-		// The finalize did not persist, so the record is still success=false, in_progress=true:
-		// the import stays hidden and needs an unimport. Report that state rather than the success
-		// we failed to write.
+		// Finalize did not persist: the record is still in_progress and hidden, so report that
+		// state (needs an unimport) rather than the success we failed to write.
 		log.For(ctx).Error().Msgf("Error saving FeedVersionImport: %s", err.Error())
 		fviresult.Success = false
 		fviresult.InProgress = true
 		return Result{FeedVersionImport: fviresult}, err
 	}
 
-	// Activation is its own transaction: a failure here leaves the feed version imported but not
+	// Activation runs in its own transaction: a failure leaves the feed version imported but not
 	// active, rather than undoing a good import.
 	if opts.Activate {
 		log.For(ctx).Info().Msgf("Activating feed version")

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -105,19 +105,17 @@ func TestImportFeedVersion(t *testing.T) {
 	})
 }
 
-// A failed import leaves behind the rows the copier already wrote: ImportFeedVersion neither
-// rolls them back nor removes them, and the failed import record is what keeps them out of
-// entity queries. TestImportFeedVersion/Failed cannot cover this: it fails on a missing file,
-// before the copier writes anything.
+// A failed import leaves the copied rows in place -- not rolled back, kept out of entity queries
+// only by the failed import record. TestImportFeedVersion/Failed can't cover this: it fails on a
+// missing file, before the copier writes anything.
 func TestImportFeedVersion_FailedImportLeavesRows(t *testing.T) {
 	ctx := context.TODO()
-	// Not TempSqlite: that runs the callback inside a transaction, which is the thing this
-	// import no longer has.
+	// Not TempSqlite: it runs inside a transaction, the thing this import no longer has.
 	atx := testdb.TempSqliteAdapter()
 	fv := testdb.CreateTestFeedVersion(atx, testreader.ExampleZip.URL)
 
-	// A negative threshold can never be met, and it is checked after the copier runs, so the
-	// import fails with every entity already written.
+	// A negative threshold can never be met and is checked after the copy, so the import fails
+	// with every entity already written.
 	if _, err := ImportFeedVersion(ctx, feedmanager.NewDBFeedManager(atx), Options{
 		FeedVersionID:  fv.ID,
 		Storage:        "/",
@@ -140,24 +138,20 @@ func TestImportFeedVersion_FailedImportLeavesRows(t *testing.T) {
 	}
 }
 
-// A caller's context can be cancelled mid-import -- most often a client disconnecting on the
-// GraphQL path. The finalize writes run under context.WithoutCancel so they still commit: the
-// import record must not be stranded in_progress, which would hide it and refuse a reimport.
+// A cancelled caller ctx (commonly a client disconnect) must not strand the import record
+// in_progress: the finalize writes run under context.WithoutCancel so they still commit.
 func TestImportFeedVersion_CancelledContextStillFinalizes(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	atx := testdb.TempSqliteAdapter()
 	fv := testdb.CreateTestFeedVersion(atx, testreader.ExampleZip.URL)
 
-	// Cancel as soon as the record exists, so the context is already cancelled by the time the
-	// import reaches its finalize write.
+	// Cancel once the record exists, so ctx is already cancelled at the finalize write.
 	fm := &cancelOnCreateFeedManager{DBFeedManager: feedmanager.NewDBFeedManager(atx), cancel: cancel}
 	if _, err := ImportFeedVersion(ctx, fm, Options{FeedVersionID: fv.ID, Storage: "/"}); err != nil {
 		t.Fatalf("import should finalize under a cancelled context, got: %v", err)
 	}
 
-	// The finalize ran under context.WithoutCancel, so the record is flipped out of in_progress
-	// and the import is visible. Without that, the cancelled context would fail the write and
-	// strand it in_progress.
+	// Finalized out of in_progress despite the cancelled ctx: WithoutCancel let the write commit.
 	fvi := dmfr.FeedVersionImport{}
 	testdb.ShouldGet(t, atx, &fvi, "SELECT * FROM feed_version_gtfs_imports WHERE feed_version_id = ?", fv.ID)
 	if fvi.InProgress || !fvi.Success {

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -105,7 +105,42 @@ func TestImportFeedVersion(t *testing.T) {
 	})
 }
 
-func Test_iImportFeedVersionTx(t *testing.T) {
+// A failed import leaves behind the rows the copier already wrote: ImportFeedVersion neither
+// rolls them back nor removes them, and the failed import record is what keeps them out of
+// entity queries. TestImportFeedVersion/Failed cannot cover this: it fails on a missing file,
+// before the copier writes anything.
+func TestImportFeedVersion_FailedImportLeavesRows(t *testing.T) {
+	ctx := context.TODO()
+	// Not TempSqlite: that runs the callback inside a transaction, which is the thing this
+	// import no longer has.
+	atx := testdb.TempSqliteAdapter()
+	fv := testdb.CreateTestFeedVersion(atx, testreader.ExampleZip.URL)
+
+	// A negative threshold can never be met, and it is checked after the copier runs, so the
+	// import fails with every entity already written.
+	if _, err := ImportFeedVersion(ctx, feedmanager.NewDBFeedManager(atx), Options{
+		FeedVersionID:  fv.ID,
+		Storage:        "/",
+		ErrorThreshold: map[string]float64{"*": -1},
+	}); err == nil {
+		t.Fatal("expected the import to fail on the error threshold")
+	}
+
+	// Entity queries gate on success and in_progress, so check them as stored.
+	fvi := dmfr.FeedVersionImport{}
+	testdb.ShouldGet(t, atx, &fvi, "SELECT * FROM feed_version_gtfs_imports WHERE feed_version_id = ?", fv.ID)
+	if fvi.Success || fvi.InProgress {
+		t.Errorf("stored import record is success=%v in_progress=%v, want false/false", fvi.Success, fvi.InProgress)
+	}
+
+	count := 0
+	testdb.ShouldGet(t, atx, &count, "SELECT count(*) FROM gtfs_stops WHERE feed_version_id = ?", fv.ID)
+	if count == 0 {
+		t.Error("expected the failed import to leave its stops behind")
+	}
+}
+
+func Test_importFeedVersion(t *testing.T) {
 	ctx := context.TODO()
 	err := testdb.TempSqlite(func(atx tldb.Adapter) error {
 		// Create FV
@@ -115,7 +150,7 @@ func Test_iImportFeedVersionTx(t *testing.T) {
 		fvid := testdb.ShouldInsert(t, atx, &fv)
 		fv.ID = fvid // TODO: ?? Should be set by canSetID
 		// Import
-		fviresult, err := importFeedVersionTx(ctx, feedmanager.NewDBFeedManager(atx), fv, Options{Storage: "/"})
+		fviresult, err := importFeedVersion(ctx, feedmanager.NewDBFeedManager(atx), fv, Options{Storage: "/"})
 		if err != nil {
 			t.Error(err)
 		}

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -140,6 +140,44 @@ func TestImportFeedVersion_FailedImportLeavesRows(t *testing.T) {
 	}
 }
 
+// A caller's context can be cancelled mid-import -- most often a client disconnecting on the
+// GraphQL path. The finalize writes run under context.WithoutCancel so they still commit: the
+// import record must not be stranded in_progress, which would hide it and refuse a reimport.
+func TestImportFeedVersion_CancelledContextStillFinalizes(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	atx := testdb.TempSqliteAdapter()
+	fv := testdb.CreateTestFeedVersion(atx, testreader.ExampleZip.URL)
+
+	// Cancel as soon as the record exists, so the context is already cancelled by the time the
+	// import reaches its finalize write.
+	fm := &cancelOnCreateFeedManager{DBFeedManager: feedmanager.NewDBFeedManager(atx), cancel: cancel}
+	if _, err := ImportFeedVersion(ctx, fm, Options{FeedVersionID: fv.ID, Storage: "/"}); err != nil {
+		t.Fatalf("import should finalize under a cancelled context, got: %v", err)
+	}
+
+	// The finalize ran under context.WithoutCancel, so the record is flipped out of in_progress
+	// and the import is visible. Without that, the cancelled context would fail the write and
+	// strand it in_progress.
+	fvi := dmfr.FeedVersionImport{}
+	testdb.ShouldGet(t, atx, &fvi, "SELECT * FROM feed_version_gtfs_imports WHERE feed_version_id = ?", fv.ID)
+	if fvi.InProgress || !fvi.Success {
+		t.Errorf("stored record is success=%v in_progress=%v, want true/false; finalize did not survive cancellation", fvi.Success, fvi.InProgress)
+	}
+}
+
+// cancelOnCreateFeedManager cancels the import context the moment the import record is created,
+// standing in for a client that disconnects mid-import.
+type cancelOnCreateFeedManager struct {
+	*feedmanager.DBFeedManager
+	cancel context.CancelFunc
+}
+
+func (m *cancelOnCreateFeedManager) CreateFeedVersionImport(ctx context.Context, fvi *dmfr.FeedVersionImport) (int, error) {
+	id, err := m.DBFeedManager.CreateFeedVersionImport(ctx, fvi)
+	m.cancel()
+	return id, err
+}
+
 func Test_importFeedVersion(t *testing.T) {
 	ctx := context.TODO()
 	err := testdb.TempSqlite(func(atx tldb.Adapter) error {

--- a/internal/feedstate/manager.go
+++ b/internal/feedstate/manager.go
@@ -14,7 +14,10 @@ import (
 )
 
 // Manager handles feed state and materialized table operations
-// NOTE: Methods do NOT handle transactions - the caller must manage transactions
+//
+// ActivateFeedVersion and DeactivateFeedVersion are self-transactional, joining the caller's
+// transaction if one is open, and SetActiveFeedVersions transacts per feed version through them.
+// Other methods leave transactions to the caller.
 type Manager struct {
 	adapter tldb.Adapter
 }
@@ -28,7 +31,16 @@ func NewManager(adapter tldb.Adapter) *Manager {
 
 // ActivateFeedVersion activates a feed version by setting it in feed_states and adding to materialized tables
 // If another version of the same feed is currently active, it will be deactivated first
+//
+// Runs in a transaction: the feed_states swap and materialized table rebuild must not be
+// observed half done.
 func (m *Manager) ActivateFeedVersion(ctx context.Context, feedVersionID int) error {
+	return m.adapter.Tx(func(atx tldb.Adapter) error {
+		return (&Manager{adapter: atx}).activateFeedVersion(ctx, feedVersionID)
+	})
+}
+
+func (m *Manager) activateFeedVersion(ctx context.Context, feedVersionID int) error {
 	// Get the feed_id for this feed version
 	feedID, err := m.GetFeedIDForFeedVersion(ctx, feedVersionID)
 	if err != nil {
@@ -58,7 +70,7 @@ func (m *Manager) ActivateFeedVersion(ctx context.Context, feedVersionID int) er
 			Int("new_feed_version_id", feedVersionID).
 			Int("feed_id", feedID).
 			Msg("Deactivating current feed version before activating new one")
-		if err := m.DeactivateFeedVersion(ctx, currentFeedVersionID); err != nil {
+		if err := m.deactivateFeedVersion(ctx, currentFeedVersionID); err != nil {
 			return fmt.Errorf("failed to deactivate current feed version %d: %w", currentFeedVersionID, err)
 		}
 	}
@@ -90,6 +102,12 @@ func (m *Manager) ActivateFeedVersion(ctx context.Context, feedVersionID int) er
 // DeactivateFeedVersion deactivates a feed version by removing it from feed_states and materialized tables
 // If the feed version is not currently active, does nothing
 func (m *Manager) DeactivateFeedVersion(ctx context.Context, feedVersionID int) error {
+	return m.adapter.Tx(func(atx tldb.Adapter) error {
+		return (&Manager{adapter: atx}).deactivateFeedVersion(ctx, feedVersionID)
+	})
+}
+
+func (m *Manager) deactivateFeedVersion(ctx context.Context, feedVersionID int) error {
 	// Get the feed_id for this feed version
 	feedID, err := m.GetFeedIDForFeedVersion(ctx, feedVersionID)
 	if err != nil {

--- a/internal/testdb/testdb.go
+++ b/internal/testdb/testdb.go
@@ -2,12 +2,16 @@ package testdb
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/interline-io/transitland-lib/dmfr"
 	"github.com/interline-io/transitland-lib/tldb"
 	"github.com/interline-io/transitland-lib/tldb/postgres"
 	"github.com/interline-io/transitland-lib/tldb/sqlite"
+	"github.com/interline-io/transitland-lib/tt"
 )
 
 func MustOpenWriter(dburl string, create bool) *tldb.Writer {
@@ -166,3 +170,21 @@ func CreateTestFeed(atx tldb.Adapter, url string) dmfr.Feed {
 	tlfeed.ID = MustInsert(atx, &tlfeed)
 	return tlfeed
 }
+
+// CreateTestFeedVersion returns a feed version, and the feed that owns it, inserted into a
+// database.
+//
+// The feed is named uniquely per call rather than after the test: TempPostgres commits, and
+// current_feeds.onestop_id is unique, so a stable name would wedge every run after the first.
+func CreateTestFeedVersion(atx tldb.Adapter, file string) dmfr.FeedVersion {
+	name := fmt.Sprintf("%d-%d", time.Now().UnixNano(), testFeedSeq.Add(1))
+	feed := CreateTestFeed(atx, "feed-"+name)
+	fv := dmfr.FeedVersion{SHA1: name, File: file}
+	fv.FeedID = feed.ID
+	fv.EarliestCalendarDate = tt.NewDate(time.Now())
+	fv.LatestCalendarDate = tt.NewDate(time.Now())
+	fv.ID = MustInsert(atx, &fv)
+	return fv
+}
+
+var testFeedSeq atomic.Int64

--- a/internal/testdb/testdb.go
+++ b/internal/testdb/testdb.go
@@ -174,8 +174,8 @@ func CreateTestFeed(atx tldb.Adapter, url string) dmfr.Feed {
 // CreateTestFeedVersion inserts a feed version and its owning feed into a database, returning
 // the feed version.
 //
-// The feed is named uniquely per call rather than after the test: TempPostgres commits, and
-// current_feeds.onestop_id is unique, so a stable name would wedge every run after the first.
+// The feed is named uniquely per call: TempPostgres commits and current_feeds.onestop_id is
+// unique, so a stable name would wedge reruns.
 func CreateTestFeedVersion(atx tldb.Adapter, file string) dmfr.FeedVersion {
 	name := fmt.Sprintf("%d-%d", time.Now().UnixNano(), testFeedSeq.Add(1))
 	feed := CreateTestFeed(atx, "feed-"+name)

--- a/internal/testdb/testdb.go
+++ b/internal/testdb/testdb.go
@@ -171,8 +171,8 @@ func CreateTestFeed(atx tldb.Adapter, url string) dmfr.Feed {
 	return tlfeed
 }
 
-// CreateTestFeedVersion returns a feed version, and the feed that owns it, inserted into a
-// database.
+// CreateTestFeedVersion inserts a feed version and its owning feed into a database, returning
+// the feed version.
 //
 // The feed is named uniquely per call rather than after the test: TempPostgres commits, and
 // current_feeds.onestop_id is unique, so a stable name would wedge every run after the first.


### PR DESCRIPTION
## Summary

Import no longer wraps the entity copy in a single transaction. A GTFS import writes millions of rows, and holding one transaction open across all of them pins the Postgres `xmin` horizon for the life of the import, which stalls autovacuum database-wide — with imports running continuously, dead tuples are never reclaimed and the database bloats. This PR removes that transaction: the import record is committed with `in_progress = true` before the copy starts, the copy commits as it goes, and the record is finalized to `success = true` afterwards. Partial and failed imports are kept out of entity queries by the `feed_version_gtfs_imports` visibility gate from #696, so nothing incomplete is ever returned even though it is no longer rolled back. This is the first of two PRs; unimport and delete are unchanged and remain single-transaction.

### Non-transactional import

- The copy runs outside any transaction. The record is created `in_progress = true` and committed first, so the gate hides the feed version for the whole copy; it is flipped to `success = true` only once every entity is written.
- A failed import leaves the rows the copier already wrote in place, recorded `success = false, in_progress = false` and therefore hidden. They are not rolled back and not auto-removed; an `unimport` reclaims them.
- A crash mid-import leaves the record at `in_progress = true`: hidden, and cleaned up by a later unimport.
- Activation, when requested, runs afterwards in its own transaction, so a failed activation leaves a good, visible import that simply is not the active version, rather than undoing the import.

### Cancelled-context safety

- The two writes that finalize the import record use `context.WithoutCancel`, so they still commit when the caller's context is already cancelled — most commonly a client disconnecting mid-import on the GraphQL path. Without this the record would be stranded at `in_progress = true`, invisible and needing a manual unimport.

### Atomic activation

- `feedstate.Manager.ActivateFeedVersion` and `DeactivateFeedVersion` are now self-transactional, wrapping their `feed_states` swap and materialized-table rebuild in a transaction and joining the caller's if one is open. Activation used to be atomic by virtue of running inside the import transaction; now that that transaction is gone, activation carries its own.

### Import worker logging

- An import that succeeded but failed to activate no longer logs "critical failure, rolled back" or tells the operator to unimport — that would destroy a good, visible import. It now reports that the feed version is imported but not active. A genuine import failure still directs the operator to unimport the hidden partial state.

### Downstream contract

- Because a failed import now leaves hidden rows, anything that removes a `feed_version_gtfs_imports` record directly must instead unimport the feed version. Deleting the record alone orphans those rows: the gate needs the record to hide them, so they become permanently invisible, and a re-import then collides with them on the `(feed_version_id, stop_id)` unique index. Reaping stalled or failed imports should select unsuccessful records old enough to be safe and run `unimport`, which removes the rows and the record together.

## Test plan

- `TestImportFeedVersion_FailedImportLeavesRows` drives an import to fail after the copier has written entities (a negative error threshold, checked after the copy) and asserts the rows survive and the record is stored `success=false, in_progress=false`. It runs on a non-transactional adapter, since the property under test is that there is no enclosing transaction.
- Run a real import against Postgres, kill the process mid-copy, and confirm the feed version does not appear in entity queries and its record is left `in_progress = true`; then `unimport` it and confirm the rows are gone.
- Import a feed version with activation requested, force activation to fail, and confirm the import record is `success = true` with the entities visible, and that the worker logs the imported-but-not-active message rather than a rollback.
