### PR TITLE
Flag impossible travel speeds in the fast-travel check

### DIFF
--- a/ext/bestpractices/fast_travel.go
+++ b/ext/bestpractices/fast_travel.go
@@ -8,7 +8,7 @@ import (
 	"github.com/interline-io/transitland-lib/tt"
 )
 
-// FastTravelError reports when reasonable maximum speeds have been exceeded for at least 30 seconds.
+// FastTravelError reports when the implied speed between two consecutive stops exceeds the assumed maximum for the route type.
 type FastTravelError struct {
 	TripID       string
 	StopSequence int
@@ -119,7 +119,10 @@ func (e *StopTimeFastTravelCheck) Validate(ent tt.Entity) []error {
 		}
 		dt := trip.StopTimes[i].ArrivalTime.Int() - t.Int()
 		speed := (dx / 1000.0) / (float64(dt) / 3600.0)
-		if dt > 30 && speed > maxspeed {
+		// Two distinct stops sharing an arrival time give dt == 0 and an infinite
+		// speed (dx > 0), which exceeds maxspeed. NaN (dx == 0) and negative (dt < 0)
+		// speeds compare false, so those edges are skipped.
+		if speed > maxspeed {
 			errs = append(errs, newFastTravelError(trip.TripID.Val, trip.StopTimes[i].StopSequence.Int(), s1, s2, dt, dx, speed, maxspeed))
 		}
 		s1 = s2

--- a/ext/bestpractices/fast_travel.go
+++ b/ext/bestpractices/fast_travel.go
@@ -119,9 +119,9 @@ func (e *StopTimeFastTravelCheck) Validate(ent tt.Entity) []error {
 		}
 		dt := trip.StopTimes[i].ArrivalTime.Int() - t.Int()
 		speed := (dx / 1000.0) / (float64(dt) / 3600.0)
-		// Two distinct stops sharing an arrival time give dt == 0 and an infinite
-		// speed (dx > 0), which exceeds maxspeed. NaN (dx == 0) and negative (dt < 0)
-		// speeds compare false, so those edges are skipped.
+		// A shared arrival time between distinct stops gives dt == 0 and, with
+		// dx > 0, an infinite speed that exceeds maxspeed. Degenerate speeds --
+		// zero, NaN (0/0), or negative (dt < 0) -- all compare false and are skipped.
 		if speed > maxspeed {
 			errs = append(errs, newFastTravelError(trip.TripID.Val, trip.StopTimes[i].StopSequence.Int(), s1, s2, dt, dx, speed, maxspeed))
 		}

--- a/testdata/gtfs-validator-layers/best-practices/stop-time-fast-travel/readme.md
+++ b/testdata/gtfs-validator-layers/best-practices/stop-time-fast-travel/readme.md
@@ -1,0 +1,2 @@
+Two stops (12TH, LAKE) share arrival time 05:02:00 but sit ~740m apart, so
+the implied travel speed is infinite -> FastTravelError.

--- a/testdata/gtfs-validator-layers/best-practices/stop-time-fast-travel/stop_times.txt
+++ b/testdata/gtfs-validator-layers/best-practices/stop-time-fast-travel/stop_times.txt
@@ -1,0 +1,4 @@
+trip_id,arrival_time,departure_time,stop_id,stop_sequence,stop_headsign,pickup_type,drop_off_type,shape_dist_traveled,timepoint
+2230435WKDY,05:00:00,05:00:00,19TH,8,Fremont,,,,1
+2230435WKDY,05:02:00,05:02:00,12TH,9,Fremont,,,,1
+2230435WKDY,05:02:00,05:02:00,LAKE,10,Fremont,,,,1

--- a/testdata/gtfs-validator-layers/best-practices/stop-time-fast-travel/trips.txt
+++ b/testdata/gtfs-validator-layers/best-practices/stop-time-fast-travel/trips.txt
@@ -1,0 +1,2 @@
+route_id,service_id,trip_id,trip_headsign,direction_id,block_id,shape_id,wheelchair_accessible,bikes_allowed,expect_error
+03,WKDY,2230435WKDY,Fremont,0,,04_shp,1,1,FastTravelError


### PR DESCRIPTION
## Summary

The fast-travel best-practice check only flagged edges where the time between two stops exceeded 30 seconds, so two stops sharing an arrival time -- an infinite implied speed -- slipped through, as did any impossible speed over a sub-30-second gap. This drops the `dt > 30` guard so the check flags whenever the implied speed exceeds the route type's assumed maximum, which naturally includes the infinite case. Refreshes #313, which was 2+ years stale and conflicting; the check has since moved from `rules/` to `ext/bestpractices/`.

### The change

- `ext/bestpractices/fast_travel.go`: `if dt > 30 && speed > maxspeed` becomes `if speed > maxspeed`. Two distinct stops with the same time give `dt == 0` and `speed == +Inf` (when `dx > 0`), which exceeds any finite maximum; the degenerate speeds -- zero (`dx == 0`), `NaN` (`0/0`), and negative (`dt < 0`) -- compare false and are skipped, verified against the actual float behavior. This is the clean equivalent of #313's added `dt <= 30 && dx > 0 && (speed > maxspeed || math.IsInf(...))` branch: since `+Inf > maxspeed` is already true, the explicit `IsInf` check and the `dt`/`dx` guards are redundant, so simply removing the guard expresses the same intent in one condition and drops the `math` import.
- Updates the `FastTravelError` doc comment to drop the now-inaccurate "for at least 30 seconds".

### Test

- New overlay `testdata/gtfs-validator-layers/best-practices/stop-time-fast-travel/`: the base BART trip with 12TH and LAKE both at `05:02:00` (~740 m apart, so infinite implied speed), with `expect_error=FastTravelError` on the trip. It passes under `TestValidator_BestPractices`, and the full best-practices and error suites still pass -- the more aggressive check produces no new errors on the base feed or the other overlays.

## Test plan

- `go test -run TestValidator_BestPractices ./validator/` and `go test ./ext/bestpractices/` pass; `go vet` and `gofmt` are clean.
