### PR TITLE
Update to use feed_states active/materialized_feed_version_id

### DIFF
--- a/server/finders/dbfinder/agency.go
+++ b/server/finders/dbfinder/agency.go
@@ -213,7 +213,7 @@ func agencySelect(limit *int, after *model.Cursor, ids []int, useActive *UseActi
 		q = q.Where(In("gtfs_agencies.id", ids))
 	}
 	if useActive.Active() {
-		q = q.Join("feed_states on feed_states.feed_version_id = gtfs_agencies.feed_version_id")
+		q = q.Join("feed_states on feed_states.materialized_feed_version_id = gtfs_agencies.feed_version_id")
 	}
 
 	// Default ordering
@@ -279,8 +279,8 @@ func placeSelect(_ *int, _ *model.Cursor, _ []int, level *model.PlaceAggregation
 		Select(selKeys...).
 		Columns("json_agg(distinct tlap.agency_id) as agency_ids").
 		From("feed_states").
-		Join("tl_agency_places tlap on tlap.feed_version_id = feed_states.feed_version_id").
-		Join("feed_versions on feed_versions.id = feed_states.feed_version_id").
+		Join("tl_agency_places tlap on tlap.feed_version_id = feed_states.materialized_feed_version_id").
+		Join("feed_versions on feed_versions.id = feed_states.materialized_feed_version_id").
 		Join("current_feeds on current_feeds.id = feed_states.feed_id").
 		GroupBy(groupKeys...)
 

--- a/server/finders/dbfinder/feed.go
+++ b/server/finders/dbfinder/feed.go
@@ -110,13 +110,13 @@ func feedSelect(ctx context.Context, limit *int, after *model.Cursor, ids []int,
 		if where.Bbox != nil || where.Within != nil || where.Near != nil {
 			q = q.
 				Join("feed_states fs_geom on fs_geom.feed_id = current_feeds.id").
-				Join("tl_feed_version_geometries fv_geoms on fv_geoms.feed_version_id = fs_geom.feed_version_id")
+				Join("tl_feed_version_geometries fv_geoms on fv_geoms.feed_version_id = fs_geom.materialized_feed_version_id")
 			// Optional secondary filter on precomputed stop geohash cells.
 			// Gated on UseGeohashFilter; operators are expected to run the
 			// migration and backfill before flipping the flag on, so FVs
 			// without cells are treated as not matching.
 			useGeohashFilter := model.ForContext(ctx).UseGeohashFilter
-			fvCorrelation := sq.Expr("tl_feed_version_geohashes.feed_version_id = fs_geom.feed_version_id")
+			fvCorrelation := sq.Expr("tl_feed_version_geohashes.feed_version_id = fs_geom.materialized_feed_version_id")
 			if where.Bbox != nil {
 				b := where.Bbox
 				q = q.Where("ST_Intersects(fv_geoms.geometry, ST_MakeEnvelope(?,?,?,?,4326))", b.MinLon, b.MinLat, b.MaxLon, b.MaxLat)

--- a/server/finders/dbfinder/operator.go
+++ b/server/finders/dbfinder/operator.go
@@ -117,7 +117,7 @@ func operatorSelectBase(distinct bool, where *model.OperatorFilter) sq.SelectBui
 		if where.Bbox != nil || where.Within != nil || where.Near != nil {
 			q = q.
 				Join("feed_states fs_geom ON fs_geom.feed_id = coif.feed_id").
-				Join("gtfs_agencies a_geom ON a_geom.feed_version_id = fs_geom.feed_version_id AND a_geom.agency_id = coif.resolved_gtfs_agency_id").
+				Join("gtfs_agencies a_geom ON a_geom.feed_version_id = fs_geom.materialized_feed_version_id AND a_geom.agency_id = coif.resolved_gtfs_agency_id").
 				Join("tl_agency_geometries ON tl_agency_geometries.agency_id = a_geom.id")
 			if where.Bbox != nil {
 				q = q.Where("ST_Intersects(tl_agency_geometries.geometry, ST_MakeEnvelope(?,?,?,?,4326))", where.Bbox.MinLon, where.Bbox.MinLat, where.Bbox.MaxLon, where.Bbox.MaxLat)
@@ -178,7 +178,7 @@ func operatorsByAgencyID(_ *int, _ *model.Cursor, agencyIds []int) sq.SelectBuil
 	q = q.
 		Column("a.id as agency_id").
 		Join("feed_states fs on fs.feed_id = current_feeds.id").
-		Join("gtfs_agencies a on a.feed_version_id = fs.feed_version_id and a.agency_id = coif.resolved_gtfs_agency_id").
+		Join("gtfs_agencies a on a.feed_version_id = fs.materialized_feed_version_id and a.agency_id = coif.resolved_gtfs_agency_id").
 		Where(In("a.id", agencyIds))
 	return q
 }

--- a/server/finders/dbfinder/operator.go
+++ b/server/finders/dbfinder/operator.go
@@ -135,7 +135,7 @@ func operatorSelectBase(distinct bool, where *model.OperatorFilter) sq.SelectBui
 		if where.Adm0Iso != nil || where.Adm1Iso != nil || where.Adm0Name != nil || where.Adm1Name != nil || where.CityName != nil {
 			q = q.
 				Join("feed_states ON feed_states.feed_id = coif.feed_id").
-				Join("gtfs_agencies ON gtfs_agencies.feed_version_id = feed_states.feed_version_id AND gtfs_agencies.agency_id = coif.resolved_gtfs_agency_id").
+				Join("gtfs_agencies ON gtfs_agencies.feed_version_id = feed_states.materialized_feed_version_id AND gtfs_agencies.agency_id = coif.resolved_gtfs_agency_id").
 				Join("tl_agency_places tlap ON tlap.agency_id = gtfs_agencies.id").
 				Join("ne_10m_admin_1_states_provinces ne_admin on ne_admin.name = tlap.adm1name and ne_admin.admin = tlap.adm0name")
 			if where.Adm0Iso != nil {

--- a/server/finders/dbfinder/route.go
+++ b/server/finders/dbfinder/route.go
@@ -349,7 +349,7 @@ func routeSelect(limit *int, after *model.Cursor, ids []int, useActive *UseActiv
 	}
 
 	if useActive.Active() {
-		q = q.Join("feed_states on feed_states.feed_version_id = gtfs_routes.feed_version_id")
+		q = q.Join("feed_states on feed_states.materialized_feed_version_id = gtfs_routes.feed_version_id")
 	}
 	if len(ids) > 0 {
 		q = q.Where(In("gtfs_routes.id", ids))

--- a/server/finders/dbfinder/stop.go
+++ b/server/finders/dbfinder/stop.go
@@ -534,7 +534,7 @@ func stopSelect(limit *int, after *model.Cursor, ids []int, useActive *UseActive
 		q = q.Distinct().Options("on (gtfs_stops.feed_version_id,gtfs_stops.id)")
 	}
 	if useActive.Active() {
-		q = q.Join("feed_states on feed_states.feed_version_id = gtfs_stops.feed_version_id")
+		q = q.Join("feed_states on feed_states.materialized_feed_version_id = gtfs_stops.feed_version_id")
 	}
 	if len(ids) > 0 {
 		q = q.Where(In("gtfs_stops.id", ids))

--- a/server/finders/dbfinder/stop_onestop_probe.go
+++ b/server/finders/dbfinder/stop_onestop_probe.go
@@ -83,7 +83,7 @@ func allowPrevProbeQuery(osids []string) sq.SelectBuilder {
 		From("hist").
 		Join("gtfs_stops gs on gs.stop_id = hist.entity_id").
 		Join("feed_versions cur_fv on cur_fv.id = gs.feed_version_id and cur_fv.feed_id = hist.feed_id").
-		Join("feed_states fs on fs.feed_version_id = gs.feed_version_id").
+		Join("feed_states fs on fs.materialized_feed_version_id = gs.feed_version_id").
 		JoinClause("left join feed_version_stop_onestop_ids cur on cur.entity_id = gs.stop_id and cur.feed_version_id = gs.feed_version_id")
 }
 

--- a/server/finders/dbfinder/trip.go
+++ b/server/finders/dbfinder/trip.go
@@ -260,7 +260,7 @@ func tripSelect(limit *int, after *model.Cursor, ids []int, active bool, permFil
 		q = licenseFilter(where.License, q)
 	}
 	if active {
-		q = q.Join("feed_states on feed_states.feed_version_id = gtfs_trips.feed_version_id")
+		q = q.Join("feed_states on feed_states.materialized_feed_version_id = gtfs_trips.feed_version_id")
 	}
 	if len(ids) > 0 {
 		q = q.Where(In("gtfs_trips.id", ids))

--- a/sync/oifs.go
+++ b/sync/oifs.go
@@ -95,7 +95,7 @@ func updateOifs(ctx context.Context, atx tldb.Adapter, operator dmfr.Operator) (
 		}
 		// Get agencies
 		agencies := []gtfs.Agency{}
-		if err := atx.Select(ctx, &agencies, "select gtfs_agencies.* from gtfs_agencies inner join feed_states using(feed_version_id) where feed_states.feed_id = ?", oif.FeedID); err != nil {
+		if err := atx.Select(ctx, &agencies, "select gtfs_agencies.* from gtfs_agencies inner join feed_states on feed_states.materialized_feed_version_id = gtfs_agencies.feed_version_id where feed_states.feed_id = ?", oif.FeedID); err != nil {
 			return false, err
 		}
 		agencyID := 0
@@ -163,7 +163,7 @@ func feedUpdateOifs(ctx context.Context, atx tldb.Adapter, feed dmfr.Feed) (bool
 	agencyQuery := atx.Sqrl().
 		Select("gtfs_agencies.*", "feed_version_agency_onestop_ids.onestop_id as onestop_id").
 		From("gtfs_agencies").
-		Join("feed_states using(feed_version_id)").
+		Join("feed_states on feed_states.materialized_feed_version_id = gtfs_agencies.feed_version_id").
 		Join("current_feeds on current_feeds.id = feed_states.feed_id").
 		JoinClause("left join feed_version_agency_onestop_ids on feed_version_agency_onestop_ids.entity_id = gtfs_agencies.agency_id and feed_version_agency_onestop_ids.feed_version_id = gtfs_agencies.feed_version_id").
 		Where(sq.Eq{"current_feeds.id": feedid})

--- a/testdata/server/test_supplement.pgsql
+++ b/testdata/server/test_supplement.pgsql
@@ -86,7 +86,7 @@ insert into tl_segment_patterns(feed_version_id,segment_id,route_id,shape_id,sto
     );    
 
 -- unactivate feed
-update feed_states set feed_version_id = null where feed_id = (select id from current_feeds where onestop_id = 'EX');
+update feed_states set feed_version_id = null, materialized_feed_version_id = null, active_feed_version_id = null where feed_id = (select id from current_feeds where onestop_id = 'EX');
 
 -- set public
 update feed_states set public = false;


### PR DESCRIPTION
## Summary
Phase 2 of the active/materialized feed_state split (follow-up to #699). Repoints the query-layer and sync readers from the transitional `feed_version_id` mirror to `materialized_feed_version_id`, the canonical visible/materialized pointer #699 introduced. Every affected join previously matched `feed_states` on `feed_version_id` to restrict default/global results to a feed's current version; those joins now match on `materialized_feed_version_id` (or its `fs`/`fs_geom` aliases) instead. Because the manager keeps `feed_version_id` and `materialized_feed_version_id` equal via dual-write during the transition, this is a behavior-preserving swap — its purpose is to move the readers onto the real column so the mirror can be dropped in a later phase.

### Repointed readers
- dbfinder `.Active()` entity joins: `stop`, `route`, `trip`, `agency` (the active join plus the agency-places subquery's `tl_agency_places` and `feed_versions` joins), and `stop_onestop_probe`.
- `operator` — all three agency-resolution joins (the place filter, the spatial bbox/near filter via `fs_geom`, and the base query), so the operator finder no longer resolves agencies through the mirror on any path.
- `feed` — the spatial feed-search joins (feed-version geometry, and the geohash-cell correlation) via `fs_geom`.
- `sync/oifs.go` operator-to-agency resolution (two joins), converted from `USING (feed_version_id)` to explicit `ON feed_states.materialized_feed_version_id = gtfs_agencies.feed_version_id`.

### Test fixture
- `testdata/server/test_supplement.pgsql` now nulls all three feed_state pointers (`feed_version_id`, `materialized_feed_version_id`, `active_feed_version_id`) when "unactivating" the example feed, matching what `DeactivateFeedVersion` does. Previously it nulled only the mirror, which the repointed readers would otherwise surface.

### Semantics
`materialized_feed_version_id` is null for feeds excluded from global queries, so those feeds' entities, operator resolution, and spatial feed results stay hidden — the same outcome as today, where the mirror is also null for them. The swap is a no-op while the two columns are equal; it exists to remove these readers' dependence on `feed_version_id` ahead of dropping that column.

## Test plan
- `go test ./server/gql/... ./server/finders/dbfinder/... ./sync/...` green (the `gql` resolver suite exercises the feed/operator/entity paths and is what caught the fixture gap).
- CI-safe: the server test fixture is built via `transitland import --activate`, which activates through the feed-state manager and therefore populates `materialized_feed_version_id`, so the repointed joins return data on a freshly built database.
