### PR TITLE
New kvcache design with pluggable backends

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
       TL_TEST_DATABASE_URL: postgres://root:for_testing@localhost:5432/tlv2_test?sslmode=disable
       TL_TEST_SERVER_DATABASE_URL: postgres://root:for_testing@localhost:5432/tlv2_test_server?sslmode=disable
       TL_REDIS_URL: redis://localhost
+      TL_TEST_REDIS_URL: redis://localhost
     services:
       postgres:
         image: postgis/postgis:16-3.4-alpine

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/twpayne/go-polyline v1.1.1
 	github.com/twpayne/go-shapefile v0.0.7
 	github.com/vektah/gqlparser/v2 v2.5.33
+	golang.org/x/sync v0.21.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/dnaeon/go-vcr.v2 v2.3.0
 )
@@ -171,7 +172,6 @@ require (
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.37.0 // indirect

--- a/server/caches/kvcache/kvcache.go
+++ b/server/caches/kvcache/kvcache.go
@@ -245,12 +245,15 @@ func (c *Cache[K, V]) loadOrRefresh(ctx context.Context, key K) (Item[V], bool) 
 			if it, err := c.runRefresh(fctx, key); err == nil {
 				return result{item: it, ok: true}, nil
 			}
+			c.deleteExpiredLocal(key)
 			return result{}, nil
 		}
 		// Definite miss with no refresh source; optionally suppress
 		// repeated storage reads with a local-only tombstone.
 		if c.NegativeTTL > 0 {
 			c.setLocal(key, c.missingItem(c.NegativeTTL))
+		} else {
+			c.deleteExpiredLocal(key)
 		}
 		return result{}, nil
 	})
@@ -370,6 +373,18 @@ func (c *Cache[K, V]) getStore(ctx context.Context, key K) (Item[V], bool) {
 func (c *Cache[K, V]) setLocal(key K, it Item[V]) {
 	c.lock.Lock()
 	c.items[key] = it
+	c.lock.Unlock()
+}
+
+// deleteExpiredLocal removes key's local entry if it is still expired,
+// so keys that never re-materialize don't accumulate between scans. The
+// re-check under the write lock avoids clobbering a concurrent Set.
+func (c *Cache[K, V]) deleteExpiredLocal(key K) {
+	n := c.now()
+	c.lock.Lock()
+	if it, ok := c.items[key]; ok && !it.ExpiresAt.After(n) {
+		delete(c.items, key)
+	}
 	c.lock.Unlock()
 }
 

--- a/server/caches/kvcache/kvcache.go
+++ b/server/caches/kvcache/kvcache.go
@@ -38,6 +38,9 @@ type Cache[K comparable, V any] struct {
 	// RefreshTimeout bounds each refresh function call (default 1s).
 	RefreshTimeout time.Duration
 	// NegativeTTL enables tombstone caching of absent keys (default off).
+	// Legacy ecache/rcache readers do not understand tombstones and see
+	// them as zero-value hits; do not enable shared tombstones on a topic
+	// until all legacy readers are retired.
 	NegativeTTL time.Duration
 	// KeyPrefix namespaces storage keys as "<prefix>:<topic>:<key>". The
 	// default "ecache" preserves the legacy wire format.
@@ -122,7 +125,8 @@ func (c *Cache[K, V]) SetTTL(ctx context.Context, key K, value V, recheckTTL tim
 }
 
 // SetMissing stores a negative tombstone for key in both tiers for
-// NegativeTTL, suppressing lookups until it lapses.
+// NegativeTTL, suppressing lookups until it lapses. See NegativeTTL for
+// the legacy-reader caveat.
 func (c *Cache[K, V]) SetMissing(ctx context.Context, key K) error {
 	if c.NegativeTTL <= 0 {
 		return errors.New("kvcache: SetMissing requires NegativeTTL")
@@ -165,8 +169,12 @@ func (c *Cache[K, V]) LocalKeys() []K {
 
 // Start launches a background goroutine that periodically reconciles
 // with the shared tier and, when a refresh function is configured,
-// refreshes due keys. Start is a no-op if already running.
+// refreshes due keys. Start is a no-op if already running. It panics on
+// a non-positive interval, like time.NewTicker.
 func (c *Cache[K, V]) Start(interval time.Duration) {
+	if interval <= 0 {
+		panic("kvcache: non-positive interval for Start")
+	}
 	c.tickerLock.Lock()
 	defer c.tickerLock.Unlock()
 	if c.tickerStop != nil {
@@ -191,14 +199,16 @@ func (c *Cache[K, V]) Start(interval time.Duration) {
 // Stop halts the background goroutine and waits for an in-flight tick.
 // The cache remains usable, and Start may be called again.
 func (c *Cache[K, V]) Stop() {
+	// The lock is held across Wait so a concurrent Start cannot slip in
+	// between shutdown and the wait; the ticker goroutine never takes
+	// this lock, so this cannot deadlock.
 	c.tickerLock.Lock()
+	defer c.tickerLock.Unlock()
 	if c.tickerStop == nil {
-		c.tickerLock.Unlock()
 		return
 	}
 	close(c.tickerStop)
 	c.tickerStop = nil
-	c.tickerLock.Unlock()
 	c.tickerWg.Wait()
 }
 
@@ -223,12 +233,16 @@ func (c *Cache[K, V]) loadOrRefresh(ctx context.Context, key K) (Item[V], bool) 
 		ok   bool
 	}
 	v, _, _ := c.sf.Do(c.keyString(key), func() (any, error) {
-		if it, ok := c.getStore(ctx, key); ok {
+		// The flight's result is shared by all waiters, so its work is
+		// detached from the leader's cancellation; backends apply their
+		// own per-op timeouts.
+		fctx := context.WithoutCancel(ctx)
+		if it, ok := c.getStore(fctx, key); ok {
 			c.setLocal(key, it)
 			return result{item: it, ok: true}, nil
 		}
 		if c.refreshFn != nil {
-			if it, err := c.runRefresh(ctx, key); err == nil {
+			if it, err := c.runRefresh(fctx, key); err == nil {
 				return result{item: it, ok: true}, nil
 			}
 			return result{}, nil
@@ -250,6 +264,9 @@ func (c *Cache[K, V]) runRefresh(ctx context.Context, key K) (Item[V], error) {
 	rctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), c.RefreshTimeout)
 	defer cancel()
 	value, err := c.refreshFn(rctx, key)
+	// The storage write gets its own budget (the backend's per-op
+	// timeout), not whatever the refresh call left of RefreshTimeout.
+	sctx := context.WithoutCancel(rctx)
 	if err == nil {
 		n := c.now()
 		it := Item[V]{
@@ -258,17 +275,13 @@ func (c *Cache[K, V]) runRefresh(ctx context.Context, key K) (Item[V], error) {
 			ExpiresAt: n.Add(c.Expires),
 		}
 		c.setLocal(key, it)
-		if serr := c.setStore(rctx, key, it, c.Expires); serr != nil {
-			log.Trace().Err(serr).Str("key", c.storeKey(key)).Msg("kvcache: storage write failed")
-		}
+		_ = c.setStore(sctx, key, it, c.Expires)
 		return it, nil
 	}
 	if errors.Is(err, ErrNotFound) && c.NegativeTTL > 0 {
 		it := c.missingItem(c.NegativeTTL)
 		c.setLocal(key, it)
-		if serr := c.setStore(rctx, key, it, c.NegativeTTL); serr != nil {
-			log.Trace().Err(serr).Str("key", c.storeKey(key)).Msg("kvcache: storage write failed")
-		}
+		_ = c.setStore(sctx, key, it, c.NegativeTTL)
 		return it, nil
 	}
 	return Item[V]{}, err
@@ -362,6 +375,11 @@ func (c *Cache[K, V]) setLocal(key K, it Item[V]) {
 
 func (c *Cache[K, V]) setStore(ctx context.Context, key K, it Item[V], ttl time.Duration) error {
 	if c.store == nil {
+		return nil
+	}
+	// A non-positive ttl means the envelope is expired on arrival; on
+	// backends ttl<=0 means "no expiry", which would strand a dead key.
+	if ttl <= 0 {
 		return nil
 	}
 	skey := c.storeKey(key)

--- a/server/caches/kvcache/kvcache.go
+++ b/server/caches/kvcache/kvcache.go
@@ -1,0 +1,420 @@
+package kvcache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"sync"
+	"time"
+
+	"github.com/interline-io/log"
+	"golang.org/x/sync/singleflight"
+)
+
+// ErrNotFound is returned by refresh functions to indicate a key is
+// authoritatively absent; with NegativeTTL configured, the absence is
+// cached as a tombstone.
+var ErrNotFound = errors.New("not found")
+
+// Item is the stored envelope for a cached value. The JSON encoding is
+// wire-compatible with the ecache/rcache envelope.
+type Item[V any] struct {
+	Value     V
+	ExpiresAt time.Time
+	RecheckAt time.Time
+	Missing   bool `json:",omitempty"`
+}
+
+// Cache is a generic two-tier cache: a per-process local map in front of
+// an optional shared Store. Entries carry a soft recheck time and a hard
+// expiry; expired entries are never served from either tier.
+type Cache[K comparable, V any] struct {
+	// Recheck and Expires are the TTLs applied by Set and Refresh
+	// (defaults 1h / 1h).
+	Recheck time.Duration
+	Expires time.Duration
+	// RefreshTimeout bounds each refresh function call (default 1s).
+	RefreshTimeout time.Duration
+	// NegativeTTL enables tombstone caching of absent keys (default off).
+	NegativeTTL time.Duration
+	// KeyPrefix namespaces storage keys as "<prefix>:<topic>:<key>". The
+	// default "ecache" preserves the legacy wire format.
+	KeyPrefix string
+	// Clock overrides time.Now, for tests.
+	Clock func() time.Time
+
+	topic     string
+	store     Store
+	refreshFn func(context.Context, K) (V, error)
+
+	lock  sync.RWMutex
+	items map[K]Item[V]
+	sf    singleflight.Group
+
+	tickerLock sync.Mutex
+	tickerStop chan struct{}
+	tickerWg   sync.WaitGroup
+}
+
+// NewCache returns a two-tier cache; store may be nil for local-only use.
+func NewCache[K comparable, V any](store Store, topic string) *Cache[K, V] {
+	return &Cache[K, V]{
+		Recheck:        1 * time.Hour,
+		Expires:        1 * time.Hour,
+		RefreshTimeout: 1 * time.Second,
+		KeyPrefix:      "ecache",
+		topic:          topic,
+		store:          store,
+		items:          map[K]Item[V]{},
+	}
+}
+
+// NewRefreshCache returns a cache that populates values read-through on
+// miss and in the background via Start.
+func NewRefreshCache[K comparable, V any](store Store, topic string, refreshFn func(context.Context, K) (V, error)) *Cache[K, V] {
+	c := NewCache[K, V](store, topic)
+	c.refreshFn = refreshFn
+	return c
+}
+
+// Get returns the cached value for key. Tombstoned (negative) entries
+// read as misses.
+func (c *Cache[K, V]) Get(ctx context.Context, key K) (V, bool) {
+	if it, ok := c.GetItem(ctx, key); ok && !it.Missing {
+		return it.Value, true
+	}
+	var zero V
+	return zero, false
+}
+
+// GetItem returns the full envelope for key; ok is true when a valid
+// envelope is known, including negative tombstones (check Missing).
+func (c *Cache[K, V]) GetItem(ctx context.Context, key K) (Item[V], bool) {
+	c.lock.RLock()
+	it, ok := c.items[key]
+	c.lock.RUnlock()
+	if ok && it.ExpiresAt.After(c.now()) {
+		return it, true
+	}
+	return c.loadOrRefresh(ctx, key)
+}
+
+// Set stores value in both tiers using the configured Recheck/Expires TTLs.
+func (c *Cache[K, V]) Set(ctx context.Context, key K, value V) error {
+	return c.SetTTL(ctx, key, value, c.Recheck, c.Expires)
+}
+
+// SetTTL stores value in both tiers. The local tier serves it until
+// expireTTL; the shared tier additionally applies expireTTL as its
+// backend TTL. Storage writes are best-effort: the local tier is always
+// updated.
+func (c *Cache[K, V]) SetTTL(ctx context.Context, key K, value V, recheckTTL time.Duration, expireTTL time.Duration) error {
+	n := c.now()
+	it := Item[V]{
+		Value:     value,
+		RecheckAt: n.Add(recheckTTL),
+		ExpiresAt: n.Add(expireTTL),
+	}
+	c.setLocal(key, it)
+	return c.setStore(ctx, key, it, expireTTL)
+}
+
+// SetMissing stores a negative tombstone for key in both tiers for
+// NegativeTTL, suppressing lookups until it lapses.
+func (c *Cache[K, V]) SetMissing(ctx context.Context, key K) error {
+	if c.NegativeTTL <= 0 {
+		return errors.New("kvcache: SetMissing requires NegativeTTL")
+	}
+	it := c.missingItem(c.NegativeTTL)
+	c.setLocal(key, it)
+	return c.setStore(ctx, key, it, c.NegativeTTL)
+}
+
+// Refresh calls the refresh function for key and stores the result.
+func (c *Cache[K, V]) Refresh(ctx context.Context, key K) (V, error) {
+	var zero V
+	if c.refreshFn == nil {
+		return zero, errors.New("kvcache: no refresh function")
+	}
+	it, err := c.runRefresh(ctx, key)
+	if err != nil {
+		return zero, err
+	}
+	return it.Value, nil
+}
+
+// GetRecheckKeys reconciles the local tier against the shared tier in a
+// single multi-get — adopting entries refreshed by other processes and
+// pruning expired ones — and returns the keys still due for refresh.
+func (c *Cache[K, V]) GetRecheckKeys(ctx context.Context) []K {
+	return c.scan(ctx)
+}
+
+// LocalKeys returns a snapshot of locally known keys.
+func (c *Cache[K, V]) LocalKeys() []K {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	ret := make([]K, 0, len(c.items))
+	for k := range c.items {
+		ret = append(ret, k)
+	}
+	return ret
+}
+
+// Start launches a background goroutine that periodically reconciles
+// with the shared tier and, when a refresh function is configured,
+// refreshes due keys. Start is a no-op if already running.
+func (c *Cache[K, V]) Start(interval time.Duration) {
+	c.tickerLock.Lock()
+	defer c.tickerLock.Unlock()
+	if c.tickerStop != nil {
+		return
+	}
+	stop := make(chan struct{})
+	c.tickerStop = stop
+	c.tickerWg.Add(1)
+	go func() {
+		defer c.tickerWg.Done()
+		for {
+			select {
+			case <-time.After(jitter(interval)):
+				c.tick()
+			case <-stop:
+				return
+			}
+		}
+	}()
+}
+
+// Stop halts the background goroutine and waits for an in-flight tick.
+// The cache remains usable, and Start may be called again.
+func (c *Cache[K, V]) Stop() {
+	c.tickerLock.Lock()
+	if c.tickerStop == nil {
+		c.tickerLock.Unlock()
+		return
+	}
+	close(c.tickerStop)
+	c.tickerStop = nil
+	c.tickerLock.Unlock()
+	c.tickerWg.Wait()
+}
+
+func (c *Cache[K, V]) tick() {
+	ctx := context.Background()
+	due := c.scan(ctx)
+	if c.refreshFn == nil {
+		return
+	}
+	for _, key := range due {
+		if _, err := c.runRefresh(ctx, key); err != nil {
+			log.Trace().Err(err).Str("key", c.storeKey(key)).Msg("kvcache: refresh failed")
+		}
+	}
+}
+
+// loadOrRefresh handles a local miss: consult the shared tier, then the
+// refresh function. Concurrent callers for one key share a single flight.
+func (c *Cache[K, V]) loadOrRefresh(ctx context.Context, key K) (Item[V], bool) {
+	type result struct {
+		item Item[V]
+		ok   bool
+	}
+	v, _, _ := c.sf.Do(c.keyString(key), func() (any, error) {
+		if it, ok := c.getStore(ctx, key); ok {
+			c.setLocal(key, it)
+			return result{item: it, ok: true}, nil
+		}
+		if c.refreshFn != nil {
+			if it, err := c.runRefresh(ctx, key); err == nil {
+				return result{item: it, ok: true}, nil
+			}
+			return result{}, nil
+		}
+		// Definite miss with no refresh source; optionally suppress
+		// repeated storage reads with a local-only tombstone.
+		if c.NegativeTTL > 0 {
+			c.setLocal(key, c.missingItem(c.NegativeTTL))
+		}
+		return result{}, nil
+	})
+	r, _ := v.(result)
+	return r.item, r.ok
+}
+
+// runRefresh calls refreshFn detached from the caller's cancellation so
+// a canceled flight leader cannot fail the waiters sharing its result.
+func (c *Cache[K, V]) runRefresh(ctx context.Context, key K) (Item[V], error) {
+	rctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), c.RefreshTimeout)
+	defer cancel()
+	value, err := c.refreshFn(rctx, key)
+	if err == nil {
+		n := c.now()
+		it := Item[V]{
+			Value:     value,
+			RecheckAt: n.Add(c.Recheck),
+			ExpiresAt: n.Add(c.Expires),
+		}
+		c.setLocal(key, it)
+		if serr := c.setStore(rctx, key, it, c.Expires); serr != nil {
+			log.Trace().Err(serr).Str("key", c.storeKey(key)).Msg("kvcache: storage write failed")
+		}
+		return it, nil
+	}
+	if errors.Is(err, ErrNotFound) && c.NegativeTTL > 0 {
+		it := c.missingItem(c.NegativeTTL)
+		c.setLocal(key, it)
+		if serr := c.setStore(rctx, key, it, c.NegativeTTL); serr != nil {
+			log.Trace().Err(serr).Str("key", c.storeKey(key)).Msg("kvcache: storage write failed")
+		}
+		return it, nil
+	}
+	return Item[V]{}, err
+}
+
+// scan reconciles all local keys against the shared tier in one
+// GetMulti, adopts fresher envelopes written by other processes, prunes
+// expired entries, and returns the keys still past their RecheckAt.
+func (c *Cache[K, V]) scan(ctx context.Context) []K {
+	c.lock.RLock()
+	keys := make([]K, 0, len(c.items))
+	for k := range c.items {
+		keys = append(keys, k)
+	}
+	c.lock.RUnlock()
+	if len(keys) == 0 {
+		return nil
+	}
+	fetched := map[string][]byte{}
+	if c.store != nil {
+		skeys := make([]string, len(keys))
+		for i, k := range keys {
+			skeys[i] = c.storeKey(k)
+		}
+		var err error
+		fetched, err = c.store.GetMulti(ctx, skeys)
+		if err != nil {
+			log.Trace().Err(err).Msg("kvcache: storage multi-read failed")
+			fetched = map[string][]byte{}
+		}
+	}
+	n := c.now()
+	var due []K
+	c.lock.Lock()
+	for _, k := range keys {
+		it, ok := c.items[k]
+		if !ok {
+			continue
+		}
+		if data, ok := fetched[c.storeKey(k)]; ok {
+			sIt := Item[V]{}
+			if err := json.Unmarshal(data, &sIt); err == nil && sIt.ExpiresAt.After(n) {
+				// Adopt when fresher, or when the local copy is expired.
+				if sIt.RecheckAt.After(it.RecheckAt) || !it.ExpiresAt.After(n) {
+					c.items[k] = sIt
+					it = sIt
+				}
+			}
+		}
+		if !it.ExpiresAt.After(n) {
+			delete(c.items, k)
+			continue
+		}
+		if !it.RecheckAt.After(n) {
+			due = append(due, k)
+		}
+	}
+	c.lock.Unlock()
+	return due
+}
+
+func (c *Cache[K, V]) getStore(ctx context.Context, key K) (Item[V], bool) {
+	if c.store == nil {
+		return Item[V]{}, false
+	}
+	skey := c.storeKey(key)
+	data, ok, err := c.store.Get(ctx, skey)
+	if err != nil {
+		log.Trace().Err(err).Str("key", skey).Msg("kvcache: storage read failed")
+		return Item[V]{}, false
+	}
+	if !ok {
+		return Item[V]{}, false
+	}
+	it := Item[V]{}
+	if err := json.Unmarshal(data, &it); err != nil {
+		log.Trace().Err(err).Str("key", skey).Msg("kvcache: storage read failed during unmarshal")
+		return Item[V]{}, false
+	}
+	if !it.ExpiresAt.After(c.now()) {
+		return Item[V]{}, false
+	}
+	return it, true
+}
+
+func (c *Cache[K, V]) setLocal(key K, it Item[V]) {
+	c.lock.Lock()
+	c.items[key] = it
+	c.lock.Unlock()
+}
+
+func (c *Cache[K, V]) setStore(ctx context.Context, key K, it Item[V], ttl time.Duration) error {
+	if c.store == nil {
+		return nil
+	}
+	skey := c.storeKey(key)
+	data, err := json.Marshal(it)
+	if err != nil {
+		return err
+	}
+	if err := c.store.Set(ctx, skey, data, ttl); err != nil {
+		log.Trace().Err(err).Str("key", skey).Msg("kvcache: storage write failed")
+		return err
+	}
+	return nil
+}
+
+func (c *Cache[K, V]) missingItem(ttl time.Duration) Item[V] {
+	n := c.now()
+	return Item[V]{
+		Missing:   true,
+		RecheckAt: n.Add(ttl),
+		ExpiresAt: n.Add(ttl),
+	}
+}
+
+func (c *Cache[K, V]) storeKey(key K) string {
+	return fmt.Sprintf("%s:%s:%s", c.KeyPrefix, c.topic, c.keyString(key))
+}
+
+func (c *Cache[K, V]) keyString(key K) string {
+	switch v := any(key).(type) {
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	}
+	data, err := json.Marshal(key)
+	if err != nil {
+		panic(err)
+	}
+	return string(data)
+}
+
+func (c *Cache[K, V]) now() time.Time {
+	if c.Clock != nil {
+		return c.Clock()
+	}
+	return time.Now().In(time.UTC)
+}
+
+// jitter spreads a ticker interval by ±10% so a fleet of processes
+// desynchronizes instead of refreshing in lockstep.
+func jitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return d
+	}
+	return time.Duration(float64(d) * (0.9 + 0.2*rand.Float64()))
+}

--- a/server/caches/kvcache/kvcache_test.go
+++ b/server/caches/kvcache/kvcache_test.go
@@ -36,12 +36,14 @@ func (c *testClock) Advance(d time.Duration) {
 	c.t = c.t.Add(d)
 }
 
-// recordingStore wraps a Store and records keys and operation counts.
+// recordingStore wraps a Store, records keys and operation counts, and
+// honors context cancellation on Set so timeout behavior is observable.
 type recordingStore struct {
 	kvcache.Store
-	lock    sync.Mutex
-	setKeys []string
-	gets    int
+	lock      sync.Mutex
+	setKeys   []string
+	gets      int
+	getMultis int
 }
 
 func (s *recordingStore) Get(ctx context.Context, key string) ([]byte, bool, error) {
@@ -51,7 +53,17 @@ func (s *recordingStore) Get(ctx context.Context, key string) ([]byte, bool, err
 	return s.Store.Get(ctx, key)
 }
 
+func (s *recordingStore) GetMulti(ctx context.Context, keys []string) (map[string][]byte, error) {
+	s.lock.Lock()
+	s.getMultis++
+	s.lock.Unlock()
+	return s.Store.GetMulti(ctx, keys)
+}
+
 func (s *recordingStore) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	s.lock.Lock()
 	s.setKeys = append(s.setKeys, key)
 	s.lock.Unlock()
@@ -62,6 +74,12 @@ func (s *recordingStore) getCount() int {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	return s.gets
+}
+
+func (s *recordingStore) getMultiCount() int {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.getMultis
 }
 
 func TestCache_LocalSetGet(t *testing.T) {
@@ -364,6 +382,117 @@ func TestCache_StartStop(t *testing.T) {
 	c.Start(5 * time.Millisecond)
 	assert.Eventually(t, func() bool { return calls.Load() > after }, 2*time.Second, 5*time.Millisecond)
 	c.Stop()
+}
+
+func TestCache_ScanSingleGetMulti(t *testing.T) {
+	// The scan must be one GetMulti, not per-key Gets.
+	ctx := context.Background()
+	store := &recordingStore{Store: kvcache.NewMemoryStore()}
+	c := kvcache.NewCache[string, string](store, "test")
+	assert.NoError(t, c.Set(ctx, "a", "1"))
+	assert.NoError(t, c.Set(ctx, "b", "2"))
+	assert.NoError(t, c.Set(ctx, "c", "3"))
+	gets := store.getCount()
+	c.GetRecheckKeys(ctx)
+	assert.Equal(t, 1, store.getMultiCount())
+	assert.Equal(t, gets, store.getCount(), "scan must not issue per-key Gets")
+}
+
+func TestCache_ScanAdoptsForExpiredLocal(t *testing.T) {
+	// A valid storage envelope replaces an expired local copy even when
+	// its RecheckAt is not newer than the dead local entry's.
+	ctx := context.Background()
+	clock := newTestClock()
+	store := kvcache.NewMemoryStore()
+	a := kvcache.NewCache[string, string](store, "topic")
+	a.Clock = clock.Now
+	b := kvcache.NewCache[string, string](store, "topic")
+	b.Clock = clock.Now
+
+	assert.NoError(t, a.SetTTL(ctx, "k", "v1", 30*time.Minute, time.Hour))
+	clock.Advance(2 * time.Hour) // a's copy is now hard-expired
+	assert.NoError(t, b.SetTTL(ctx, "k", "v2", 5*time.Minute, 24*time.Hour))
+
+	a.GetRecheckKeys(ctx)
+	v, ok := a.Get(ctx, "k")
+	assert.True(t, ok)
+	assert.Equal(t, "v2", v)
+}
+
+func TestCache_NegativeSharedAcrossCaches(t *testing.T) {
+	// A tombstone written by one refresh cache suppresses the refresh
+	// function of another cache sharing the store.
+	ctx := context.Background()
+	store := kvcache.NewMemoryStore()
+	var callsA, callsB atomic.Int64
+	a := kvcache.NewRefreshCache[string, string](store, "t", func(ctx context.Context, key string) (string, error) {
+		callsA.Add(1)
+		return "", kvcache.ErrNotFound
+	})
+	a.NegativeTTL = time.Minute
+	b := kvcache.NewRefreshCache[string, string](store, "t", func(ctx context.Context, key string) (string, error) {
+		callsB.Add(1)
+		return "", kvcache.ErrNotFound
+	})
+	b.NegativeTTL = time.Minute
+
+	_, ok := a.Get(ctx, "ghost")
+	assert.False(t, ok)
+	assert.EqualValues(t, 1, callsA.Load())
+	_, ok = b.Get(ctx, "ghost")
+	assert.False(t, ok)
+	assert.EqualValues(t, 0, callsB.Load(), "b must adopt a's shared tombstone instead of refreshing")
+}
+
+func TestCache_SlowRefreshStillStored(t *testing.T) {
+	// A refresh that outlives RefreshTimeout but still returns a value
+	// must have its result written to storage under a fresh budget, not
+	// the exhausted refresh deadline.
+	ctx := context.Background()
+	store := &recordingStore{Store: kvcache.NewMemoryStore()}
+	c := kvcache.NewRefreshCache[string, string](store, "t", func(ctx context.Context, key string) (string, error) {
+		time.Sleep(60 * time.Millisecond) // ignores ctx, exceeds RefreshTimeout
+		return "v", nil
+	})
+	c.RefreshTimeout = 20 * time.Millisecond
+	v, ok := c.Get(ctx, "k")
+	assert.True(t, ok)
+	assert.Equal(t, "v", v)
+	assert.Equal(t, []string{"ecache:t:k"}, store.setKeys, "storage write must not inherit the exhausted refresh deadline")
+}
+
+func TestCache_StartStopConcurrent(t *testing.T) {
+	// Concurrent Start/Stop must neither hang nor panic.
+	c := kvcache.NewCache[string, string](nil, "test")
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			c.Start(time.Hour)
+		}()
+		go func() {
+			defer wg.Done()
+			c.Stop()
+		}()
+	}
+	wg.Wait()
+	c.Stop()
+}
+
+func TestCache_StartNonPositivePanics(t *testing.T) {
+	c := kvcache.NewCache[string, string](nil, "test")
+	assert.Panics(t, func() { c.Start(0) })
+}
+
+func TestCache_ExpireTTLNonPositiveNotStored(t *testing.T) {
+	// An envelope that is expired on arrival must not become a
+	// no-expiry key in the backend.
+	ctx := context.Background()
+	store := &recordingStore{Store: kvcache.NewMemoryStore()}
+	c := kvcache.NewCache[string, string](store, "test")
+	assert.NoError(t, c.SetTTL(ctx, "dead", "v", 0, 0))
+	assert.Empty(t, store.setKeys, "dead-on-arrival envelope must not be written to storage")
 }
 
 type stringerKey struct{ A, B string }

--- a/server/caches/kvcache/kvcache_test.go
+++ b/server/caches/kvcache/kvcache_test.go
@@ -333,6 +333,20 @@ func TestCache_RecheckConvergence(t *testing.T) {
 	assert.Equal(t, "v2", v)
 }
 
+func TestCache_ExpiredEntryPrunedOnMiss(t *testing.T) {
+	// An expired local entry whose key no longer resolves anywhere is
+	// removed on read rather than retained until a scan.
+	ctx := context.Background()
+	clock := newTestClock()
+	c := kvcache.NewCache[string, string](kvcache.NewMemoryStore(), "test")
+	c.Clock = clock.Now
+	assert.NoError(t, c.SetTTL(ctx, "a", "v", time.Minute, time.Hour))
+	clock.Advance(2 * time.Hour)
+	_, ok := c.Get(ctx, "a")
+	assert.False(t, ok)
+	assert.Empty(t, c.LocalKeys(), "expired entry must be pruned on definite miss")
+}
+
 func TestCache_ScanPrunesExpired(t *testing.T) {
 	ctx := context.Background()
 	clock := newTestClock()

--- a/server/caches/kvcache/kvcache_test.go
+++ b/server/caches/kvcache/kvcache_test.go
@@ -1,0 +1,387 @@
+package kvcache_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/interline-io/transitland-lib/server/caches/kvcache"
+	"github.com/stretchr/testify/assert"
+)
+
+// testClock is a settable clock for driving TTL transitions.
+type testClock struct {
+	lock sync.Mutex
+	t    time.Time
+}
+
+func newTestClock() *testClock {
+	return &testClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+}
+
+func (c *testClock) Now() time.Time {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.t
+}
+
+func (c *testClock) Advance(d time.Duration) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.t = c.t.Add(d)
+}
+
+// recordingStore wraps a Store and records keys and operation counts.
+type recordingStore struct {
+	kvcache.Store
+	lock    sync.Mutex
+	setKeys []string
+	gets    int
+}
+
+func (s *recordingStore) Get(ctx context.Context, key string) ([]byte, bool, error) {
+	s.lock.Lock()
+	s.gets++
+	s.lock.Unlock()
+	return s.Store.Get(ctx, key)
+}
+
+func (s *recordingStore) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	s.lock.Lock()
+	s.setKeys = append(s.setKeys, key)
+	s.lock.Unlock()
+	return s.Store.Set(ctx, key, value, ttl)
+}
+
+func (s *recordingStore) getCount() int {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.gets
+}
+
+func TestCache_LocalSetGet(t *testing.T) {
+	ctx := context.Background()
+	c := kvcache.NewCache[string, string](nil, "test")
+	_, ok := c.Get(ctx, "a")
+	assert.False(t, ok)
+	assert.NoError(t, c.SetTTL(ctx, "a", "hello", time.Minute, time.Hour))
+	v, ok := c.Get(ctx, "a")
+	assert.True(t, ok)
+	assert.Equal(t, "hello", v)
+}
+
+func TestCache_SharedStore(t *testing.T) {
+	// Two caches sharing one store emulate two processes.
+	ctx := context.Background()
+	store := kvcache.NewMemoryStore()
+	a := kvcache.NewCache[string, string](store, "topic")
+	b := kvcache.NewCache[string, string](store, "topic")
+	assert.NoError(t, a.SetTTL(ctx, "k", "from-a", time.Minute, time.Hour))
+	v, ok := b.Get(ctx, "k")
+	assert.True(t, ok)
+	assert.Equal(t, "from-a", v)
+}
+
+func TestCache_LocalExpiry(t *testing.T) {
+	ctx := context.Background()
+	clock := newTestClock()
+	c := kvcache.NewCache[string, string](nil, "test")
+	c.Clock = clock.Now
+	assert.NoError(t, c.SetTTL(ctx, "a", "hello", time.Minute, time.Hour))
+	_, ok := c.Get(ctx, "a")
+	assert.True(t, ok)
+	clock.Advance(2 * time.Hour)
+	_, ok = c.Get(ctx, "a")
+	assert.False(t, ok, "expired local entry must not be served")
+}
+
+func TestCache_StorageMissNotPoisoned(t *testing.T) {
+	// A storage miss must not install a zero-value local entry.
+	ctx := context.Background()
+	store := kvcache.NewMemoryStore()
+	c := kvcache.NewCache[string, string](store, "test")
+	_, ok := c.Get(ctx, "a")
+	assert.False(t, ok)
+	_, ok = c.Get(ctx, "a")
+	assert.False(t, ok, "second read after miss must still miss")
+	assert.Empty(t, c.LocalKeys())
+}
+
+func TestCache_WireFormat(t *testing.T) {
+	// The envelope and key must match the legacy ecache format so old
+	// and new pods share warm caches during a rolling deploy. Delete
+	// this test when ecache/rcache are removed.
+	type legacyItem struct {
+		Value     string
+		ExpiresAt time.Time
+		RecheckAt time.Time
+	}
+	n := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	want, err := json.Marshal(legacyItem{Value: "x", ExpiresAt: n.Add(time.Hour), RecheckAt: n.Add(time.Minute)})
+	assert.NoError(t, err)
+	got, err := json.Marshal(kvcache.Item[string]{Value: "x", ExpiresAt: n.Add(time.Hour), RecheckAt: n.Add(time.Minute)})
+	assert.NoError(t, err)
+	assert.Equal(t, string(want), string(got))
+
+	// Key composition: <prefix>:<topic>:<key> with default prefix "ecache".
+	ctx := context.Background()
+	store := &recordingStore{Store: kvcache.NewMemoryStore()}
+	c := kvcache.NewCache[string, string](store, "gbfs")
+	assert.NoError(t, c.Set(ctx, "some-feed:en", "v"))
+	assert.Equal(t, []string{"ecache:gbfs:some-feed:en"}, store.setKeys)
+}
+
+func TestCache_RefreshReadThrough(t *testing.T) {
+	ctx := context.Background()
+	var calls atomic.Int64
+	c := kvcache.NewRefreshCache[string, int](kvcache.NewMemoryStore(), "test", func(ctx context.Context, key string) (int, error) {
+		calls.Add(1)
+		return len(key), nil
+	})
+	v, ok := c.Get(ctx, "abc")
+	assert.True(t, ok)
+	assert.Equal(t, 3, v)
+	assert.EqualValues(t, 1, calls.Load())
+	// Second get is a local hit.
+	_, ok = c.Get(ctx, "abc")
+	assert.True(t, ok)
+	assert.EqualValues(t, 1, calls.Load())
+}
+
+func TestCache_RefreshError(t *testing.T) {
+	ctx := context.Background()
+	c := kvcache.NewRefreshCache[string, int](nil, "test", func(ctx context.Context, key string) (int, error) {
+		return 0, errors.New("upstream down")
+	})
+	_, ok := c.Get(ctx, "a")
+	assert.False(t, ok)
+	assert.Empty(t, c.LocalKeys(), "failed refresh must not install an entry")
+}
+
+func TestCache_Singleflight(t *testing.T) {
+	// N concurrent cold reads produce one refresh call.
+	ctx := context.Background()
+	var calls atomic.Int64
+	c := kvcache.NewRefreshCache[string, string](kvcache.NewMemoryStore(), "test", func(ctx context.Context, key string) (string, error) {
+		calls.Add(1)
+		time.Sleep(50 * time.Millisecond)
+		return "v", nil
+	})
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			v, ok := c.Get(ctx, "k")
+			assert.True(t, ok)
+			assert.Equal(t, "v", v)
+		}()
+	}
+	wg.Wait()
+	assert.EqualValues(t, 1, calls.Load())
+}
+
+func TestCache_SingleflightLeaderCancel(t *testing.T) {
+	// The flight leader's canceled context must not fail the waiters.
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	release := make(chan struct{})
+	c := kvcache.NewRefreshCache[string, string](nil, "test", func(ctx context.Context, key string) (string, error) {
+		cancelLeader()
+		<-release
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		return "v", nil
+	})
+	c.RefreshTimeout = 5 * time.Second
+
+	var wg sync.WaitGroup
+	var waiterOk atomic.Bool
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Leader: enters the flight, cancels its own ctx inside refreshFn.
+		c.Get(leaderCtx, "k")
+	}()
+	// Give the leader time to enter the flight, then join it and release.
+	time.Sleep(20 * time.Millisecond)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(20 * time.Millisecond)
+		close(release)
+	}()
+	v, ok := c.Get(context.Background(), "k")
+	wg.Wait()
+	waiterOk.Store(ok)
+	assert.True(t, waiterOk.Load(), "waiter must receive the refreshed value despite leader cancellation")
+	assert.Equal(t, "v", v)
+}
+
+func TestCache_NegativeRefresh(t *testing.T) {
+	// ErrNotFound with NegativeTTL installs a tombstone that suppresses
+	// refresh calls until it lapses.
+	ctx := context.Background()
+	clock := newTestClock()
+	var calls atomic.Int64
+	c := kvcache.NewRefreshCache[string, string](kvcache.NewMemoryStore(), "test", func(ctx context.Context, key string) (string, error) {
+		calls.Add(1)
+		return "", fmt.Errorf("no such user: %w", kvcache.ErrNotFound)
+	})
+	c.Clock = clock.Now
+	c.NegativeTTL = time.Minute
+
+	_, ok := c.Get(ctx, "ghost")
+	assert.False(t, ok)
+	assert.EqualValues(t, 1, calls.Load())
+	_, ok = c.Get(ctx, "ghost")
+	assert.False(t, ok)
+	assert.EqualValues(t, 1, calls.Load(), "tombstone must suppress refresh")
+	it, ok := c.GetItem(ctx, "ghost")
+	assert.True(t, ok)
+	assert.True(t, it.Missing)
+
+	clock.Advance(2 * time.Minute)
+	_, ok = c.Get(ctx, "ghost")
+	assert.False(t, ok)
+	assert.EqualValues(t, 2, calls.Load(), "lapsed tombstone must allow refresh")
+}
+
+func TestCache_SetMissing(t *testing.T) {
+	// Hand-rolled read-through consumers can tombstone explicitly and
+	// distinguish tombstones via GetItem.
+	ctx := context.Background()
+	store := kvcache.NewMemoryStore()
+	c := kvcache.NewCache[string, string](store, "test")
+	assert.Error(t, c.SetMissing(ctx, "ghost"), "requires NegativeTTL")
+	c.NegativeTTL = time.Minute
+	assert.NoError(t, c.SetMissing(ctx, "ghost"))
+	_, ok := c.Get(ctx, "ghost")
+	assert.False(t, ok)
+	it, ok := c.GetItem(ctx, "ghost")
+	assert.True(t, ok)
+	assert.True(t, it.Missing)
+	// The tombstone is shared: a second cache on the same store sees it.
+	c2 := kvcache.NewCache[string, string](store, "test")
+	it, ok = c2.GetItem(ctx, "ghost")
+	assert.True(t, ok)
+	assert.True(t, it.Missing)
+}
+
+func TestCache_NegativeLocalOnly(t *testing.T) {
+	// Without a refresh function, NegativeTTL suppresses repeat storage
+	// reads for absent keys locally without writing tombstones to storage.
+	ctx := context.Background()
+	store := &recordingStore{Store: kvcache.NewMemoryStore()}
+	c := kvcache.NewCache[string, string](store, "test")
+	c.NegativeTTL = time.Minute
+	_, ok := c.Get(ctx, "absent")
+	assert.False(t, ok)
+	_, ok = c.Get(ctx, "absent")
+	assert.False(t, ok)
+	assert.Equal(t, 1, store.getCount(), "second read must be suppressed by the local tombstone")
+	assert.Empty(t, store.setKeys, "local-only tombstone must not be written to storage")
+}
+
+func TestCache_RecheckConvergence(t *testing.T) {
+	// Pod B adopts pod A's refresh via the scan instead of re-fetching.
+	ctx := context.Background()
+	clockA, clockB := newTestClock(), newTestClock()
+	store := kvcache.NewMemoryStore()
+	a := kvcache.NewCache[string, string](store, "topic")
+	a.Clock = clockA.Now
+	b := kvcache.NewCache[string, string](store, "topic")
+	b.Clock = clockB.Now
+
+	assert.NoError(t, a.SetTTL(ctx, "k", "v1", 5*time.Minute, 24*time.Hour))
+	_, ok := b.Get(ctx, "k")
+	assert.True(t, ok)
+
+	// Both advance past the recheck; A refreshes first.
+	clockA.Advance(6 * time.Minute)
+	clockB.Advance(6 * time.Minute)
+	assert.NoError(t, a.SetTTL(ctx, "k", "v2", 5*time.Minute, 24*time.Hour))
+
+	// B's scan adopts A's fresher envelope; the key is no longer due.
+	due := b.GetRecheckKeys(ctx)
+	assert.Empty(t, due)
+	v, ok := b.Get(ctx, "k")
+	assert.True(t, ok)
+	assert.Equal(t, "v2", v)
+}
+
+func TestCache_ScanPrunesExpired(t *testing.T) {
+	ctx := context.Background()
+	clock := newTestClock()
+	c := kvcache.NewCache[string, string](kvcache.NewMemoryStore(), "test")
+	c.Clock = clock.Now
+	assert.NoError(t, c.SetTTL(ctx, "a", "v", time.Minute, time.Hour))
+	clock.Advance(2 * time.Hour)
+	c.GetRecheckKeys(ctx)
+	assert.Empty(t, c.LocalKeys(), "expired entries must be pruned by the scan")
+}
+
+func TestCache_GetRecheckKeysDue(t *testing.T) {
+	ctx := context.Background()
+	clock := newTestClock()
+	c := kvcache.NewCache[string, string](nil, "test")
+	c.Clock = clock.Now
+	assert.NoError(t, c.SetTTL(ctx, "a", "v", 5*time.Minute, 24*time.Hour))
+	assert.Empty(t, c.GetRecheckKeys(ctx))
+	clock.Advance(6 * time.Minute)
+	assert.Equal(t, []string{"a"}, c.GetRecheckKeys(ctx))
+}
+
+func TestCache_StartStop(t *testing.T) {
+	// The ticker refreshes due keys and Stop halts it; Start/Stop are
+	// idempotent and Start-after-Stop restarts.
+	ctx := context.Background()
+	var calls atomic.Int64
+	c := kvcache.NewRefreshCache[string, string](nil, "test", func(ctx context.Context, key string) (string, error) {
+		calls.Add(1)
+		return "v", nil
+	})
+	c.Recheck = 1 * time.Millisecond
+	c.Expires = time.Hour
+	_, ok := c.Get(ctx, "k")
+	assert.True(t, ok)
+	before := calls.Load()
+
+	c.Start(5 * time.Millisecond)
+	c.Start(5 * time.Millisecond) // no-op
+	assert.Eventually(t, func() bool { return calls.Load() > before }, 2*time.Second, 5*time.Millisecond)
+	c.Stop()
+	c.Stop() // no-op
+	after := calls.Load()
+	time.Sleep(30 * time.Millisecond)
+	assert.Equal(t, after, calls.Load(), "no refreshes after Stop")
+
+	c.Start(5 * time.Millisecond)
+	assert.Eventually(t, func() bool { return calls.Load() > after }, 2*time.Second, 5*time.Millisecond)
+	c.Stop()
+}
+
+type stringerKey struct{ A, B string }
+
+func (k stringerKey) String() string { return k.A + ":" + k.B }
+
+type plainKey struct{ A int }
+
+func TestCache_KeyStringification(t *testing.T) {
+	ctx := context.Background()
+	// fmt.Stringer keys use String().
+	s1 := &recordingStore{Store: kvcache.NewMemoryStore()}
+	c1 := kvcache.NewCache[stringerKey, string](s1, "t")
+	assert.NoError(t, c1.Set(ctx, stringerKey{"x", "y"}, "v"))
+	assert.Equal(t, []string{"ecache:t:x:y"}, s1.setKeys)
+	// Other comparable keys use JSON.
+	s2 := &recordingStore{Store: kvcache.NewMemoryStore()}
+	c2 := kvcache.NewCache[plainKey, string](s2, "t")
+	assert.NoError(t, c2.Set(ctx, plainKey{7}, "v"))
+	assert.Equal(t, []string{`ecache:t:{"A":7}`}, s2.setKeys)
+}

--- a/server/caches/kvcache/store.go
+++ b/server/caches/kvcache/store.go
@@ -1,0 +1,28 @@
+// Package kvcache provides a generic two-tier cache: a per-process local
+// tier in front of a shared Store such as Redis. It replaces the older
+// ecache and rcache packages.
+package kvcache
+
+import (
+	"context"
+	"time"
+)
+
+// Store is a shared key-value tier for a Cache. Keys arrive fully
+// namespaced; values are opaque byte envelopes. Implementations must be
+// safe for concurrent use.
+//
+// Store is intentionally minimal. Future backend capabilities (deletion,
+// pub/sub notification for the realtime store) will arrive as optional
+// sibling interfaces discovered by type assertion, never as new methods
+// on Store.
+type Store interface {
+	// Get returns the value for key. ok is false on a normal miss; err
+	// reports a backend failure. Callers treat errors as misses.
+	Get(ctx context.Context, key string) (value []byte, ok bool, err error)
+	// GetMulti returns values for the subset of keys that are present.
+	GetMulti(ctx context.Context, keys []string) (map[string][]byte, error)
+	// Set stores value. The backend may evict the entry after ttl; a ttl
+	// of zero or less means no backend-enforced expiry.
+	Set(ctx context.Context, key string, value []byte, ttl time.Duration) error
+}

--- a/server/caches/kvcache/store_memory.go
+++ b/server/caches/kvcache/store_memory.go
@@ -37,7 +37,8 @@ func (s *MemoryStore) Get(ctx context.Context, key string) ([]byte, bool, error)
 		s.deleteExpired(key)
 		return nil, false, nil
 	}
-	return ent.value, true, nil
+	// Copy so callers cannot mutate stored state, matching RedisStore.
+	return append([]byte(nil), ent.value...), true, nil
 }
 
 func (s *MemoryStore) GetMulti(ctx context.Context, keys []string) (map[string][]byte, error) {
@@ -50,7 +51,7 @@ func (s *MemoryStore) GetMulti(ctx context.Context, keys []string) (map[string][
 				dead = append(dead, key)
 				continue
 			}
-			ret[key] = ent.value
+			ret[key] = append([]byte(nil), ent.value...)
 		}
 	}
 	s.lock.RUnlock()

--- a/server/caches/kvcache/store_memory.go
+++ b/server/caches/kvcache/store_memory.go
@@ -30,7 +30,11 @@ func (s *MemoryStore) Get(ctx context.Context, key string) ([]byte, bool, error)
 	s.lock.RLock()
 	ent, ok := s.m[key]
 	s.lock.RUnlock()
-	if !ok || s.expired(ent) {
+	if !ok {
+		return nil, false, nil
+	}
+	if s.expired(ent) {
+		s.deleteExpired(key)
 		return nil, false, nil
 	}
 	return ent.value, true, nil
@@ -38,14 +42,31 @@ func (s *MemoryStore) Get(ctx context.Context, key string) ([]byte, bool, error)
 
 func (s *MemoryStore) GetMulti(ctx context.Context, keys []string) (map[string][]byte, error) {
 	ret := map[string][]byte{}
+	var dead []string
 	s.lock.RLock()
-	defer s.lock.RUnlock()
 	for _, key := range keys {
-		if ent, ok := s.m[key]; ok && !s.expired(ent) {
+		if ent, ok := s.m[key]; ok {
+			if s.expired(ent) {
+				dead = append(dead, key)
+				continue
+			}
 			ret[key] = ent.value
 		}
 	}
+	s.lock.RUnlock()
+	for _, key := range dead {
+		s.deleteExpired(key)
+	}
 	return ret, nil
+}
+
+// deleteExpired evicts key if it is still expired under the write lock.
+func (s *MemoryStore) deleteExpired(key string) {
+	s.lock.Lock()
+	if ent, ok := s.m[key]; ok && s.expired(ent) {
+		delete(s.m, key)
+	}
+	s.lock.Unlock()
 }
 
 func (s *MemoryStore) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {

--- a/server/caches/kvcache/store_memory.go
+++ b/server/caches/kvcache/store_memory.go
@@ -1,0 +1,64 @@
+package kvcache
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// MemoryStore is an in-process Store for tests and single-process use.
+// Two Caches sharing one MemoryStore emulate cross-process behavior.
+type MemoryStore struct {
+	now  func() time.Time
+	lock sync.RWMutex
+	m    map[string]memoryEntry
+}
+
+type memoryEntry struct {
+	value     []byte
+	expiresAt time.Time // zero = no expiry
+}
+
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{
+		now: time.Now,
+		m:   map[string]memoryEntry{},
+	}
+}
+
+func (s *MemoryStore) Get(ctx context.Context, key string) ([]byte, bool, error) {
+	s.lock.RLock()
+	ent, ok := s.m[key]
+	s.lock.RUnlock()
+	if !ok || s.expired(ent) {
+		return nil, false, nil
+	}
+	return ent.value, true, nil
+}
+
+func (s *MemoryStore) GetMulti(ctx context.Context, keys []string) (map[string][]byte, error) {
+	ret := map[string][]byte{}
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	for _, key := range keys {
+		if ent, ok := s.m[key]; ok && !s.expired(ent) {
+			ret[key] = ent.value
+		}
+	}
+	return ret, nil
+}
+
+func (s *MemoryStore) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	ent := memoryEntry{value: append([]byte(nil), value...)}
+	if ttl > 0 {
+		ent.expiresAt = s.now().Add(ttl)
+	}
+	s.lock.Lock()
+	s.m[key] = ent
+	s.lock.Unlock()
+	return nil
+}
+
+func (s *MemoryStore) expired(ent memoryEntry) bool {
+	return !ent.expiresAt.IsZero() && !ent.expiresAt.After(s.now())
+}

--- a/server/caches/kvcache/store_memory_test.go
+++ b/server/caches/kvcache/store_memory_test.go
@@ -1,0 +1,14 @@
+package kvcache_test
+
+import (
+	"testing"
+
+	"github.com/interline-io/transitland-lib/server/caches/kvcache"
+	"github.com/interline-io/transitland-lib/server/caches/kvcache/storetest"
+)
+
+func TestMemoryStore(t *testing.T) {
+	storetest.Run(t, func(t *testing.T) kvcache.Store {
+		return kvcache.NewMemoryStore()
+	})
+}

--- a/server/caches/kvcache/store_redis.go
+++ b/server/caches/kvcache/store_redis.go
@@ -1,0 +1,71 @@
+package kvcache
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+)
+
+// RedisStore adapts a *redis.Client to Store. A nil client is a no-op
+// store: all reads miss and writes are discarded, preserving the
+// historical nil-client local-only mode.
+type RedisStore struct {
+	// Timeout bounds each Redis operation (default 1s).
+	Timeout time.Duration
+	client  *redis.Client
+}
+
+func NewRedisStore(client *redis.Client) *RedisStore {
+	return &RedisStore{
+		Timeout: 1 * time.Second,
+		client:  client,
+	}
+}
+
+func (s *RedisStore) Get(ctx context.Context, key string) ([]byte, bool, error) {
+	if s.client == nil {
+		return nil, false, nil
+	}
+	rctx, cancel := context.WithTimeout(ctx, s.Timeout)
+	defer cancel()
+	data, err := s.client.Get(rctx, key).Bytes()
+	if err == redis.Nil {
+		return nil, false, nil
+	} else if err != nil {
+		return nil, false, err
+	}
+	return data, true, nil
+}
+
+func (s *RedisStore) GetMulti(ctx context.Context, keys []string) (map[string][]byte, error) {
+	ret := map[string][]byte{}
+	if s.client == nil || len(keys) == 0 {
+		return ret, nil
+	}
+	rctx, cancel := context.WithTimeout(ctx, s.Timeout)
+	defer cancel()
+	vals, err := s.client.MGet(rctx, keys...).Result()
+	if err != nil {
+		return nil, err
+	}
+	for i, val := range vals {
+		// MGET returns nil for absent keys and strings for present ones.
+		if sval, ok := val.(string); ok && i < len(keys) {
+			ret[keys[i]] = []byte(sval)
+		}
+	}
+	return ret, nil
+}
+
+func (s *RedisStore) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	if s.client == nil {
+		return nil
+	}
+	rctx, cancel := context.WithTimeout(ctx, s.Timeout)
+	defer cancel()
+	if ttl < 0 {
+		ttl = 0
+	}
+	return s.client.Set(rctx, key, value, ttl).Err()
+}

--- a/server/caches/kvcache/store_redis.go
+++ b/server/caches/kvcache/store_redis.go
@@ -50,9 +50,16 @@ func (s *RedisStore) GetMulti(ctx context.Context, keys []string) (map[string][]
 		return nil, err
 	}
 	for i, val := range vals {
-		// MGET returns nil for absent keys and strings for present ones.
-		if sval, ok := val.(string); ok && i < len(keys) {
-			ret[keys[i]] = []byte(sval)
+		if i >= len(keys) {
+			break
+		}
+		// MGET returns nil for absent keys; present values decode as
+		// string or []byte depending on client version.
+		switch v := val.(type) {
+		case string:
+			ret[keys[i]] = []byte(v)
+		case []byte:
+			ret[keys[i]] = v
 		}
 	}
 	return ret, nil

--- a/server/caches/kvcache/store_redis_test.go
+++ b/server/caches/kvcache/store_redis_test.go
@@ -1,0 +1,43 @@
+package kvcache_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/interline-io/transitland-lib/server/caches/kvcache"
+	"github.com/interline-io/transitland-lib/server/caches/kvcache/storetest"
+	"github.com/interline-io/transitland-lib/server/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedisStore(t *testing.T) {
+	if _, ok := testutil.CheckTestRedisClient(); !ok {
+		t.Skip("TL_TEST_REDIS_URL not set")
+	}
+	client := testutil.MustOpenTestRedisClient(t)
+	storetest.Run(t, func(t *testing.T) kvcache.Store {
+		// Clear conformance-suite keys from previous subtests.
+		keys, err := client.Keys(context.Background(), "storetest:*").Result()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(keys) > 0 {
+			if err := client.Del(context.Background(), keys...).Err(); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return kvcache.NewRedisStore(client)
+	})
+}
+
+func TestRedisStore_NilClient(t *testing.T) {
+	ctx := context.Background()
+	store := kvcache.NewRedisStore(nil)
+	assert.NoError(t, store.Set(ctx, "storetest:a", []byte("x"), 0))
+	_, ok, err := store.Get(ctx, "storetest:a")
+	assert.NoError(t, err)
+	assert.False(t, ok)
+	got, err := store.GetMulti(ctx, []string{"storetest:a"})
+	assert.NoError(t, err)
+	assert.Empty(t, got)
+}

--- a/server/caches/kvcache/storetest/storetest.go
+++ b/server/caches/kvcache/storetest/storetest.go
@@ -58,14 +58,14 @@ func Run(t *testing.T, mk func(t *testing.T) kvcache.Store) {
 	})
 	t.Run("TTLExpiry", func(t *testing.T) {
 		store := mk(t)
-		assert.NoError(t, store.Set(ctx, "storetest:ttl", []byte("gone"), 100*time.Millisecond))
+		assert.NoError(t, store.Set(ctx, "storetest:ttl", []byte("gone"), 500*time.Millisecond))
 		_, ok, err := store.Get(ctx, "storetest:ttl")
 		assert.NoError(t, err)
 		assert.True(t, ok, "value should be present before ttl")
-		time.Sleep(200 * time.Millisecond)
-		_, ok, err = store.Get(ctx, "storetest:ttl")
-		assert.NoError(t, err)
-		assert.False(t, ok, "value should be absent after ttl")
+		assert.Eventually(t, func() bool {
+			_, ok, err := store.Get(ctx, "storetest:ttl")
+			return err == nil && !ok
+		}, 3*time.Second, 50*time.Millisecond, "value should expire after ttl")
 	})
 	t.Run("Concurrent", func(t *testing.T) {
 		store := mk(t)

--- a/server/caches/kvcache/storetest/storetest.go
+++ b/server/caches/kvcache/storetest/storetest.go
@@ -1,0 +1,86 @@
+// Package storetest provides a conformance suite for kvcache.Store
+// implementations.
+package storetest
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/interline-io/transitland-lib/server/caches/kvcache"
+	"github.com/stretchr/testify/assert"
+)
+
+// Run exercises a Store implementation against the interface contract.
+// mk is called per subtest and should return an empty store.
+func Run(t *testing.T, mk func(t *testing.T) kvcache.Store) {
+	ctx := context.Background()
+	t.Run("SetGet", func(t *testing.T) {
+		store := mk(t)
+		assert.NoError(t, store.Set(ctx, "storetest:a", []byte("hello"), 0))
+		val, ok, err := store.Get(ctx, "storetest:a")
+		assert.NoError(t, err)
+		assert.True(t, ok)
+		assert.Equal(t, []byte("hello"), val)
+	})
+	t.Run("MissingKey", func(t *testing.T) {
+		store := mk(t)
+		_, ok, err := store.Get(ctx, "storetest:absent")
+		assert.NoError(t, err)
+		assert.False(t, ok)
+	})
+	t.Run("Overwrite", func(t *testing.T) {
+		store := mk(t)
+		assert.NoError(t, store.Set(ctx, "storetest:a", []byte("one"), 0))
+		assert.NoError(t, store.Set(ctx, "storetest:a", []byte("two"), 0))
+		val, ok, err := store.Get(ctx, "storetest:a")
+		assert.NoError(t, err)
+		assert.True(t, ok)
+		assert.Equal(t, []byte("two"), val)
+	})
+	t.Run("GetMulti", func(t *testing.T) {
+		store := mk(t)
+		assert.NoError(t, store.Set(ctx, "storetest:a", []byte("one"), 0))
+		assert.NoError(t, store.Set(ctx, "storetest:b", []byte("two"), 0))
+		got, err := store.GetMulti(ctx, []string{"storetest:a", "storetest:b", "storetest:absent"})
+		assert.NoError(t, err)
+		assert.Equal(t, map[string][]byte{
+			"storetest:a": []byte("one"),
+			"storetest:b": []byte("two"),
+		}, got)
+	})
+	t.Run("GetMultiEmpty", func(t *testing.T) {
+		store := mk(t)
+		got, err := store.GetMulti(ctx, nil)
+		assert.NoError(t, err)
+		assert.Empty(t, got)
+	})
+	t.Run("TTLExpiry", func(t *testing.T) {
+		store := mk(t)
+		assert.NoError(t, store.Set(ctx, "storetest:ttl", []byte("gone"), 100*time.Millisecond))
+		_, ok, err := store.Get(ctx, "storetest:ttl")
+		assert.NoError(t, err)
+		assert.True(t, ok, "value should be present before ttl")
+		time.Sleep(200 * time.Millisecond)
+		_, ok, err = store.Get(ctx, "storetest:ttl")
+		assert.NoError(t, err)
+		assert.False(t, ok, "value should be absent after ttl")
+	})
+	t.Run("Concurrent", func(t *testing.T) {
+		store := mk(t)
+		var wg sync.WaitGroup
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 20; j++ {
+					_ = store.Set(ctx, "storetest:c", []byte("v"), 0)
+					_, _, _ = store.Get(ctx, "storetest:c")
+					_, _ = store.GetMulti(ctx, []string{"storetest:c"})
+				}
+			}()
+		}
+		wg.Wait()
+	})
+}


### PR DESCRIPTION
## Summary

Adds `server/caches/kvcache`, a generic two-tier cache — a per-process local map in front of a pluggable shared storage backend — that unifies the near-duplicate `ecache` and `rcache` packages and will replace them once consumers migrate. The stored envelope and key format (`ecache:<topic>:<key>`) are byte-compatible with `ecache`, so processes running old and new code share warm caches during a rolling deploy. Storage is behind a minimal three-method interface with Redis and in-memory implementations; a Postgres backend can be added later with no changes to the typed API or consumers. This PR is purely additive: `ecache` and `rcache` are untouched and nothing is migrated yet.

### Store interface and backends

- `Store` is `Get`/`GetMulti`/`Set` over opaque byte values with backend-enforced TTLs; values stay non-generic so one store instance can back many cache instantiations, and the envelope encoding lives entirely in `Cache`.
- Future backend capabilities (deletion, pub/sub notification for the realtime store) are documented to arrive as optional sibling interfaces discovered by type assertion, never as new `Store` methods — adding methods to an exported interface breaks external implementers.
- `RedisStore` wraps a `*redis.Client` with a per-op timeout; a nil client is a no-op store, preserving the historical nil-client local-only mode. `MemoryStore` is the test double and single-process option; it evicts expired entries on read.
- `storetest.Run` is an exported conformance suite exercised by both backends; a future Postgres backend reuses it verbatim.

### Cache semantics

- `NewCache` for plain shared caching, `NewRefreshCache` for read-through with a refresh function; `Get`/`SetTTL`/`Refresh`/`GetRecheckKeys`/`LocalKeys` keep the shapes existing consumers already use, plus `Start`/`Stop` for a jittered, stoppable background recheck ticker.
- Concurrency: the mutex guards only the local map — no storage I/O or refresh call runs under it; singleflight collapses concurrent cold reads to one storage read and at most one refresh; flight work runs detached from the leader's cancellation so a canceled request cannot fail the waiters sharing its result, and the post-refresh storage write gets its own budget rather than the exhausted refresh deadline.
- The recheck scan is a single `GetMulti` over all local keys: it adopts fresher envelopes written by other processes (preserving cross-process convergence), prunes hard-expired local entries, and returns the keys still due.
- Opt-in negative caching (`NegativeTTL`): a refresh returning `ErrNotFound` writes a shared tombstone; `SetMissing`/`GetItem` support consumers that keep their own read-through; without a refresh function, absent keys are suppressed with local-only tombstones. Tombstones read as zero-value hits to legacy `ecache` readers, so they must not be enabled on a shared topic until legacy readers are retired (documented).
- Fixes defects present in `ecache`/`rcache`: local reads now enforce expiry (entries were immortal), storage misses no longer install zero-value entries that read as hits, the cache-wide lock is no longer held across network I/O or refresh calls, the background ticker is stoppable, the scan no longer issues one storage round trip per key, and the key namespace argument is actually honored.
- An injectable `Clock` makes TTL-transition tests deterministic instead of sleep-based.

### CI

- Adds `TL_TEST_REDIS_URL` to the test workflow: the Redis service container was already provisioned but the env var tests gate on was never set, so all Redis-backed cache tests silently skipped in CI. They now run.

### Dependencies

- Promotes `golang.org/x/sync` (singleflight) from indirect to direct.

## Test plan

- `go test -race ./server/caches/...` — full suite including singleflight collapse, leader-cancellation, tombstone lifecycle, cross-process convergence via a shared `MemoryStore`, concurrent `Start`/`Stop`, and scan adopt/prune behavior.
- Wire-format golden test asserts the new envelope marshals byte-identically to the legacy `ecache` `Item` JSON and composes the same storage key; delete it together with `ecache`/`rcache`.
- `storetest` conformance suite runs against `MemoryStore` unconditionally and `RedisStore` when `TL_TEST_REDIS_URL` is set — verified locally against a real Redis, and now also exercised in CI.
