### PR TITLE
Use hash indexes for onestop_ids

### DIFF
--- a/schema/postgres/migrations/20260721000001_feed_version_stop_onestop_ids_hash_index.up.pgsql
+++ b/schema/postgres/migrations/20260721000001_feed_version_stop_onestop_ids_hash_index.up.pgsql
@@ -1,0 +1,8 @@
+-- feed_version_stop_onestop_ids is looked up only by exact onestop_id equality
+-- (AllowPrevious resolution), so a hash index fits: it stores just the hash of
+-- the long onestop_id key, landing at roughly half the size of the covering
+-- btree it replaces (see the next migration) with equivalent lookup cost.
+-- Concurrent build, in its own single-statement migration: CREATE INDEX
+-- CONCURRENTLY cannot run inside a transaction block.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS feed_version_stop_onestop_ids_onestop_id_idx
+    ON feed_version_stop_onestop_ids USING hash (onestop_id);

--- a/schema/postgres/migrations/20260721000002_feed_version_stop_onestop_ids_drop_include_index.up.pgsql
+++ b/schema/postgres/migrations/20260721000002_feed_version_stop_onestop_ids_drop_include_index.up.pgsql
@@ -1,0 +1,7 @@
+-- Drop the old covering btree on onestop_id, superseded by the hash index in the
+-- previous migration. Its INCLUDE (entity_id, feed_version_id) payload never
+-- delivered index-only scans in practice -- the table churns constantly, so its
+-- visibility map stays stale and lookups fetch from the heap anyway. Concurrent
+-- drop, in its own single-statement migration: DROP INDEX CONCURRENTLY cannot run
+-- inside a transaction block.
+DROP INDEX CONCURRENTLY IF EXISTS feed_version_stop_onestop_ids_onestop_id_entity_id_feed_ver_idx;

--- a/schema/postgres/migrations/20260721000003_feed_version_route_onestop_ids_hash_index.up.pgsql
+++ b/schema/postgres/migrations/20260721000003_feed_version_route_onestop_ids_hash_index.up.pgsql
@@ -1,0 +1,6 @@
+-- Same equality-only AllowPrevious access as feed_version_stop_onestop_ids: a
+-- hash index on onestop_id replaces the covering btree at roughly half the size.
+-- Concurrent build, in its own single-statement migration: CREATE INDEX
+-- CONCURRENTLY cannot run inside a transaction block.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS feed_version_route_onestop_ids_onestop_id_idx
+    ON feed_version_route_onestop_ids USING hash (onestop_id);

--- a/schema/postgres/migrations/20260721000004_feed_version_route_onestop_ids_drop_include_index.up.pgsql
+++ b/schema/postgres/migrations/20260721000004_feed_version_route_onestop_ids_drop_include_index.up.pgsql
@@ -1,0 +1,6 @@
+-- Drop the old covering btree on onestop_id, superseded by the hash index in the
+-- previous migration -- the same change made to feed_version_stop_onestop_ids,
+-- where the INCLUDE payload was shown never to deliver index-only scans. Concurrent
+-- drop, in its own single-statement migration: DROP INDEX CONCURRENTLY cannot run
+-- inside a transaction block.
+DROP INDEX CONCURRENTLY IF EXISTS feed_version_route_onestop_id_onestop_id_entity_id_feed_ver_idx;

--- a/schema/postgres/migrations/20260721000005_feed_version_agency_onestop_ids_hash_index.up.pgsql
+++ b/schema/postgres/migrations/20260721000005_feed_version_agency_onestop_ids_hash_index.up.pgsql
@@ -1,0 +1,6 @@
+-- Same equality-only AllowPrevious access as feed_version_stop_onestop_ids: a
+-- hash index on onestop_id replaces the covering btree at roughly half the size.
+-- Concurrent build, in its own single-statement migration: CREATE INDEX
+-- CONCURRENTLY cannot run inside a transaction block.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS feed_version_agency_onestop_ids_onestop_id_idx
+    ON feed_version_agency_onestop_ids USING hash (onestop_id);

--- a/schema/postgres/migrations/20260721000006_feed_version_agency_onestop_ids_drop_include_index.up.pgsql
+++ b/schema/postgres/migrations/20260721000006_feed_version_agency_onestop_ids_drop_include_index.up.pgsql
@@ -1,0 +1,6 @@
+-- Drop the old covering btree on onestop_id, superseded by the hash index in the
+-- previous migration -- the same change made to feed_version_stop_onestop_ids,
+-- where the INCLUDE payload was shown never to deliver index-only scans. Concurrent
+-- drop, in its own single-statement migration: DROP INDEX CONCURRENTLY cannot run
+-- inside a transaction block.
+DROP INDEX CONCURRENTLY IF EXISTS feed_version_agency_onestop_i_onestop_id_entity_id_feed_ver_idx;


### PR DESCRIPTION
## Summary
Replaces the covering btree index on `onestop_id` with a hash index across the three `feed_version_*_onestop_ids` tables (stop, route, agency). These tables are looked up exclusively by exact `onestop_id` equality — the AllowPrevious resolution in `server/finders/dbfinder` — and their values are long `s-<geohash>-<name>` strings, so a hash index (which stores only the 4-byte hash of the key rather than the full string) is roughly half the size of the btree it replaces, at equivalent lookup performance. Six concurrent, idempotent migrations: create the hash index and drop the old covering index, one pair per table.

### Why hash instead of the covering btree
- Access is equality-only. AllowPrevious resolves onestop_ids via `WHERE onestop_id IN (...)`; there are no range, prefix, or ordering queries on the column, which is precisely the case a hash index exists for.
- The old index was `(onestop_id) INCLUDE (entity_id, feed_version_id)` — a covering btree whose payload was meant to enable index-only scans. It never did in practice: these tables churn constantly (an insert per fetch, deletes from onestop_id retention), so their visibility map stays stale and lookups fetch from the heap regardless. Verified on a production dataset — the index-only-scan path reported heap fetches equal to 100% of rows returned, and the large-result path is a bitmap heap scan that never touches the payload.
- Since the covering payload delivers nothing, a hash on `onestop_id` yields the same query plans and latency at roughly half the storage. On a production database the stop table's onestop_id index dropped from 79 GB (covering btree) to 36 GB (hash), with equivalent — marginally faster — timings on real AllowPrevious queries.
- The `(feed_version_id, entity_id)` unique index and the `feed_version_id` foreign key are unchanged; they serve the cull/delete and integrity paths and are unrelated to onestop_id lookups.

### Migration structure
- Six files: a create-hash and a drop-old-covering migration for each of the stop, route, and agency tables, ordered create-before-drop so an onestop_id index is always present.
- Each is a single `CONCURRENTLY` statement with no transaction wrapper: golang-migrate runs each file as one statement execution, and `CREATE`/`DROP INDEX CONCURRENTLY` cannot run inside a transaction block. One operation per file also makes a mid-build failure recoverable per operation.
- Idempotent — `CREATE INDEX ... IF NOT EXISTS` and `DROP INDEX ... IF EXISTS` — so the migration converges whether or not an index was already built out of band. The old covering indexes were auto-named, so the drops target their exact generated names, verified against the live catalog (including the table-name truncation the name generator applied).
- Postgres-only; sqlite has no hash indexes and its onestop_id tables are test-scale, so its schema is untouched.

## Test plan
- `go build ./schema/postgres/`; confirm the migrations embed and parse.
- Run `dbmigrate up` against a database and verify the three hash indexes exist (`\d feed_version_stop_onestop_ids`, etc.) and the three old covering indexes are gone.
- Re-run an AllowPrevious lookup (`WHERE onestop_id IN (...)`) and confirm the plan uses the hash index (`Bitmap Index Scan on ..._onestop_id_idx`) at equivalent latency.
- Confirm idempotency: `dbmigrate up` a second time is a no-op, and it skips cleanly against a database where an index was pre-built.
