### PR TITLE
kvcache fixes

### DIFF
--- a/server/caches/kvcache/kvcache.go
+++ b/server/caches/kvcache/kvcache.go
@@ -37,10 +37,11 @@ type Cache[K comparable, V any] struct {
 	Expires time.Duration
 	// RefreshTimeout bounds each refresh function call (default 1s).
 	RefreshTimeout time.Duration
-	// NegativeTTL enables tombstone caching of absent keys (default off).
-	// Legacy ecache/rcache readers do not understand tombstones and see
-	// them as zero-value hits; do not enable shared tombstones on a topic
-	// until all legacy readers are retired.
+	// NegativeTTL enables tombstone caching of authoritatively absent
+	// keys — via SetMissing or a refresh function returning ErrNotFound
+	// (default off). Legacy ecache/rcache readers do not understand
+	// tombstones and see them as zero-value hits; do not enable shared
+	// tombstones on a topic until all legacy readers are retired.
 	NegativeTTL time.Duration
 	// KeyPrefix namespaces storage keys as "<prefix>:<topic>:<key>". The
 	// default "ecache" preserves the legacy wire format.
@@ -248,13 +249,12 @@ func (c *Cache[K, V]) loadOrRefresh(ctx context.Context, key K) (Item[V], bool) 
 			c.deleteExpiredLocal(key)
 			return result{}, nil
 		}
-		// Definite miss with no refresh source; optionally suppress
-		// repeated storage reads with a local-only tombstone.
-		if c.NegativeTTL > 0 {
-			c.setLocal(key, c.missingItem(c.NegativeTTL))
-		} else {
-			c.deleteExpiredLocal(key)
-		}
+		// Definite miss with no refresh source. Absence is cached only
+		// when stated authoritatively (SetMissing, or a refresh function
+		// returning ErrNotFound) — a bare storage miss may just mean
+		// "not fetched yet", and tombstoning it would turn a concurrent
+		// first read into a spurious cached miss.
+		c.deleteExpiredLocal(key)
 		return result{}, nil
 	})
 	r, _ := v.(result)

--- a/server/caches/kvcache/kvcache_test.go
+++ b/server/caches/kvcache/kvcache_test.go
@@ -291,9 +291,10 @@ func TestCache_SetMissing(t *testing.T) {
 	assert.True(t, it.Missing)
 }
 
-func TestCache_NegativeLocalOnly(t *testing.T) {
-	// Without a refresh function, NegativeTTL suppresses repeat storage
-	// reads for absent keys locally without writing tombstones to storage.
+func TestCache_NegativeMissNotTombstoned(t *testing.T) {
+	// A bare storage miss is not authoritative absence: even with
+	// NegativeTTL set, it must not install a tombstone that could mask a
+	// concurrent first write.
 	ctx := context.Background()
 	store := &recordingStore{Store: kvcache.NewMemoryStore()}
 	c := kvcache.NewCache[string, string](store, "test")
@@ -302,8 +303,9 @@ func TestCache_NegativeLocalOnly(t *testing.T) {
 	assert.False(t, ok)
 	_, ok = c.Get(ctx, "absent")
 	assert.False(t, ok)
-	assert.Equal(t, 1, store.getCount(), "second read must be suppressed by the local tombstone")
-	assert.Empty(t, store.setKeys, "local-only tombstone must not be written to storage")
+	assert.Equal(t, 2, store.getCount(), "misses must keep consulting storage")
+	assert.Empty(t, c.LocalKeys(), "a bare miss must not install a tombstone")
+	assert.Empty(t, store.setKeys)
 }
 
 func TestCache_RecheckConvergence(t *testing.T) {

--- a/server/finders/gbfsfinder/finder.go
+++ b/server/finders/gbfsfinder/finder.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/go-redis/redis/v8"
 	"github.com/interline-io/transitland-lib/internal/gbfs"
-	"github.com/interline-io/transitland-lib/server/caches/ecache"
+	"github.com/interline-io/transitland-lib/server/caches/kvcache"
 	"github.com/interline-io/transitland-lib/server/model"
 	"github.com/interline-io/transitland-lib/tlxy"
 	"github.com/twpayne/go-geom"
@@ -18,7 +18,7 @@ import (
 
 type Finder struct {
 	client           *redis.Client
-	cache            *ecache.Cache[gbfs.GbfsFeed]
+	cache            *kvcache.Cache[string, gbfs.GbfsFeed]
 	ttlRecheck       time.Duration
 	ttlExpire        time.Duration
 	prefix           string
@@ -27,7 +27,7 @@ type Finder struct {
 }
 
 func NewFinder(client *redis.Client) *Finder {
-	c := ecache.NewCache[gbfs.GbfsFeed](client, "gbfs")
+	c := kvcache.NewCache[string, gbfs.GbfsFeed](kvcache.NewRedisStore(client), "gbfs")
 	return &Finder{
 		ttlRecheck:       5 * time.Minute,
 		ttlExpire:        24 * time.Hour,
@@ -45,8 +45,6 @@ func (c *Finder) AddData(ctx context.Context, topic string, sf gbfs.GbfsFeed) er
 		return err
 	}
 	// Geosearch index bikes
-	ts := time.Now().In(time.UTC).Unix()
-	_ = ts
 	if c.client != nil {
 		bbox := geom.NewBounds(geom.XY)
 		for _, ent := range sf.Bikes {


### PR DESCRIPTION
## Summary

Two follow-ups to the new kvcache package, plus its first consumer migration: the negative-caching semantics are narrowed so that only authoritatively absent keys are tombstoned, and gbfsfinder moves from ecache to kvcache. After this, gbfsfinder no longer uses ecache; the old packages remain for external consumers until those migrate.

### kvcache: tombstone only authoritative absence

- A bare storage miss no longer installs a local tombstone when NegativeTTL is set. For consumers that run their own read-through outside the cache, a miss frequently means "not fetched yet" rather than "does not exist" — the removed behavior would let a concurrent first read for a key install a tombstone that then masks the in-flight fetch's result, turning a legitimate first request into a spurious cached miss for up to NegativeTTL.
- Tombstones are now created only by the two authoritative paths: an explicit SetMissing call, or a refresh function returning ErrNotFound. The NegativeTTL doc comment states this, and the definite-miss path now just prunes an expired local entry.
- Test updated accordingly: TestCache_NegativeMissNotTombstoned asserts that misses keep consulting storage and never install tombstones, replacing the prior local-only-tombstone test.

### gbfsfinder: ecache to kvcache

- The feed cache becomes kvcache.Cache[string, gbfs.GbfsFeed] over kvcache.NewRedisStore(client); a nil client degrades to the same local-only mode as before. NewFinder keeps its signature, so no call sites change.
- Storage keys and envelopes are byte-identical to the ecache format (ecache:gbfs:<topic>), so processes running old and new code share warm caches during a rolling deploy; TTLs are unchanged (5m recheck / 24h expire).
- Behavior fix inherited from kvcache: locally cached feeds now expire (ecache pinned the first-read value in process memory indefinitely), and a storage miss no longer poisons the local map with a permanently empty feed.
- Removes a dead ts assignment in AddData.

## Test plan

- `go test -race ./server/caches/kvcache/... ./server/finders/gbfsfinder/...` — passes, including the gbfsfinder suite against a real Redis via TL_TEST_REDIS_URL (now also exercised in CI).
- The kvcache wire-format golden test continues to assert envelope and key compatibility with ecache, which is what guarantees the warm-cache rolling deploy for the gbfs topic.
