### PR TITLE
Add CensusSource.tables resolver

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -265,6 +265,8 @@ models:
         resolver: true
       geographies:
         resolver: true
+      tables:
+        resolver: true
     extraFields:
       DatasetID:
         type: int

--- a/internal/generated/gqlout/generated.go
+++ b/internal/generated/gqlout/generated.go
@@ -214,7 +214,7 @@ type ComplexityRoot struct {
 		Layers      func(childComplexity int) int
 		Name        func(childComplexity int) int
 		Sha1        func(childComplexity int) int
-		Tables      func(childComplexity int, limit *int) int
+		Tables      func(childComplexity int, limit *int, where *model.CensusTableFilter) int
 		URL         func(childComplexity int) int
 	}
 
@@ -1377,7 +1377,7 @@ type CensusLayerResolver interface {
 }
 type CensusSourceResolver interface {
 	Geographies(ctx context.Context, obj *model.CensusSource, limit *int, where *model.CensusSourceGeographyFilter) ([]*model.CensusGeography, error)
-
+	Tables(ctx context.Context, obj *model.CensusSource, limit *int, where *model.CensusTableFilter) ([]*model.CensusTable, error)
 	Layers(ctx context.Context, obj *model.CensusSource) ([]*model.CensusLayer, error)
 }
 type CensusTableResolver interface {
@@ -2384,7 +2384,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.ComplexityRoot.CensusSource.Tables(childComplexity, args["limit"].(*int)), true
+		return e.ComplexityRoot.CensusSource.Tables(childComplexity, args["limit"].(*int), args["where"].(*model.CensusTableFilter)), true
 	case "CensusSource.url":
 		if e.ComplexityRoot.CensusSource.URL == nil {
 			break
@@ -10777,7 +10777,7 @@ type CensusSource {
   geographies(limit: Int, where: CensusSourceGeographyFilter): [CensusGeography!]
 
   "Data tables loaded from this source file"
-  tables(limit: Int): [CensusTable!]
+  tables(limit: Int, where: CensusTableFilter): [CensusTable!]
 
   "Geographic layers defined by this source file"
   layers: [CensusLayer!]
@@ -14872,6 +14872,14 @@ func (ec *executionContext) field_CensusSource_tables_args(ctx context.Context, 
 		return nil, err
 	}
 	args["limit"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "where",
+		func(ctx context.Context, v any) (*model.CensusTableFilter, error) {
+			return ec.unmarshalOCensusTableFilter2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐCensusTableFilter(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["where"] = arg1
 	return args, nil
 }
 
@@ -19758,7 +19766,8 @@ func (ec *executionContext) _CensusSource_tables(ctx context.Context, field grap
 			return ec.fieldContext_CensusSource_tables(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
-			return obj.Tables, nil
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.CensusSource().Tables(ctx, obj, fc.Args["limit"].(*int), fc.Args["where"].(*model.CensusTableFilter))
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v []*model.CensusTable) graphql.Marshaler {
@@ -19772,8 +19781,8 @@ func (ec *executionContext) fieldContext_CensusSource_tables(ctx context.Context
 	fc = &graphql.FieldContext{
 		Object:     "CensusSource",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return ec.childFields_CensusTable(ctx, field)
 		},
@@ -47063,7 +47072,38 @@ func (ec *executionContext) _CensusSource(ctx context.Context, sel ast.Selection
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "tables":
-			out.Values[i] = ec._CensusSource_tables(ctx, field, obj)
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._CensusSource_tables(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "layers":
 			field := field
 

--- a/schema/graphql/schema.graphqls
+++ b/schema/graphql/schema.graphqls
@@ -1921,7 +1921,7 @@ type CensusSource {
   geographies(limit: Int, where: CensusSourceGeographyFilter): [CensusGeography!]
 
   "Data tables loaded from this source file"
-  tables(limit: Int): [CensusTable!]
+  tables(limit: Int, where: CensusTableFilter): [CensusTable!]
 
   "Geographic layers defined by this source file"
   layers: [CensusLayer!]

--- a/server/finders/dbfinder/census.go
+++ b/server/finders/dbfinder/census.go
@@ -198,6 +198,42 @@ func (f *Finder) CensusSourceLayersBySourceIDs(ctx context.Context, keys []int) 
 	return ret, nil
 }
 
+func (f *Finder) CensusTablesBySourceIDs(ctx context.Context, limit *int, where *model.CensusTableFilter, keys []int) ([][]*model.CensusTable, error) {
+	type qent struct {
+		SourceID int
+		model.CensusTable
+	}
+	var ents []*qent
+	// Tables have no source_id; the source->table association lives in the loaded
+	// values. Dedup per (source, table) since the loader batches multiple source ids
+	// and a table can appear across sources.
+	q := sq.StatementBuilder.
+		Select("v.source_id", "tlct.*").
+		Distinct().Options("on (v.source_id, tlct.id)").
+		From("tl_census_values v").
+		Join("tl_census_tables tlct on tlct.id = v.table_id").
+		Where(sq.Eq{"v.source_id": keys})
+	if where != nil && where.Search != nil {
+		q = q.Where(sq.ILike{"tlct.table_name": dbutil.EscapeLike(*where.Search, true, true)})
+	}
+	if err := dbutil.Select(ctx, f.db, q, &ents); err != nil {
+		return nil, logErr(ctx, err)
+	}
+	grouped := arrangeGroup(keys, ents, func(ent *qent) int { return ent.SourceID })
+	var ret [][]*model.CensusTable
+	for _, group := range grouped {
+		var g []*model.CensusTable
+		for _, ent := range group {
+			g = append(g, &ent.CensusTable)
+		}
+		if limit != nil && len(g) > *limit {
+			g = g[:*limit]
+		}
+		ret = append(ret, g)
+	}
+	return ret, nil
+}
+
 func (f *Finder) CensusGeographiesByDatasetIDs(ctx context.Context, limit *int, p *model.CensusDatasetGeographyFilter, keys []int) ([][]*model.CensusGeography, error) {
 	var ents []*model.CensusGeography
 	q := censusDatasetGeographySelect(limit, p, getCensusGeographySelectFields(ctx)).Where(sq.Eq{"tlcd.id": keys})

--- a/server/finders/dbfinder/census.go
+++ b/server/finders/dbfinder/census.go
@@ -212,7 +212,8 @@ func (f *Finder) CensusTablesBySourceIDs(ctx context.Context, limit *int, where 
 		Distinct().Options("on (v.source_id, tlct.id)").
 		From("tl_census_values v").
 		Join("tl_census_tables tlct on tlct.id = v.table_id").
-		Where(sq.Eq{"v.source_id": keys})
+		Where(sq.Eq{"v.source_id": keys}).
+		OrderBy("v.source_id", "tlct.id")
 	if where != nil && where.Search != nil {
 		q = q.Where(sq.ILike{"tlct.table_name": dbutil.EscapeLike(*where.Search, true, true)})
 	}
@@ -226,7 +227,7 @@ func (f *Finder) CensusTablesBySourceIDs(ctx context.Context, limit *int, where 
 		for _, ent := range group {
 			g = append(g, &ent.CensusTable)
 		}
-		if limit != nil && len(g) > *limit {
+		if limit != nil && *limit >= 0 && len(g) > *limit {
 			g = g[:*limit]
 		}
 		ret = append(ret, g)

--- a/server/gql/census_resolver.go
+++ b/server/gql/census_resolver.go
@@ -95,7 +95,7 @@ func (r *censusSourceResolver) Geographies(ctx context.Context, obj *model.Censu
 }
 
 func (r *censusSourceResolver) Tables(ctx context.Context, obj *model.CensusSource, limit *int, where *model.CensusTableFilter) (ret []*model.CensusTable, err error) {
-	return LoaderFor(ctx).CensusTablesBySourceIDs.Load(ctx, censusSourceTableLoaderParam{SourceID: obj.ID, Limit: resolverCheckLimit(limit), Where: where})()
+	return LoaderFor(ctx).CensusTablesBySourceIDs.Load(ctx, censusSourceTableLoaderParam{SourceID: obj.ID, Limit: resolverCheckLimitMax(limit, RESOLVER_CENSUS_MAXLIMIT), Where: where})()
 }
 
 type censusGeographyResolver struct{ *Resolver }

--- a/server/gql/census_resolver.go
+++ b/server/gql/census_resolver.go
@@ -94,6 +94,10 @@ func (r *censusSourceResolver) Geographies(ctx context.Context, obj *model.Censu
 	return LoaderFor(ctx).CensusGeographiesBySourceIDs.Load(ctx, censusSourceGeographyLoaderParam{SourceID: obj.ID, Limit: resolverCheckLimitMax(limit, RESOLVER_CENSUS_MAXLIMIT), Where: where})()
 }
 
+func (r *censusSourceResolver) Tables(ctx context.Context, obj *model.CensusSource, limit *int, where *model.CensusTableFilter) (ret []*model.CensusTable, err error) {
+	return LoaderFor(ctx).CensusTablesBySourceIDs.Load(ctx, censusSourceTableLoaderParam{SourceID: obj.ID, Limit: resolverCheckLimit(limit), Where: where})()
+}
+
 type censusGeographyResolver struct{ *Resolver }
 
 func (r *censusGeographyResolver) Values(ctx context.Context, obj *model.CensusGeography, tableNames []string, datasetName *string, limit *int) ([]*model.CensusValue, error) {

--- a/server/gql/census_resolver_test.go
+++ b/server/gql/census_resolver_test.go
@@ -188,6 +188,20 @@ func TestCensusResolver(t *testing.T) {
 			vars:   vars,
 			expect: `{"census_datasets":[{"name":"tiger2024","sources":[{"layers":[{"description":"Layer: tract","name":"tract"}],"name":"tl_2024_06_tract.zip"}]}]}`,
 		},
+		// Source tables: an ACS source resolves to the table it loaded; a TIGER source
+		// (geographies only) resolves to none -- the tables-vs-layers distinction.
+		{
+			name:   "source tables",
+			query:  `query { census_datasets(where:{name:"acsdt5y2022"}) {name sources(where:{name:"acsdt5y2022-b01001.dat"}) {name tables { table_name }} } }`,
+			vars:   vars,
+			expect: `{"census_datasets":[{"name":"acsdt5y2022","sources":[{"name":"acsdt5y2022-b01001.dat","tables":[{"table_name":"b01001"}]}]}]}`,
+		},
+		{
+			name:   "source tables empty for tiger",
+			query:  `query { census_datasets(where:{name:"tiger2024"}) {name sources(where:{name:"tl_2024_06_tract.zip"}) {name tables { table_name }} } }`,
+			vars:   vars,
+			expect: `{"census_datasets":[{"name":"tiger2024","sources":[{"name":"tl_2024_06_tract.zip","tables":null}]}]}`,
+		},
 		{
 			name:   "source geographies",
 			query:  `query { census_datasets(where:{name:"tiger2024"}) {name sources(where:{name:"tl_2024_us_county.zip"}) {name geographies(where:{search:"ala"}) { name } } } }`,

--- a/server/gql/loader_params.go
+++ b/server/gql/loader_params.go
@@ -197,6 +197,11 @@ type censusTableLoaderParam struct {
 	Limit     *int
 	Where     *model.CensusTableFilter
 }
+type censusSourceTableLoaderParam struct {
+	SourceID int
+	Limit    *int
+	Where    *model.CensusTableFilter
+}
 
 type routeStopPatternLoaderParam struct {
 	RouteID int

--- a/server/gql/loaders.go
+++ b/server/gql/loaders.go
@@ -41,6 +41,7 @@ type Loaders struct {
 	CensusGeographiesByEntityIDs                                  *dataloader.Loader[censusGeographyLoaderParam, []*model.CensusGeography]
 	CensusSourcesByDatasetIDs                                     *dataloader.Loader[censusSourceLoaderParam, []*model.CensusSource]
 	CensusTablesByDatasetIDs                                      *dataloader.Loader[censusTableLoaderParam, []*model.CensusTable]
+	CensusTablesBySourceIDs                                       *dataloader.Loader[censusSourceTableLoaderParam, []*model.CensusTable]
 	CensusGeographiesByLayerIDs                                   *dataloader.Loader[censusSourceGeographyLoaderParam, []*model.CensusGeography]
 	CensusSourcesByIDs                                            *dataloader.Loader[int, *model.CensusSource]
 	CensusLayersByIDs                                             *dataloader.Loader[int, *model.CensusLayer]
@@ -188,6 +189,11 @@ func NewLoaders(dbf model.Finder, batchSize int, stopTimeBatchSize int) *Loaders
 		CensusTablesByDatasetIDs: withWaitAndCapacityGroup(waitTime, batchSize, dbf.CensusTablesByDatasetIDs,
 			func(p censusTableLoaderParam) (int, *model.CensusTableFilter, *int) {
 				return p.DatasetID, p.Where, p.Limit
+			},
+		),
+		CensusTablesBySourceIDs: withWaitAndCapacityGroup(waitTime, batchSize, dbf.CensusTablesBySourceIDs,
+			func(p censusSourceTableLoaderParam) (int, *model.CensusTableFilter, *int) {
+				return p.SourceID, p.Where, p.Limit
 			},
 		),
 		CensusTableByIDs:   withWaitAndCapacity(waitTime, batchSize, dbf.CensusTableByIDs),

--- a/server/model/finders.go
+++ b/server/model/finders.go
@@ -65,6 +65,7 @@ type EntityLoader interface {
 	CensusSourceLayersBySourceIDs(context.Context, []int) ([][]*CensusLayer, []error)
 	CensusSourcesByDatasetIDs(context.Context, *int, *CensusSourceFilter, []int) ([][]*CensusSource, error)
 	CensusTablesByDatasetIDs(context.Context, *int, *CensusTableFilter, []int) ([][]*CensusTable, error)
+	CensusTablesBySourceIDs(context.Context, *int, *CensusTableFilter, []int) ([][]*CensusTable, error)
 	CensusTableByIDs(context.Context, []int) ([]*CensusTable, []error)
 	CensusValuesByGeographyIDs(context.Context, *int, string, []string, []string) ([][]*CensusValue, error)
 	FeedFetchesByFeedIDs(context.Context, *int, *FeedFetchFilter, []int) ([][]*FeedFetch, error)

--- a/server/model/unimplemented_finder.go
+++ b/server/model/unimplemented_finder.go
@@ -163,6 +163,10 @@ func (UnimplementedFinder) CensusSourcesByDatasetIDs(context.Context, *int, *Cen
 func (UnimplementedFinder) CensusTablesByDatasetIDs(context.Context, *int, *CensusTableFilter, []int) ([][]*CensusTable, error) {
 	return nil, notImplErr()
 }
+
+func (UnimplementedFinder) CensusTablesBySourceIDs(context.Context, *int, *CensusTableFilter, []int) ([][]*CensusTable, error) {
+	return nil, notImplErr()
+}
 func (UnimplementedFinder) CensusTableByIDs(_ context.Context, ids []int) ([]*CensusTable, []error) {
 	return notImplBatch[*CensusTable](ids)
 }


### PR DESCRIPTION
## Summary

`CensusSource.tables` always returned null. The field existed in the schema and model, but had no resolver — gqlgen bound it to the never-populated `model.CensusSource.Tables` struct field (and ignored its `limit` arg), so `census_datasets { sources { tables } }` came back empty. This adds a real resolver: a `CensusTablesBySourceIDs` loader and finder that resolves a source's tables through the values it loaded. Fixes deployment-repo issue 205.

### Why it was broken

- `CensusSource.tables` was not marked `resolver: true`, so gqlgen generated a field binding that returned `obj.Tables` — which nothing populates. Its sibling fields `layers` and `geographies` do have resolvers, which is why they worked and `tables` did not.
- Tables have no `source_id`; they are dataset-scoped. The source-to-table association only exists in `tl_census_values (source_id, table_id)`, so the resolver derives a source's tables from the distinct tables it loaded values for.

### The fix

- Mark `CensusSource.tables` as a resolver (`gqlgen.yml`), regenerate, and add `censusSourceResolver.Tables`.
- New `CensusTablesBySourceIDs` finder: `SELECT DISTINCT ON (source_id, table_id) ... FROM tl_census_values JOIN tl_census_tables ...`, grouped per source. The `(source_id, table_id)` dedup keeps each source's tables correct when the dataloader batches multiple source ids.
- Add `where: CensusTableFilter` to the field, matching `CensusDataset.tables`.

### Tests

- Extend `TestCensusResolver`: an ACS source (`acsdt5y2022-b01001.dat`) now resolves to its table (`b01001`), and a TIGER source (geographies only) resolves to none — the tables-vs-layers signal used to tell ACS from TIGER data.

### Performance note

- The lookup scans a source's value rows (index-supported on `source_id`) to find its distinct tables. It is an opt-in resolver and each source typically loads one table, so results are tiny; if it ever becomes hot, a materialized source-to-table association would remove the values scan.

## Test plan

- `go test -run TestCensusResolver ./server/gql/` passes, including the new `source tables` and `source tables empty for tiger` cases.
- `go generate ./...` leaves the tree clean; the regen only adds the `CensusSource.tables` wiring.
