### PR TITLE
Separate active from materialized feed state pointers

### DIFF
--- a/cmds/feed_state_cmd.go
+++ b/cmds/feed_state_cmd.go
@@ -122,32 +122,29 @@ func (cmd *FeedStateManagerCommand) Run(ctx context.Context) error {
 
 	// Execute in transaction
 	return cmd.Adapter.Tx(func(atx tldb.Adapter) error {
-		// Get current active feed versions to determine sync operations
-		log.Info().Msg("Getting current active feed versions")
 		txManager := feedstate.NewManager(atx)
-		activeFeedVersions, err := txManager.GetActiveFeedVersions(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to get active feed versions: %w", err)
-		}
-		activeSet := toSet(activeFeedVersions)
 
-		// Sync active feed versions to materialized tables
+		// Sync materialized tables to the feeds that should be materialized
+		// (materialized_feed_version_id), which excludes globally-hidden feeds.
 		if cmd.SyncActive {
-			log.For(ctx).Info().Msg("Getting materialized feed versions to sync active feed versions")
-			var materializedFeedVersions []int
-			materializedFeedVersions, err = txManager.GetMaterializedFeedVersions(ctx)
+			log.For(ctx).Info().Msg("Syncing materialized tables to materialized feed versions")
+			targetPointers, err := txManager.GetMaterializedFeedVersionPointers(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to get materialized feed version pointers: %w", err)
+			}
+			targetSet := toSet(targetPointers)
+			materializedFeedVersions, err := txManager.GetMaterializedFeedVersions(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to get materialized feed versions: %w", err)
 			}
-			// Determine which feed versions to materialize and dematerialize
 			materializedSet := toSet(materializedFeedVersions)
-			for fvid := range activeSet {
+			for fvid := range targetSet {
 				if !materializedSet[fvid] {
 					forceMaterializeIDs = append(forceMaterializeIDs, fvid)
 				}
 			}
 			for fvid := range materializedSet {
-				if !activeSet[fvid] {
+				if !targetSet[fvid] {
 					forceDematerializeIDs = append(forceDematerializeIDs, fvid)
 				}
 			}

--- a/dmfr/feed_state.go
+++ b/dmfr/feed_state.go
@@ -6,15 +6,19 @@ import (
 	"github.com/interline-io/transitland-lib/tt"
 )
 
-// FeedState stores a pointer to the active FeedVersion and values that control feed fetch and permissions.
+// FeedState holds a feed's active and materialized feed version pointers, its
+// global-query visibility, and values that control feed fetch and permissions.
 type FeedState struct {
-	FeedID              int
-	FeedVersionID       tt.Int
-	FeedPriority        tt.Int
-	FetchWait           tt.Int
-	FeedRealtimeEnabled bool
-	Public              bool
-	RTRetentionPeriod   int // days to retain archived RT messages; 0 disables
+	FeedID                    int
+	FeedVersionID             tt.Int // transitional mirror of MaterializedFeedVersionID
+	ActiveFeedVersionID       tt.Int // current version for retention/lifecycle; set even when excluded
+	MaterializedFeedVersionID tt.Int // visible/materialized version; null when excluded from global
+	ExcludeFromGlobal         bool   // keep this feed out of default global results and materialized tables
+	FeedPriority              tt.Int
+	FetchWait                 tt.Int
+	FeedRealtimeEnabled       bool
+	Public                    bool
+	RTRetentionPeriod         int // days to retain archived RT messages; 0 disables
 	tt.DatabaseEntity
 	tt.Timestamps
 }

--- a/internal/feedstate/manager.go
+++ b/internal/feedstate/manager.go
@@ -2,6 +2,8 @@ package feedstate
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -10,6 +12,7 @@ import (
 	"github.com/interline-io/log"
 	"github.com/interline-io/transitland-lib/server/dbutil"
 	"github.com/interline-io/transitland-lib/tldb"
+	"github.com/interline-io/transitland-lib/tt"
 	sq "github.com/irees/squirrel"
 )
 
@@ -41,61 +44,78 @@ func (m *Manager) ActivateFeedVersion(ctx context.Context, feedVersionID int) er
 }
 
 func (m *Manager) activateFeedVersion(ctx context.Context, feedVersionID int) error {
-	// Get the feed_id for this feed version
 	feedID, err := m.GetFeedIDForFeedVersion(ctx, feedVersionID)
 	if err != nil {
 		return fmt.Errorf("failed to get feed_id for feed version %d: %w", feedVersionID, err)
 	}
-
-	// Get current feed states to check if this feed version is already active
-	feedStates, err := m.getActiveFeedStates(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get active feed states: %w", err)
-	}
-
-	// If this feed version is already active, do nothing
-	currentFeedVersionID, feedIsActive := feedStates[feedID]
-	if feedIsActive && currentFeedVersionID == feedVersionID {
-		log.For(ctx).Info().
-			Int("feed_version_id", feedVersionID).
-			Int("feed_id", feedID).
-			Msg("Feed version is already active")
-		return nil
-	}
-
-	// If another version is active, deactivate it first
-	if feedIsActive {
-		log.For(ctx).Info().
-			Int("old_feed_version_id", currentFeedVersionID).
-			Int("new_feed_version_id", feedVersionID).
-			Int("feed_id", feedID).
-			Msg("Deactivating current feed version before activating new one")
-		if err := m.deactivateFeedVersion(ctx, currentFeedVersionID); err != nil {
-			return fmt.Errorf("failed to deactivate current feed version %d: %w", currentFeedVersionID, err)
-		}
-	}
-
-	// Activate the new feed version
 	log.For(ctx).Info().
 		Int("feed_version_id", feedVersionID).
 		Int("feed_id", feedID).
 		Msg("Activating feed version")
+	return m.reconcileFeed(ctx, feedID, tt.NewInt(feedVersionID))
+}
 
-	// Set in feed_states using Squirrel
+// feedStatePointers is the pointer/visibility state the reconciler derives from.
+type feedStatePointers struct {
+	ActiveFeedVersionID       tt.Int `db:"active_feed_version_id"`
+	MaterializedFeedVersionID tt.Int `db:"materialized_feed_version_id"`
+	ExcludeFromGlobal         bool   `db:"exclude_from_global"`
+}
+
+func (m *Manager) getFeedStatePointers(ctx context.Context, feedID int) (feedStatePointers, error) {
+	var fs feedStatePointers
+	err := dbutil.Get(ctx, m.adapter.DBX(), m.adapter.Sqrl().
+		Select("active_feed_version_id", "materialized_feed_version_id", "exclude_from_global").
+		From("feed_states").
+		Where(sq.Eq{"feed_id": feedID}), &fs)
+	if errors.Is(err, sql.ErrNoRows) {
+		// No feed_states row yet: no active/materialized version, not excluded.
+		return feedStatePointers{}, nil
+	}
+	return fs, err
+}
+
+// reconcileFeed sets a feed's active feed version and brings its materialized pointer and
+// materialized tables into line. materialized_feed_version_id is the active version unless the
+// feed is excluded from global queries, in which case it is null; feed_version_id is written as a
+// transitional mirror of it. Materialized rows change only when the visible version does. Assumes
+// an open transaction.
+func (m *Manager) reconcileFeed(ctx context.Context, feedID int, active tt.Int) error {
+	cur, err := m.getFeedStatePointers(ctx, feedID)
+	if err != nil {
+		return fmt.Errorf("failed to read feed_states for feed %d: %w", feedID, err)
+	}
+
+	materialized := active
+	if cur.ExcludeFromGlobal {
+		materialized = tt.Int{}
+	}
+
+	// Reconcile materialized tables only when the visible version actually changes.
+	old := cur.MaterializedFeedVersionID
+	if old.Valid != materialized.Valid || (materialized.Valid && old.Int() != materialized.Int()) {
+		if old.Valid {
+			if err := m.DematerializeFeedVersion(ctx, old.Int()); err != nil {
+				return err
+			}
+		}
+		if materialized.Valid {
+			if err := m.MaterializeFeedVersion(ctx, materialized.Int()); err != nil {
+				return err
+			}
+		}
+	}
+
 	_, err = m.adapter.Sqrl().
 		Update("feed_states").
-		Set("feed_version_id", feedVersionID).
+		Set("active_feed_version_id", active).
+		Set("materialized_feed_version_id", materialized).
+		Set("feed_version_id", materialized). // TRANSITIONAL: mirror of materialized_feed_version_id; delete with the column
 		Where(sq.Eq{"feed_id": feedID}).
 		ExecContext(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to set feed version in feed_states: %w", err)
+		return fmt.Errorf("failed to update feed_states for feed %d: %w", feedID, err)
 	}
-
-	// Add to materialized tables
-	if err := m.MaterializeFeedVersion(ctx, feedVersionID); err != nil {
-		return fmt.Errorf("failed to add to materialized tables: %w", err)
-	}
-
 	return nil
 }
 
@@ -108,49 +128,48 @@ func (m *Manager) DeactivateFeedVersion(ctx context.Context, feedVersionID int) 
 }
 
 func (m *Manager) deactivateFeedVersion(ctx context.Context, feedVersionID int) error {
-	// Get the feed_id for this feed version
 	feedID, err := m.GetFeedIDForFeedVersion(ctx, feedVersionID)
 	if err != nil {
 		return fmt.Errorf("failed to get feed_id for feed version %d: %w", feedVersionID, err)
 	}
-
-	// Get current feed states to check if this feed version is active
-	feedStates, err := m.getActiveFeedStates(ctx)
+	cur, err := m.getFeedStatePointers(ctx, feedID)
 	if err != nil {
-		return fmt.Errorf("failed to get active feed states: %w", err)
+		return fmt.Errorf("failed to read feed_states for feed %d: %w", feedID, err)
 	}
-
-	// If this feed version is not active, do nothing
-	currentFeedVersionID, feedIsActive := feedStates[feedID]
-	if !feedIsActive || currentFeedVersionID != feedVersionID {
+	// Only clear when this feed version is the feed's current active version.
+	if !cur.ActiveFeedVersionID.Valid || cur.ActiveFeedVersionID.Int() != feedVersionID {
 		log.For(ctx).Info().
 			Int("feed_version_id", feedVersionID).
 			Int("feed_id", feedID).
 			Msg("Feed version is not currently active")
 		return nil
 	}
-
 	log.For(ctx).Info().
 		Int("feed_version_id", feedVersionID).
 		Int("feed_id", feedID).
 		Msg("Deactivating feed version")
+	return m.reconcileFeed(ctx, feedID, tt.Int{})
+}
 
-	// Unset in feed_states using Squirrel
-	_, err = m.adapter.Sqrl().
-		Update("feed_states").
-		Set("feed_version_id", nil).
-		Where(sq.Eq{"feed_id": feedID}).
-		ExecContext(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to unset feed version in feed_states: %w", err)
-	}
-
-	// Remove from materialized tables
-	if err := m.DematerializeFeedVersion(ctx, feedVersionID); err != nil {
-		return fmt.Errorf("failed to remove from materialized tables: %w", err)
-	}
-
-	return nil
+// SetExcludeFromGlobal sets a feed's global-query visibility and reconciles its materialized
+// pointer and materialized tables: excluding dematerializes the active version, including
+// materializes it. Runs in a transaction.
+func (m *Manager) SetExcludeFromGlobal(ctx context.Context, feedID int, exclude bool) error {
+	return m.adapter.Tx(func(atx tldb.Adapter) error {
+		mm := &Manager{adapter: atx}
+		if _, err := mm.adapter.Sqrl().
+			Update("feed_states").
+			Set("exclude_from_global", exclude).
+			Where(sq.Eq{"feed_id": feedID}).
+			ExecContext(ctx); err != nil {
+			return fmt.Errorf("failed to set exclude_from_global for feed %d: %w", feedID, err)
+		}
+		cur, err := mm.getFeedStatePointers(ctx, feedID)
+		if err != nil {
+			return err
+		}
+		return mm.reconcileFeed(ctx, feedID, cur.ActiveFeedVersionID)
+	})
 }
 
 // GetFeedIDForFeedVersion gets the feed_id for a given feed_version_id (public version)
@@ -163,25 +182,25 @@ func (m *Manager) GetFeedIDForFeedVersion(ctx context.Context, fvid int) (int, e
 	return feedID, err
 }
 
-// getActiveFeedStates returns a map of feed_id to feed_version_id for all active feeds
+// getActiveFeedStates returns a map of feed_id to active_feed_version_id for feeds with an active version
 func (m *Manager) getActiveFeedStates(ctx context.Context) (map[int]int, error) {
 	type feedState struct {
-		FeedID        int `db:"feed_id"`
-		FeedVersionID int `db:"feed_version_id"`
+		FeedID              int `db:"feed_id"`
+		ActiveFeedVersionID int `db:"active_feed_version_id"`
 	}
 
 	var states []feedState
 	err := dbutil.Select(ctx, m.adapter.DBX(), m.adapter.Sqrl().
-		Select("feed_id", "feed_version_id").
+		Select("feed_id", "active_feed_version_id").
 		From("feed_states").
-		Where("feed_version_id IS NOT NULL"), &states)
+		Where("active_feed_version_id IS NOT NULL"), &states)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query feed_states: %w", err)
 	}
 
 	feedStates := make(map[int]int)
 	for _, state := range states {
-		feedStates[state.FeedID] = state.FeedVersionID
+		feedStates[state.FeedID] = state.ActiveFeedVersionID
 	}
 
 	return feedStates, nil
@@ -449,6 +468,21 @@ func (m *Manager) GetActiveFeedVersions(ctx context.Context) ([]int, error) {
 	// Sort for consistent ordering
 	sort.Ints(feedVersionIDs)
 	return feedVersionIDs, nil
+}
+
+// GetMaterializedFeedVersionPointers returns the materialized_feed_version_id of every feed that
+// has one — the set that should be present in the materialized tables.
+func (m *Manager) GetMaterializedFeedVersionPointers(ctx context.Context) ([]int, error) {
+	var ids []int
+	err := dbutil.Select(ctx, m.adapter.DBX(), m.adapter.Sqrl().
+		Select("materialized_feed_version_id").
+		From("feed_states").
+		Where("materialized_feed_version_id IS NOT NULL"), &ids)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query materialized feed versions: %w", err)
+	}
+	sort.Ints(ids)
+	return ids, nil
 }
 
 type FeedVersionChanges struct {

--- a/internal/feedstate/manager.go
+++ b/internal/feedstate/manager.go
@@ -93,7 +93,7 @@ func (m *Manager) reconcileFeed(ctx context.Context, feedID int, active tt.Int) 
 
 	// Reconcile materialized tables only when the visible version actually changes.
 	old := cur.MaterializedFeedVersionID
-	if old.Valid != materialized.Valid || (materialized.Valid && old.Int() != materialized.Int()) {
+	if old != materialized {
 		if old.Valid {
 			if err := m.DematerializeFeedVersion(ctx, old.Int()); err != nil {
 				return err
@@ -180,30 +180,6 @@ func (m *Manager) GetFeedIDForFeedVersion(ctx context.Context, fvid int) (int, e
 		From("feed_versions").
 		Where(sq.Eq{"id": fvid}), &feedID)
 	return feedID, err
-}
-
-// getActiveFeedStates returns a map of feed_id to active_feed_version_id for feeds with an active version
-func (m *Manager) getActiveFeedStates(ctx context.Context) (map[int]int, error) {
-	type feedState struct {
-		FeedID              int `db:"feed_id"`
-		ActiveFeedVersionID int `db:"active_feed_version_id"`
-	}
-
-	var states []feedState
-	err := dbutil.Select(ctx, m.adapter.DBX(), m.adapter.Sqrl().
-		Select("feed_id", "active_feed_version_id").
-		From("feed_states").
-		Where("active_feed_version_id IS NOT NULL"), &states)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query feed_states: %w", err)
-	}
-
-	feedStates := make(map[int]int)
-	for _, state := range states {
-		feedStates[state.FeedID] = state.ActiveFeedVersionID
-	}
-
-	return feedStates, nil
 }
 
 // sortedColumnsAndSelects converts a map of column->expression into sorted parallel slices
@@ -453,21 +429,18 @@ func (m *Manager) GetMaterializedFeedVersions(ctx context.Context) ([]int, error
 	return slices.Collect(maps.Keys(feedVersionIds)), nil
 }
 
-// GetActiveFeedVersions returns a list of currently active feed version IDs
+// GetActiveFeedVersions returns the active_feed_version_id of every feed that has one.
 func (m *Manager) GetActiveFeedVersions(ctx context.Context) ([]int, error) {
-	feedStates, err := m.getActiveFeedStates(ctx)
+	var ids []int
+	err := dbutil.Select(ctx, m.adapter.DBX(), m.adapter.Sqrl().
+		Select("active_feed_version_id").
+		From("feed_states").
+		Where("active_feed_version_id IS NOT NULL"), &ids)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to query active feed versions: %w", err)
 	}
-
-	var feedVersionIDs []int
-	for _, feedVersionID := range feedStates {
-		feedVersionIDs = append(feedVersionIDs, feedVersionID)
-	}
-
-	// Sort for consistent ordering
-	sort.Ints(feedVersionIDs)
-	return feedVersionIDs, nil
+	sort.Ints(ids)
+	return ids, nil
 }
 
 // GetMaterializedFeedVersionPointers returns the materialized_feed_version_id of every feed that

--- a/internal/feedstate/manager_test.go
+++ b/internal/feedstate/manager_test.go
@@ -134,6 +134,38 @@ func verifyFeedState(t *testing.T, adapter tldb.Adapter, feedID int, expectedFee
 	}
 }
 
+// assertIntPtr asserts a nullable int column matches want (nil means SQL NULL).
+func assertIntPtr(t *testing.T, want, got *int, name string) {
+	t.Helper()
+	if want == nil {
+		assert.Nil(t, got, "%s should be null", name)
+		return
+	}
+	require.NotNil(t, got, "%s should not be null", name)
+	assert.Equal(t, *want, *got, "wrong %s", name)
+}
+
+// verifyPointers checks active_feed_version_id and materialized_feed_version_id, and that
+// feed_version_id still mirrors materialized_feed_version_id during the transition.
+func verifyPointers(t *testing.T, adapter tldb.Adapter, feedID int, wantActive, wantMaterialized *int) {
+	t.Helper()
+	ctx := context.Background()
+	var row struct {
+		Active       *int `db:"active_feed_version_id"`
+		Materialized *int `db:"materialized_feed_version_id"`
+		Mirror       *int `db:"feed_version_id"`
+	}
+	err := dbutil.Get(ctx, adapter.DBX(), adapter.Sqrl().
+		Select("active_feed_version_id", "materialized_feed_version_id", "feed_version_id").
+		From("feed_states").
+		Where("feed_id = ?", feedID), &row)
+	require.NoError(t, err, "failed to query feed_states pointers")
+
+	assertIntPtr(t, wantActive, row.Active, "active_feed_version_id")
+	assertIntPtr(t, wantMaterialized, row.Materialized, "materialized_feed_version_id")
+	assertIntPtr(t, wantMaterialized, row.Mirror, "feed_version_id (mirror)")
+}
+
 func TestManager_ActivateFeedVersion(t *testing.T) {
 	adapter, feedID, feedVersionID := setupTestDB(t, testFeedOnestopID, testreader.ExampleZip.URL)
 	defer adapter.Close()
@@ -389,4 +421,31 @@ func TestManager_GetFeedIDForFeedVersion(t *testing.T) {
 	// Test with non-existent feed version
 	_, err = manager.GetFeedIDForFeedVersion(ctx, 99999)
 	assert.Error(t, err, "should error for non-existent feed version")
+}
+
+func TestManager_ExcludeFromGlobal(t *testing.T) {
+	adapter, feedID, feedVersionID := setupTestDB(t, testFeedOnestopID, testreader.ExampleZip.URL)
+	defer adapter.Close()
+
+	manager := NewManager(adapter)
+	ctx := context.Background()
+
+	// Visible: active, materialized, and the mirror all point at the version, and it is materialized.
+	require.NoError(t, manager.ActivateFeedVersion(ctx, feedVersionID))
+	verifyPointers(t, adapter, feedID, &feedVersionID, &feedVersionID)
+	verifyMaterializedCounts(t, adapter, feedVersionID, map[string]int{})
+
+	// Excluding keeps the active version but drops the materialized pointer and clears the tables.
+	require.NoError(t, manager.SetExcludeFromGlobal(ctx, feedID, true))
+	verifyPointers(t, adapter, feedID, &feedVersionID, nil)
+	verifyMaterializedCounts(t, adapter, feedVersionID, map[string]int{
+		"routes":   0,
+		"stops":    0,
+		"agencies": 0,
+	})
+
+	// Re-including restores the materialized pointer and re-materializes.
+	require.NoError(t, manager.SetExcludeFromGlobal(ctx, feedID, false))
+	verifyPointers(t, adapter, feedID, &feedVersionID, &feedVersionID)
+	verifyMaterializedCounts(t, adapter, feedVersionID, map[string]int{})
 }

--- a/schema/postgres/migrations/20260715000001_feed_states_active_materialized.up.pgsql
+++ b/schema/postgres/migrations/20260715000001_feed_states_active_materialized.up.pgsql
@@ -18,50 +18,14 @@ FROM current_feeds
 WHERE current_feeds.id = feed_states.feed_id
   AND current_feeds.feed_tags->>'exclude_from_global_query' = 'true';
 
--- Mirror the current visible pointer; this matches what is actually materialized today.
-UPDATE feed_states SET materialized_feed_version_id = feed_version_id;
-
--- Backfill active_feed_version_id = the newest started importable version per feed, using
--- the active-selection logic without the global-exclude filter (status/deleted still gate),
--- so excluded feeds get a retained active version immediately and unimport protects it.
-WITH importable_fvs AS (
-    SELECT fv.id AS feed_version_id,
-        fv.feed_id,
-        (now() at time zone fvsw.default_timezone)::date AS local_time,
-        greatest(
-            fvsw.feed_start_date,
-            fvsw.earliest_calendar_date,
-            fv.earliest_calendar_date
-        ) AS greatest_start_date,
-        greatest(ff.fetched_at, fv.fetched_at) AS greatest_fetched_at
-    FROM feed_versions fv
-        JOIN feed_version_gtfs_imports fvgi ON fvgi.feed_version_id = fv.id
-        JOIN feed_version_service_windows fvsw ON fvsw.feed_version_id = fv.id
-        LEFT JOIN LATERAL (
-            SELECT * FROM feed_fetches WHERE feed_fetches.feed_version_id = fv.id LIMIT 1
-        ) ff ON TRUE
-    WHERE fvsw.default_timezone != ''
-        AND fvgi.success = TRUE
-        AND fvgi.schedule_removed = FALSE
-),
-selected_fvs AS (
-    SELECT DISTINCT ON (cf.id) cf.id AS feed_id,
-        importable_fvs.feed_version_id
-    FROM current_feeds cf
-        JOIN importable_fvs ON importable_fvs.feed_id = cf.id
-    WHERE importable_fvs.greatest_start_date <= importable_fvs.local_time
-        AND cf.deleted_at IS NULL
-        AND (
-            cf.feed_tags->'status' IS NULL
-            OR cf.feed_tags->>'status' NOT IN ('archived', 'unpublished')
-        )
-    ORDER BY cf.id ASC,
-        importable_fvs.greatest_fetched_at DESC
-)
+-- Initialize both pointers to the current visible version: materialized_ matches what is actually
+-- materialized today, and active_ protects that same version from unimport. Feeds excluded from
+-- global queries have a null feed_version_id, so their active_ starts null and is filled by the
+-- first set-active reconcile after deploy (safe: the unimport guard skips a feed whose active_ is
+-- null until then). Kept to feed_states only so the migration does not scan feed_versions.
 UPDATE feed_states
-SET active_feed_version_id = selected_fvs.feed_version_id
-FROM selected_fvs
-WHERE feed_states.feed_id = selected_fvs.feed_id;
+SET materialized_feed_version_id = feed_version_id,
+    active_feed_version_id = feed_version_id;
 
 -- materialized_feed_version_id becomes the global-query / materialized-table join key when
 -- its readers migrate off feed_version_id; give it the same unique index now.

--- a/schema/postgres/migrations/20260715000001_feed_states_active_materialized.up.pgsql
+++ b/schema/postgres/migrations/20260715000001_feed_states_active_materialized.up.pgsql
@@ -1,0 +1,71 @@
+BEGIN;
+
+-- Split the active feed version from the materialized/visible one.
+-- active_feed_version_id is the current version for every importable feed (including
+-- feeds excluded from global queries) and drives retention. materialized_feed_version_id
+-- is the visible/materialized version, NULL when the feed is excluded. feed_version_id is
+-- kept as a transitional mirror of materialized_feed_version_id until its readers migrate.
+-- exclude_from_global is the visibility decision, seeded once from the DMFR tag and owned
+-- here thereafter.
+ALTER TABLE public.feed_states
+    ADD COLUMN active_feed_version_id bigint REFERENCES feed_versions(id),
+    ADD COLUMN materialized_feed_version_id bigint REFERENCES feed_versions(id),
+    ADD COLUMN exclude_from_global boolean NOT NULL DEFAULT false;
+
+-- Seed exclude_from_global from the DMFR feed tag.
+UPDATE feed_states SET exclude_from_global = true
+FROM current_feeds
+WHERE current_feeds.id = feed_states.feed_id
+  AND current_feeds.feed_tags->>'exclude_from_global_query' = 'true';
+
+-- Mirror the current visible pointer; this matches what is actually materialized today.
+UPDATE feed_states SET materialized_feed_version_id = feed_version_id;
+
+-- Backfill active_feed_version_id = the newest started importable version per feed, using
+-- the active-selection logic without the global-exclude filter (status/deleted still gate),
+-- so excluded feeds get a retained active version immediately and unimport protects it.
+WITH importable_fvs AS (
+    SELECT fv.id AS feed_version_id,
+        fv.feed_id,
+        (now() at time zone fvsw.default_timezone)::date AS local_time,
+        greatest(
+            fvsw.feed_start_date,
+            fvsw.earliest_calendar_date,
+            fv.earliest_calendar_date
+        ) AS greatest_start_date,
+        greatest(ff.fetched_at, fv.fetched_at) AS greatest_fetched_at
+    FROM feed_versions fv
+        JOIN feed_version_gtfs_imports fvgi ON fvgi.feed_version_id = fv.id
+        JOIN feed_version_service_windows fvsw ON fvsw.feed_version_id = fv.id
+        LEFT JOIN LATERAL (
+            SELECT * FROM feed_fetches WHERE feed_fetches.feed_version_id = fv.id LIMIT 1
+        ) ff ON TRUE
+    WHERE fvsw.default_timezone != ''
+        AND fvgi.success = TRUE
+        AND fvgi.schedule_removed = FALSE
+),
+selected_fvs AS (
+    SELECT DISTINCT ON (cf.id) cf.id AS feed_id,
+        importable_fvs.feed_version_id
+    FROM current_feeds cf
+        JOIN importable_fvs ON importable_fvs.feed_id = cf.id
+    WHERE importable_fvs.greatest_start_date <= importable_fvs.local_time
+        AND cf.deleted_at IS NULL
+        AND (
+            cf.feed_tags->'status' IS NULL
+            OR cf.feed_tags->>'status' NOT IN ('archived', 'unpublished')
+        )
+    ORDER BY cf.id ASC,
+        importable_fvs.greatest_fetched_at DESC
+)
+UPDATE feed_states
+SET active_feed_version_id = selected_fvs.feed_version_id
+FROM selected_fvs
+WHERE feed_states.feed_id = selected_fvs.feed_id;
+
+-- materialized_feed_version_id becomes the global-query / materialized-table join key when
+-- its readers migrate off feed_version_id; give it the same unique index now.
+CREATE UNIQUE INDEX index_feed_states_on_materialized_feed_version_id
+    ON public.feed_states (materialized_feed_version_id);
+
+COMMIT;

--- a/schema/sqlite/sqlite.sql
+++ b/schema/sqlite/sqlite.sql
@@ -209,6 +209,9 @@ CREATE TABLE IF NOT EXISTS "feed_states" (
   "id" integer primary key autoincrement,
   "feed_id" integer NOT NULL,
   "feed_version_id" integer,
+  "active_feed_version_id" integer,
+  "materialized_feed_version_id" integer,
+  "exclude_from_global" bool not null default false,
   "feed_realtime_enabled" bool not null,
   "public" bool not null,
   "feed_priority" integer,
@@ -217,6 +220,8 @@ CREATE TABLE IF NOT EXISTS "feed_states" (
   "created_at" datetime DEFAULT CURRENT_TIMESTAMP,
   "updated_at" datetime DEFAULT CURRENT_TIMESTAMP,
   foreign key(feed_version_id) REFERENCES feed_versions(id),
+  foreign key(active_feed_version_id) REFERENCES feed_versions(id),
+  foreign key(materialized_feed_version_id) REFERENCES feed_versions(id),
   foreign key(feed_id) references current_feeds(id)
 );
 CREATE TABLE IF NOT EXISTS "gtfs_feed_infos" (

--- a/stats/dbutil.go
+++ b/stats/dbutil.go
@@ -35,6 +35,14 @@ func EnsureFeedState(ctx context.Context, atx tldb.Adapter, feedId int) (dmfr.Fe
 	fs := dmfr.FeedState{FeedID: feedId}
 	if err := atx.Get(ctx, &fs, `SELECT * FROM feed_states WHERE feed_id = ?`, feedId); err == sql.ErrNoRows {
 		fs.Public = true // Default: new feeds are public
+		// Seed exclude_from_global from the DMFR tag once, at creation; owned by feed_states after.
+		feed := dmfr.Feed{}
+		if ferr := atx.Get(ctx, &feed, `SELECT * FROM current_feeds WHERE id = ?`, feedId); ferr != nil {
+			return fs, ferr
+		}
+		if v, _ := feed.Tags.Get("exclude_from_global_query"); v == "true" {
+			fs.ExcludeFromGlobal = true
+		}
 		fs.ID, err = atx.Insert(ctx, &fs)
 		if err != nil {
 			return fs, err


### PR DESCRIPTION
## Summary
Splits the overloaded `feed_states.feed_version_id` into two pointers with distinct jobs, so a feed can be excluded from default/global results and the materialized tables while still being activated and retention-managed. `active_feed_version_id` is the current version for lifecycle/retention and is set for every importable feed, including ones hidden from global queries; `materialized_feed_version_id` is the visible/materialized version and is null when a feed is excluded. A new `exclude_from_global` boolean carries the visibility decision. `feed_version_id` is kept as a transitional mirror of `materialized_feed_version_id` so the existing query-layer and materialized-table readers keep working unchanged; they migrate to `materialized_feed_version_id` in a follow-up. This is the library half — the workflow that populates these pointers and the retention query that reads `active_feed_version_id` live in the deployment repo.

The invariant across the three pointers: `active_feed_version_id` is the newest importable version; `materialized_feed_version_id = exclude_from_global ? null : active_feed_version_id`; and `feed_version_id` mirrors `materialized_feed_version_id`.

### Schema
Adds `active_feed_version_id`, `materialized_feed_version_id`, and `exclude_from_global` to `feed_states`, with FKs on the two version pointers and a unique index on `materialized_feed_version_id` for the eventual join-key migration. The backfill seeds `exclude_from_global` from the `exclude_from_global_query` DMFR tag and initializes both new pointers to the current `feed_version_id`.

### Model and seeding
`dmfr.FeedState` gains the three fields, with `FeedVersionID` documented as the transitional mirror. `stats.EnsureFeedState` seeds `exclude_from_global` from the feed's DMFR tag once, at row creation, after which the column is the source of truth; the tag is read nowhere else in the library.

### Manager
Introduces a single `reconcileFeed(feedID, active)` choke point in `feedstate.Manager`: it reads the stored exclude flag, derives `materialized_feed_version_id` (null when excluded), adds or removes the feed from the materialized tables only when the visible version actually changes, and dual-writes the `feed_version_id` mirror. `ActivateFeedVersion` and `DeactivateFeedVersion` now delegate to it, and `SetExcludeFromGlobal` toggles a feed's visibility by writing the flag and reconciling (excluding dematerializes, including materializes) in one transaction. The "active set" accessor now reads `active_feed_version_id`, and a new `GetMaterializedFeedVersionPointers` returns the set that should be materialized; `feed-state --sync-active` targets that materialized set so it no longer materializes excluded feeds.

## Test plan
- `go test ./internal/feedstate/...`, including the new `TestManager_ExcludeFromGlobal`, which activates a feed, excludes it (asserts `active_feed_version_id` retained, `materialized_feed_version_id` and the mirror null, materialized tables cleared), then re-includes it (asserts both pointers restored and re-materialized).
- Verified green against the Postgres test DB: `importer`, `cmds`, `sync`, `dbfinder`, and the `tldb` schema-drift check (confirms the new struct fields and columns stay in sync).
- Confirmed the migration applies cleanly and its backfill plans as a `feed_states`-only update (no `feed_versions` scan).
