### PR TITLE
Require context-aware DB handles in dbutil query helpers

### DIFF
--- a/internal/clock/swcache.go
+++ b/internal/clock/swcache.go
@@ -21,13 +21,13 @@ type ServiceWindow struct {
 }
 
 type ServiceWindowCache struct {
-	db          sqlx.Ext
+	db          sqlx.ExtContext
 	lock        sync.Mutex
 	fvslWindows map[int]*ServiceWindow
 	tzCache     *tzcache.Cache[int]
 }
 
-func NewServiceWindowCache(db sqlx.Ext) *ServiceWindowCache {
+func NewServiceWindowCache(db sqlx.ExtContext) *ServiceWindowCache {
 	return &ServiceWindowCache{
 		db:          db,
 		fvslWindows: map[int]*ServiceWindow{},

--- a/server/auth/azchecker/checker.go
+++ b/server/auth/azchecker/checker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/interline-io/transitland-lib/server/auth/authn"
 	"github.com/interline-io/transitland-lib/server/auth/authz"
 	"github.com/interline-io/transitland-lib/server/dbutil"
+	"github.com/interline-io/transitland-lib/tldb"
 )
 
 // For less typing
@@ -71,7 +72,7 @@ type FGAProvider interface {
 type Checker struct {
 	userClient   UserProvider
 	fgaClient    FGAProvider
-	db           sqlx.Ext
+	db           tldb.Ext
 	globalAdmins []string
 }
 
@@ -83,7 +84,7 @@ var (
 
 // NewChecker constructs an FGA-backed Checker. All arguments are required;
 // nil returns an error.
-func NewChecker(userClient UserProvider, fgaClient FGAProvider, db sqlx.Ext) (*Checker, error) {
+func NewChecker(userClient UserProvider, fgaClient FGAProvider, db tldb.Ext) (*Checker, error) {
 	if userClient == nil {
 		return nil, errors.New("azchecker.NewChecker: UserProvider must be non-nil")
 	}
@@ -840,7 +841,7 @@ func checkIds[T hasId](ents []T, ids []int64) error {
 	return nil
 }
 
-func getEntities[T hasId](ctx context.Context, db sqlx.Ext, ids []int64, table string, cols ...string) ([]T, error) {
+func getEntities[T hasId](ctx context.Context, db sqlx.ExtContext, ids []int64, table string, cols ...string) ([]T, error) {
 	var t []T
 	q := sq.StatementBuilder.Select(cols...).From(table).Where(sq.Eq{"id": ids})
 	if err := dbutil.Select(ctx, db, q, &t); err != nil {

--- a/server/dbutil/db.go
+++ b/server/dbutil/db.go
@@ -77,15 +77,11 @@ func WithQueryLogger(db querylogger.Ext, trace bool, longQueryDuration time.Dura
 }
 
 // Select runs a query and reads results into dest.
-func Select(ctx context.Context, db sqlx.Ext, q sq.SelectBuilder, dest interface{}) error {
+func Select(ctx context.Context, db sqlx.ExtContext, q sq.SelectBuilder, dest interface{}) error {
 	q = q.PlaceholderFormat(sq.Dollar)
 	qstr, qargs, err := q.ToSql()
 	if err == nil {
-		if a, ok := db.(sqlx.QueryerContext); ok {
-			err = sqlx.SelectContext(ctx, a, dest, qstr, qargs...)
-		} else {
-			err = sqlx.Select(db, dest, qstr, qargs...)
-		}
+		err = sqlx.SelectContext(ctx, db, dest, qstr, qargs...)
 	}
 	if ctx.Err() == context.Canceled {
 		log.Trace().Err(err).Str("query", qstr).Interface("args", qargs).Msg("query canceled")
@@ -96,15 +92,11 @@ func Select(ctx context.Context, db sqlx.Ext, q sq.SelectBuilder, dest interface
 }
 
 // Get runs a query and reads results into dest.
-func Get(ctx context.Context, db sqlx.Ext, q sq.SelectBuilder, dest interface{}) error {
+func Get(ctx context.Context, db sqlx.ExtContext, q sq.SelectBuilder, dest interface{}) error {
 	q = q.PlaceholderFormat(sq.Dollar)
 	qstr, qargs, err := q.ToSql()
 	if err == nil {
-		if a, ok := db.(sqlx.QueryerContext); ok {
-			err = sqlx.GetContext(ctx, a, dest, qstr, qargs...)
-		} else {
-			err = sqlx.Get(db, dest, qstr, qargs...)
-		}
+		err = sqlx.GetContext(ctx, db, dest, qstr, qargs...)
 	}
 	if ctx.Err() == context.Canceled {
 		log.Trace().Err(err).Str("query", qstr).Interface("args", qargs).Msg("query canceled")
@@ -115,15 +107,11 @@ func Get(ctx context.Context, db sqlx.Ext, q sq.SelectBuilder, dest interface{})
 }
 
 // Update runs an update statement.
-func Update(ctx context.Context, db sqlx.Ext, q sq.UpdateBuilder) error {
+func Update(ctx context.Context, db sqlx.ExtContext, q sq.UpdateBuilder) error {
 	q = q.PlaceholderFormat(sq.Dollar)
 	qstr, qargs, err := q.ToSql()
 	if err == nil {
-		if a, ok := db.(sqlx.ExecerContext); ok {
-			_, err = a.ExecContext(ctx, qstr, qargs...)
-		} else {
-			_, err = db.Exec(qstr, qargs...)
-		}
+		_, err = db.ExecContext(ctx, qstr, qargs...)
 	}
 	if ctx.Err() == context.Canceled {
 		log.Trace().Err(err).Str("query", qstr).Interface("args", qargs).Msg("update canceled")

--- a/server/finders/dbfinder/admincache.go
+++ b/server/finders/dbfinder/admincache.go
@@ -25,7 +25,7 @@ type adminCache struct {
 	index *tlxy.PolygonIndex
 }
 
-func newAdminCache(ctx context.Context, dbx sqlx.Ext) (*adminCache, error) {
+func newAdminCache(ctx context.Context, dbx sqlx.ExtContext) (*adminCache, error) {
 	ac := &adminCache{}
 	if err := ac.loadAdmins(ctx, dbx); err != nil {
 		return nil, err
@@ -33,7 +33,7 @@ func newAdminCache(ctx context.Context, dbx sqlx.Ext) (*adminCache, error) {
 	return ac, nil
 }
 
-func (c *adminCache) loadAdmins(ctx context.Context, dbx sqlx.Ext) error {
+func (c *adminCache) loadAdmins(ctx context.Context, dbx sqlx.ExtContext) error {
 	var ents []struct {
 		Adm0Name tt.String
 		Adm1Name tt.String


### PR DESCRIPTION
## Summary

The `dbutil` query helpers (`Select`, `Get`, `Update`) took the non-context `sqlx.Ext` interface and type-asserted up to the context-aware variant at runtime, with a non-context `else` fallback that silently dropped `ctx`. That branch was dead — every concrete handle passed in already implements the context methods — but if it ever fired it would run the query with no cancellation, no deadline, and no trace propagation. This removes the fallback and tightens each helper's DB argument to `sqlx.ExtContext`, moving the guarantee to compile time: a caller without context methods now fails to build instead of quietly losing `ctx`. The tightening ripples to the handful of holders that pass their DB handle into these helpers. Addresses deployment-repo issue 400.

### dbutil helpers

- `Select`/`Get`/`Update` now take `sqlx.ExtContext` and call `sqlx.SelectContext` / `sqlx.GetContext` / `db.ExecContext` directly. The `db.(sqlx.QueryerContext)` / `db.(sqlx.ExecerContext)` assertions and their non-context `else` branches are deleted. This was the only place in the tree carrying that assert-up-with-fallback shape.

### Callers tightened to match

- `internal/clock/ServiceWindowCache` and dbfinder's `newAdminCache` / `loadAdmins` hold or pass their handle only through `dbutil`, so their field and params move `sqlx.Ext` → `sqlx.ExtContext`.
- `azchecker.getEntities` → `sqlx.ExtContext` (it only runs a `dbutil.Select`).
- `azchecker.Checker.db` and `NewChecker` → `tldb.Ext`, not `sqlx.ExtContext`. The checker also builds statements with squirrel's `RunWith(c.db)`, which needs the non-context `BaseRunner` (`Exec`/`Query`). `sqlx.Ext` and `sqlx.ExtContext` are disjoint interfaces — neither embeds the other — so the field needs `tldb.Ext`, which satisfies both. `tldb.Ext` is still strictly tighter than the old `sqlx.Ext`: it now guarantees the context methods at compile time.

### API compatibility

- `NewChecker` (`sqlx.Ext` → `tldb.Ext`) and `NewServiceWindowCache` (`sqlx.Ext` → `sqlx.ExtContext`) are exported, so this is technically a breaking signature change. In practice every caller passes `*sqlx.DB`, `*querylogger.QueryLogger`, or `tldb.Ext`, all of which satisfy the new types, so the deployment repo and all internal callers build unchanged. Warrants a minor version bump.

### Out of scope

- `rtfinder`'s lookup cache and azchecker's `EKLookup` / `dbNameToEntityKey` / `dbTupleLookup` call the non-context `sqlx.Get` / `sqlx.Select` package functions directly and don't receive a `ctx`. That is a related but distinct ctx-drop, not the assert-up fallback this issue targets, and fixing it means threading `ctx` through those signatures. Left for a follow-up.

## Test plan

- `go build ./...` and `go vet ./...` are clean; vet compiles the test files too, confirming no test passes a loose handle into the tightened helpers.
- `go test ./server/dbutil/ ./internal/clock/ ./server/finders/dbfinder/ ./server/auth/azchecker/` pass against a Postgres test database.
