### PR TITLE
Fix census source-to-layer resolver dropping shared layers

### DIFF
--- a/server/finders/dbfinder/census.go
+++ b/server/finders/dbfinder/census.go
@@ -172,9 +172,12 @@ func (f *Finder) CensusSourceLayersBySourceIDs(ctx context.Context, keys []int) 
 		model.CensusLayer
 	}
 	var ents []*qent
+	// Dedup per (source, layer): the dataloader batches multiple source ids into one
+	// query, and sources can share a layer, so deduping on layer id alone would drop a
+	// shared layer from every source but one.
 	q := sq.StatementBuilder.
 		Select("tlcg.source_id", "tlcl.*").
-		Distinct().Options("on (tlcl.id)").
+		Distinct().Options("on (tlcg.source_id, tlcl.id)").
 		From("tl_census_geographies tlcg").
 		Join("tl_census_layers tlcl on tlcl.id = tlcg.layer_id").
 		Where(sq.Eq{"tlcg.source_id": keys})

--- a/server/finders/dbfinder/census_test.go
+++ b/server/finders/dbfinder/census_test.go
@@ -1,0 +1,44 @@
+package dbfinder
+
+import (
+	"context"
+	"testing"
+
+	"github.com/interline-io/transitland-lib/server/dbutil"
+	"github.com/interline-io/transitland-lib/server/model"
+	"github.com/interline-io/transitland-lib/server/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// When two census sources share a layer, the batched loader must return that layer
+// for both. Deduping the geography->layer join on layer id alone dropped a shared
+// layer from every source but one.
+func TestCensusSourceLayersBySourceIDs_SharedLayer(t *testing.T) {
+	ctx := context.Background()
+	db := testutil.MustOpenTestDB(t)
+	dbf := NewFinder(dbutil.WithQueryLogger(db, false, 0))
+
+	// Both sources have geographies in the tract layer -- the shared-layer case that
+	// exposes the batch collision (a single source id would dedup correctly).
+	var s1, s2 int
+	if err := db.Get(&s1, "select id from tl_census_sources where name = 'tl_2024_06_tract.zip'"); err != nil {
+		t.Skipf("census fixture not loaded: %v", err)
+	}
+	require.NoError(t, db.Get(&s2, "select id from tl_census_sources where name = 'tl_2024_53_tract.zip'"))
+
+	got, errs := dbf.CensusSourceLayersBySourceIDs(ctx, []int{s1, s2})
+	for _, err := range errs {
+		require.NoError(t, err)
+	}
+	require.Len(t, got, 2)
+	require.Contains(t, layerNames(got[0]), "tract", "first source missing shared layer")
+	require.Contains(t, layerNames(got[1]), "tract", "second source missing shared layer")
+}
+
+func layerNames(layers []*model.CensusLayer) []string {
+	names := make([]string, 0, len(layers))
+	for _, l := range layers {
+		names = append(names, l.Name)
+	}
+	return names
+}


### PR DESCRIPTION
## Summary

`CensusSource.layers` could return an incomplete or empty layer list. The resolver's finder, `CensusSourceLayersBySourceIDs`, is a dataloader that batches multiple source ids into one query, but it deduped the geography-to-layer join with `DISTINCT ON (tlcl.id)` — on layer id alone. When two sources in the same batch share a layer, Postgres keeps one arbitrary row for that layer, so every source but one loses it. This changes the dedup key to `(source_id, layer_id)` so each source keeps all of its layers. Found while investigating the census source child resolvers; it is a standalone correctness fix.

### The bug

- The dedup key ignored the source, so a shared layer collapsed to a single source across the whole batch. A single-source resolution (batch of one) dedups correctly, which is why it went unnoticed and the existing single-source test passed.
- Reproduced on the loaded test fixture: sources `tl_2024_06_tract.zip` and `tl_2024_53_tract.zip` both have geographies in the `tract` layer. The old query returns `tract` for only one of them; the new query returns it for both.

### Test

- Add `TestCensusSourceLayersBySourceIDs_SharedLayer`, a finder-level regression test that resolves both tract sources in a single batch and asserts each keeps the `tract` layer. It is deterministic (no dataloader-timing dependency) and fails on the old query — verified by reverting the fix.

## Test plan

- `go test -run TestCensusSourceLayersBySourceIDs_SharedLayer ./server/finders/dbfinder/` passes, and fails when the dedup key is reverted to `on (tlcl.id)`.
- `go test -run TestCensusResolver ./server/gql/` still passes; the existing single-source `source layers` case is unaffected.
