### PR TITLE
Fix validation reports blocking unimport

### DIFF
--- a/importer/unimporter.go
+++ b/importer/unimporter.go
@@ -93,6 +93,12 @@ func DeleteFeedVersion(ctx context.Context, atx tldb.Adapter, id int, extraTable
 		return err
 	}
 
+	// Validation report child rows are keyed on the report, not feed_version_id, so
+	// the generic table loop cannot reach them. Delete them before tl_validation_reports.
+	if err := deleteFeedVersionValidationReports(ctx, atx, id); err != nil {
+		return err
+	}
+
 	// Required tables
 	fvt := dmfr.GetFeedVersionTables()
 	tables := []string{}
@@ -116,4 +122,33 @@ func DeleteFeedVersion(ctx context.Context, atx tldb.Adapter, id int, extraTable
 	}
 	return nil
 
+}
+
+// deleteFeedVersionValidationReports removes the tl_validation_reports subtree for a
+// feed version. Its child and grandchild tables are keyed on the report id, not
+// feed_version_id, and their foreign keys are NOT DEFERRABLE, so they must be deleted
+// through the parent, deepest first. tl_validation_reports itself is keyed on
+// feed_version_id and is removed by the caller's generic table loop.
+func deleteFeedVersionValidationReports(ctx context.Context, atx tldb.Adapter, id int) error {
+	// error_exemplars -> error_groups -> reports
+	if _, err := atx.Sqrl().
+		Delete("tl_validation_report_error_exemplars").
+		Where("validation_report_error_group_id IN (SELECT id FROM tl_validation_report_error_groups WHERE validation_report_id IN (SELECT id FROM tl_validation_reports WHERE feed_version_id = ?))", id).
+		ExecContext(ctx); err != nil {
+		return err
+	}
+	// The remaining children reference the report directly.
+	for _, table := range []string{
+		"tl_validation_report_error_groups",
+		"tl_validation_trip_update_stats",
+		"tl_validation_vehicle_position_stats",
+	} {
+		if _, err := atx.Sqrl().
+			Delete(table).
+			Where("validation_report_id IN (SELECT id FROM tl_validation_reports WHERE feed_version_id = ?)", id).
+			ExecContext(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/importer/unimporter_test.go
+++ b/importer/unimporter_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/interline-io/transitland-lib/tlcsv"
 	"github.com/interline-io/transitland-lib/tldb"
 	"github.com/interline-io/transitland-lib/tt"
+	"github.com/interline-io/transitland-lib/validator"
 	sq "github.com/irees/squirrel"
 	"github.com/stretchr/testify/assert"
 )
@@ -216,6 +217,68 @@ func TestDeleteFeedVersion(t *testing.T) {
 					t.Fatal(err)
 				}
 				assert.Equal(t, 1, fvCount, "feed versions")
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+// A stored validation report and its child/grandchild rows have NOT DEFERRABLE
+// foreign keys onto tl_validation_reports and no feed_version_id column, so they used
+// to block feed version delete. DeleteFeedVersion must clear the whole subtree.
+func TestDeleteFeedVersion_ValidationReport(t *testing.T) {
+	ctx := context.TODO()
+	dburl := os.Getenv("TL_TEST_DATABASE_URL")
+	err := testdb.TempPostgres(dburl, func(atx tldb.Adapter) error {
+		fvid := setupImport(ctx, t, atx)
+
+		// Report -> error group -> exemplar, plus the two RT stat children.
+		report := validator.NewResult(time.Now(), time.Now())
+		report.FeedVersionID = fvid
+		reportID := testdb.ShouldInsert(t, atx, report)
+		group := &validator.ValidationReportErrorGroup{
+			ValidationReportID: reportID,
+			Filename:           "stops.txt",
+			Field:              "stop_id",
+			ErrorType:          "test",
+			ErrorCode:          "test",
+			Count:              1,
+		}
+		groupID := testdb.ShouldInsert(t, atx, group)
+		testdb.ShouldInsert(t, atx, &validator.ValidationReportErrorExemplar{
+			ValidationReportErrorGroupID: groupID,
+			Line:                         1,
+			EntityID:                     "s-1",
+			Value:                        "x",
+			Message:                      "test",
+		})
+		testdb.ShouldInsert(t, atx, &validator.ValidationReportTripUpdateStat{ValidationReportID: reportID, AgencyID: "a", RouteID: "r"})
+		testdb.ShouldInsert(t, atx, &validator.ValidationReportVehiclePositionStat{ValidationReportID: reportID, AgencyID: "a", RouteID: "r"})
+
+		if err := DeleteFeedVersion(ctx, atx, fvid, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		for _, tc := range []struct {
+			table string
+			col   string
+			id    int
+		}{
+			{"tl_validation_reports", "feed_version_id", fvid},
+			{"tl_validation_report_error_groups", "validation_report_id", reportID},
+			{"tl_validation_report_error_exemplars", "validation_report_error_group_id", groupID},
+			{"tl_validation_trip_update_stats", "validation_report_id", reportID},
+			{"tl_validation_vehicle_position_stats", "validation_report_id", reportID},
+		} {
+			t.Run(tc.table, func(t *testing.T) {
+				count := 0
+				if err := atx.Sqrl().Select("count(*)").From(tc.table).Where(sq.Eq{tc.col: tc.id}).Scan(&count); err != nil {
+					t.Fatal(err)
+				}
+				assert.Equal(t, 0, count, tc.table)
 			})
 		}
 		return nil


### PR DESCRIPTION
## Summary

`DeleteFeedVersion` could not remove a feed version that had a stored validation report. The report's child and grandchild tables — error groups, error exemplars, and the RT trip-update and vehicle-position stats — carry NOT DEFERRABLE foreign keys onto `tl_validation_reports` and have no `feed_version_id` column, so the generic `feed_version_id`-keyed delete loop can't reach them. Deleting `tl_validation_reports` (last in the table order) then fails on the foreign key whenever the report has at least one error group, which is essentially always. This adds a targeted step that clears the report subtree through the parent before `tl_validation_reports` is deleted. Reported against the deployment repo (issue 410).

### The fix

- New `deleteFeedVersionValidationReports` helper, called from `DeleteFeedVersion` before the generic table loop reaches `tl_validation_reports`.
- Deletes the subtree deepest-first: exemplars, then error groups / trip-update stats / vehicle-position stats. Each child is scoped through the parent (`... WHERE validation_report_id IN (SELECT id FROM tl_validation_reports WHERE feed_version_id = ?)`), and the exemplars via a two-level subquery. `tl_validation_reports` itself is keyed on `feed_version_id` and continues to be removed by the existing loop.
- Static-literal SQL with a bound parameter, matching the adapter's existing query style.

### Scope note

- The report subtree is four tables, not three. Besides the error-groups table and the two RT-stat tables, `tl_validation_report_error_exemplars` foreign-keys onto error groups, so it has to be deleted first or the error-groups delete hits its own FK. The delete order was verified against every `REFERENCES tl_validation*` in the schema.

### Tests

- New `TestDeleteFeedVersion_ValidationReport` inserts a report, error group, and exemplar plus both RT-stat children — using the `validator` models, the same way reports are written in production — then asserts the delete succeeds and all five tables are empty. The existing `TestDeleteFeedVersion` never inserted a report, so this path was previously untested.

## Test plan

- With a Postgres test database (`TL_TEST_DATABASE_URL`), run `go test -run TestDeleteFeedVersion ./importer/`; the existing and new delete tests pass.
- Optional manual check: import a feed version, validate it so a report with error groups is stored, then delete the feed version and confirm it succeeds with the `tl_validation_*` rows gone.
