### PR TITLE
Additional feed_fetches index

### DIFF
--- a/schema/postgres/migrations/20260718000001_feed_fetches_latest_fetch_index.up.pgsql
+++ b/schema/postgres/migrations/20260718000001_feed_fetches_latest_fetch_index.up.pgsql
@@ -1,0 +1,12 @@
+BEGIN;
+
+-- Supports "latest successful static_current fetch per feed" lookups (feed version
+-- import list, public feed list): seek (feed_id, url_type) and read the newest row by
+-- fetched_at, instead of scanning a feed's fetches backward and filtering url_type and
+-- success per row. feed_version_id rides in INCLUDE so the lookup stays index-only.
+CREATE INDEX IF NOT EXISTS feed_fetches_feed_id_url_type_fetched_at_success_idx
+    ON feed_fetches (feed_id, url_type, fetched_at DESC)
+    INCLUDE (feed_version_id)
+    WHERE success;
+
+COMMIT;


### PR DESCRIPTION
## Summary
Adds a partial covering index on `feed_fetches` for the "latest successful `static_current` fetch per feed" lookup — `WHERE feed_id = ? AND url_type = 'static_current' AND success ORDER BY fetched_at DESC LIMIT 1`, run per feed to resolve its current feed version.

Previously only `feed_id` was an index condition, so `url_type` and `success` fell to a post-scan filter: each feed scanned its fetch history backward until a match, and scanned *all* of it for feeds with no matching fetch — pathologically slow at scale. The new index `(feed_id, url_type, fetched_at DESC) INCLUDE (feed_version_id) WHERE success` turns each lookup into a single index-only seek.

## Notes
- Non-concurrent `CREATE INDEX IF NOT EXISTS` (migrations run in a transaction). Builds fast on a fresh DB. It already exists on production (added out of band to fix a live slowdown), so the migration is a no-op there once that index is renamed to `feed_fetches_feed_id_url_type_fetched_at_success_idx` to match the name.
- No SQLite change — the schema-drift test compares columns, not indexes.
