### PR TITLE
Use tl_route_representative_shapes in queries

### DIFF
--- a/internal/feedstate/manager.go
+++ b/internal/feedstate/manager.go
@@ -254,10 +254,11 @@ func routeMaterializeFields(spatial bool) map[string]string {
 		"created_at":          "gtfs_routes.created_at",
 		"updated_at":          "gtfs_routes.updated_at",
 	}
-	// Geometry column - full geometry for SQLite, simplified for PostGIS
-	fields["geometry_simplified"] = "tlrg.geometry"
+	// Geometry column - full geometry for SQLite, simplified for PostGIS.
+	// Sourced from the route's primary (rank 0) representative shape.
+	fields["geometry_simplified"] = "rep_shape.geometry"
 	if spatial {
-		fields["geometry_simplified"] = "ST_Simplify(tlrg.geometry::geometry, 0.01)"
+		fields["geometry_simplified"] = "ST_Simplify(ST_Force2D(rep_shape.geometry::geometry), 0.01)"
 	}
 	return fields
 }
@@ -351,7 +352,8 @@ func (m *Manager) MaterializeFeedVersion(ctx context.Context, feedVersionID int)
 			Join("gtfs_agencies ON gtfs_agencies.id = gtfs_routes.agency_id").
 			Join("feed_versions ON feed_versions.id = gtfs_routes.feed_version_id").
 			LeftJoin("feed_version_route_onestop_ids osid ON osid.entity_id = gtfs_routes.route_id AND osid.feed_version_id = feed_versions.id").
-			LeftJoin("tl_route_geometries tlrg ON tlrg.route_id = gtfs_routes.id").
+			LeftJoin("tl_route_representative_shapes rep0 ON rep0.route_id = gtfs_routes.id AND rep0.rank = 0").
+			LeftJoin("gtfs_shapes rep_shape ON rep_shape.id = rep0.shape_id").
 			Where(sq.Eq{"gtfs_routes.feed_version_id": feedVersionID}))
 
 	_, err := routeQuery.ExecContext(ctx)

--- a/server/finders/dbfinder/route.go
+++ b/server/finders/dbfinder/route.go
@@ -101,20 +101,27 @@ func (f *Finder) RouteStopPatternsByRouteIDs(ctx context.Context, limit *int, ke
 	return arrangeGroup(keys, ents, func(ent *model.RouteStopPattern) int { return ent.RouteID }), err
 }
 
+// RouteGeometriesByRouteIDs reconstructs each route's geometry from the shapes it
+// points at in tl_route_representative_shapes: rank 0 is the primary line, the ranked
+// set collected is the combined geometry, and the scalars are aggregates over the
+// pointed-at shapes. There is one geometry per route, so limit is unused.
 func (f *Finder) RouteGeometriesByRouteIDs(ctx context.Context, limit *int, keys []int) ([][]*model.RouteGeometry, error) {
 	var ents []*model.RouteGeometry
-	err := dbutil.Select(ctx,
-		f.db,
-		lateralWrap(
-			quickSelectOrder("tl_route_geometries", limit, nil, nil, "route_id"),
-			"gtfs_routes",
-			"id",
-			"tl_route_geometries",
-			"route_id",
-			keys,
-		),
-		&ents,
-	)
+	q := sq.StatementBuilder.
+		Select(
+			"tl_route_representative_shapes.route_id AS route_id",
+			"bool_or(tl_route_representative_shapes.generated) AS generated",
+			"max(tl_route_representative_shapes.length) AS length",
+			"max(tl_route_representative_shapes.max_segment_length) AS max_segment_length",
+			"max(tl_route_representative_shapes.first_point_max_distance) AS first_point_max_distance",
+			"ST_Force2D((array_agg(gtfs_shapes.geometry::geometry ORDER BY tl_route_representative_shapes.rank))[1]) AS geometry",
+			"ST_Multi(ST_Collect(ST_Force2D(gtfs_shapes.geometry::geometry) ORDER BY tl_route_representative_shapes.rank)) AS combined_geometry",
+		).
+		From("tl_route_representative_shapes").
+		Join("gtfs_shapes ON gtfs_shapes.id = tl_route_representative_shapes.shape_id").
+		Where(In("tl_route_representative_shapes.route_id", keys)).
+		GroupBy("tl_route_representative_shapes.route_id")
+	err := dbutil.Select(ctx, f.db, q, &ents)
 	return arrangeGroup(keys, ents, func(ent *model.RouteGeometry) int { return ent.RouteID }), err
 }
 

--- a/server/finders/dbfinder/route.go
+++ b/server/finders/dbfinder/route.go
@@ -341,16 +341,18 @@ func routeSelect(limit *int, after *model.Cursor, ids []int, useActive *UseActiv
 			) tlrs_near on tlrs_near.route_id = gtfs_routes.id`, loc.Near.Lon, loc.Near.Lat, radius)
 		}
 		if loc.Focus != nil {
-			// Use materialized route geometries when requested
+			// Materialized routes carry geometry_simplified; otherwise sort against the
+			// route's primary (rank 0) representative shape.
 			orderExpr := sq.Expr(
 				useActive.UseTable(
-					"tl_route_geometries.geometry <-> ST_MakePoint(?,?), gtfs_routes.id",
+					"rep_shape.geometry <-> ST_MakePoint(?,?), gtfs_routes.id",
 					"gtfs_routes.geometry_simplified <-> ST_MakePoint(?,?), gtfs_routes.id",
 				),
 				loc.Focus.Lon,
 				loc.Focus.Lat)
 			q = q.
-				Join("tl_route_geometries ON tl_route_geometries.route_id = gtfs_routes.id").
+				Join("tl_route_representative_shapes rep0 ON rep0.route_id = gtfs_routes.id AND rep0.rank = 0").
+				Join("gtfs_shapes rep_shape ON rep_shape.id = rep0.shape_id").
 				OrderByClause(orderExpr)
 		}
 	}
@@ -371,7 +373,7 @@ func routeSelect(limit *int, after *model.Cursor, ids []int, useActive *UseActiv
 			// When materialized, we have tl_materialized_active_routes set as 'gtfs_routes', which has a 'geometry_simplified' column
 			whereExpr := sq.Expr(
 				useActive.UseTable(
-					"(ST_Distance(tl_route_geometries.geometry, ST_MakePoint(?,?)), gtfs_routes.id) > (select ST_Distance(geometry, ST_MakePoint(?,?)), route_id from tl_route_geometries where route_id = ?)",
+					"(ST_Distance(rep_shape.geometry, ST_MakePoint(?,?)), gtfs_routes.id) > (select ST_Distance(s.geometry, ST_MakePoint(?,?)), r.route_id from tl_route_representative_shapes r join gtfs_shapes s on s.id = r.shape_id where r.route_id = ? and r.rank = 0)",
 					"(ST_Distance(gtfs_routes.geometry_simplified, ST_MakePoint(?,?)), gtfs_routes.id) > (select ST_Distance(geometry, ST_MakePoint(?,?)), route_id from gtfs_routes where route_id = ?)",
 				),
 				where.Location.Focus.Lon,

--- a/server/finders/dbfinder/route.go
+++ b/server/finders/dbfinder/route.go
@@ -374,7 +374,7 @@ func routeSelect(limit *int, after *model.Cursor, ids []int, useActive *UseActiv
 			whereExpr := sq.Expr(
 				useActive.UseTable(
 					"(ST_Distance(rep_shape.geometry, ST_MakePoint(?,?)), gtfs_routes.id) > (select ST_Distance(s.geometry, ST_MakePoint(?,?)), r.route_id from tl_route_representative_shapes r join gtfs_shapes s on s.id = r.shape_id where r.route_id = ? and r.rank = 0)",
-					"(ST_Distance(gtfs_routes.geometry_simplified, ST_MakePoint(?,?)), gtfs_routes.id) > (select ST_Distance(geometry, ST_MakePoint(?,?)), route_id from gtfs_routes where route_id = ?)",
+					"(ST_Distance(gtfs_routes.geometry_simplified, ST_MakePoint(?,?)), gtfs_routes.id) > (select ST_Distance(geometry_simplified, ST_MakePoint(?,?)), id from tl_materialized_active_routes where id = ?)",
 				),
 				where.Location.Focus.Lon,
 				where.Location.Focus.Lat,

--- a/server/finders/dbfinder/route_test.go
+++ b/server/finders/dbfinder/route_test.go
@@ -1,0 +1,36 @@
+package dbfinder
+
+import (
+	"context"
+	"testing"
+
+	"github.com/interline-io/transitland-lib/server/dbutil"
+	"github.com/interline-io/transitland-lib/server/model"
+	"github.com/interline-io/transitland-lib/server/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// Exercises the active+materialized focus-pagination path, which had no coverage --
+// letting a broken cursor subquery (text route_id vs int id, and a missing geometry
+// column) survive. Asserts only that the query executes: it is the first test to run
+// routeSelect in materialized mode.
+func TestRouteSelect_MaterializedFocusCursor(t *testing.T) {
+	ctx := context.Background()
+	db := testutil.MustOpenTestDB(t)
+
+	var afterID int
+	if err := db.Get(&afterID, "select id from tl_materialized_active_routes limit 1"); err != nil {
+		t.Skipf("no materialized routes in test db: %v", err)
+	}
+
+	q := routeSelect(
+		nil,
+		&model.Cursor{Valid: true, ID: afterID},
+		nil,
+		&UseActive{active: true, materialized: true},
+		&model.PermFilter{IsGlobalAdmin: true},
+		&model.RouteFilter{Location: &model.RouteLocationFilter{Focus: &model.FocusPoint{Lon: -122.4, Lat: 37.8}}},
+	)
+	var ents []*model.Route
+	require.NoError(t, dbutil.Select(ctx, db, q, &ents))
+}

--- a/server/gql/route_resolver_test.go
+++ b/server/gql/route_resolver_test.go
@@ -69,6 +69,29 @@ func TestRouteResolver(t *testing.T) {
 			selectExpect: []string{"false"},
 		},
 		{
+			// Migration guard: geometry is reconstructed from tl_route_representative_shapes,
+			// so pin the structural invariants on a reviewed shape (Caltrain Bu-130). These
+			// hold regardless of the source table and outlive the tl_route_geometries drop.
+			name:  "geometry invariants (Bu-130)",
+			query: `query { routes(where:{route_id:"Bu-130"}) { geometries { generated geometry combined_geometry } } }`,
+			f: func(t *testing.T, jj string) {
+				g := gjson.Get(jj, "routes.0.geometries.0")
+				// combined_geometry is a MultiLineString with one linestring per representative shape.
+				assert.Equal(t, "MultiLineString", g.Get("combined_geometry.type").String())
+				assert.Len(t, g.Get("combined_geometry.coordinates").Array(), 4, "combined_geometry linestring count")
+				// primary geometry is the rank-0 line: a LineString equal to combined_geometry[0].
+				assert.Equal(t, "LineString", g.Get("geometry.type").String())
+				assert.Equal(t, g.Get("combined_geometry.coordinates.0").Raw, g.Get("geometry.coordinates").Raw, "primary geometry == combined_geometry[0]")
+				assert.False(t, g.Get("generated").Bool())
+				// shape_id isn't exposed via the resolver, so pin the rank-0 line's point
+				// count and first vertex to lock the actual shape it resolves to.
+				pts := g.Get("geometry.coordinates").Array()
+				assert.Len(t, pts, 382, "primary geometry point count")
+				assert.InDelta(t, -121.903170, pts[0].Array()[0].Float(), 1e-5, "first vertex lon")
+				assert.InDelta(t, 37.330157, pts[0].Array()[1].Float(), 1e-5, "first vertex lat")
+			},
+		},
+		{
 			name:         "route_stop_buffer stop_points 10m",
 			query:        `query($route_id: String!) { routes(where:{route_id:$route_id}) {route_stop_buffer(radius: 100.0) {stop_points	stop_buffer	stop_convexhull}}}`,
 			vars:         vars,


### PR DESCRIPTION
## Summary
Migrates every reader of `tl_route_geometries` to reconstruct route geometry on the fly from `tl_route_representative_shapes` (added in #694), so `tl_route_geometries` becomes write-only and can be dropped in a follow-up. That table stores one ranked pointer per route to the `gtfs_shapes` it was assembled from — rank 0 is the primary line, the ranked set is the combined geometry, and the route-level scalars are recoverable as aggregates — so the reconstruction is exact and transparent to callers. No schema, model, or GraphQL changes.

### Route geometry resolver
`RouteGeometriesByRouteIDs`, which serves both `route.geometry` and `route.geometries`, now `GROUP BY route_id` over `tl_route_representative_shapes` joined to `gtfs_shapes`: `ST_Multi(ST_Collect(... ORDER BY rank))` for `combined_geometry`, the rank-0 shape for the primary `geometry`, and `max`/`bool_or` for `length` / `max_segment_length` / `first_point_max_distance` / `generated`. The model and resolver signatures are unchanged.

### Nearest-route (focus) sort
The `location.focus` KNN sort's non-materialized branch previously sorted against `tl_route_geometries.geometry`; it now sorts against the route's rank-0 representative shape, in both the order-by and the keyset cursor. The materialized branch is unchanged — it continues to use the indexed `gtfs_routes.geometry_simplified`, so the hot path is unaffected.

### Materialized routes
The materialization that builds `tl_materialized_active_routes` derived `geometry_simplified` from `tl_route_geometries.geometry`; it now derives it from the rank-0 representative shape (`ST_Simplify(ST_Force2D(...))`). Because `ST_Simplify` is sensitive to the sub-meter difference between the old blob and the raw shape coordinates, re-materialized `geometry_simplified` values shift slightly — cosmetic for nearest-route ranking, but they are not byte-identical to before.

### Incidental fix: materialized focus-pagination cursor
Unrelated to representative shapes, but surfaced while reworking the focus cursor: the *materialized* branch of the keyset predicate had a pre-existing bug (introduced in #520). Its subquery read `from gtfs_routes where route_id = ?`, which hits the base table — text `route_id`, no geometry column — instead of `tl_materialized_active_routes` keyed by `id`, so materialized focus pagination errored with a `bigint > character varying` type mismatch. It went unnoticed because nothing exercised the materialized path. Now keyed off `id` against `tl_materialized_active_routes` using `geometry_simplified` (matching the order-by), plus `TestRouteSelect_MaterializedFocusCursor` — the first materialized-mode test — which fails on the old query and passes on the fixed one.

### Tests
Adds a `geometry invariants (Bu-130)` case to `route_resolver_test.go` that pins the reconstructed shape through the resolver: `combined_geometry` is a `MultiLineString` with the expected linestring count, the primary line equals `combined_geometry[0]` (the rank-0 invariant), and its point count and first vertex are locked to a reviewed shape. It asserts structural invariants rather than the source table, so it guards reconstruction faithfulness now and survives the `tl_route_geometries` drop.

### Not included
The builder still writes `tl_route_geometries` and it remains registered in `GetFeedVersionTables`. Stopping the write and dropping the table is a follow-up, once these readers are deployed and active feeds have been re-materialized.

## Test plan
- `go test ./server/gql/ ./server/finders/dbfinder/` — covers `route.geometry` / `route.geometries` (including the new geometry-invariant guard) and the `location.focus` sort and pagination cases (including the new materialized-mode cursor test).
- Confirm reconstructed geometry matches `tl_route_geometries` per route: scalars exact, `combined_geometry` equal within floating-point precision.
- Confirm every route with a `tl_route_geometries` row also has representative shapes, so no route silently loses its geometry.
- After deploy, re-materialize active feeds so `geometry_simplified` is rebuilt from rank 0 before the `tl_route_geometries` drop.
