### PR TITLE
[EXP] Add Postgres backend for kvcache Store

### DIFF
--- a/schema/postgres/migrations/20260724000001_kv_cache.up.pgsql
+++ b/schema/postgres/migrations/20260724000001_kv_cache.up.pgsql
@@ -1,0 +1,22 @@
+BEGIN;
+
+-- Shared key-value tier for kvcache. Unlogged because every cached byte is
+-- regenerable (fetch cycles, gatekeeper HTTP), so crash-truncation self-heals
+-- within a TTL/fetch cycle. Expiry is enforced on read; a periodic sweep
+-- reclaims lapsed rows (expires_at NULL means no expiry).
+CREATE UNLOGGED TABLE public.tl_kv_cache (
+    key text PRIMARY KEY,
+    value bytea,
+    expires_at timestamptz
+);
+CREATE INDEX tl_kv_cache_expires_at_idx ON public.tl_kv_cache (expires_at) WHERE expires_at IS NOT NULL;
+
+-- Field-addressable hash tier (HashStore), e.g. the GBFS bounding-box index.
+CREATE UNLOGGED TABLE public.tl_kv_hash (
+    hash_key text NOT NULL,
+    field text NOT NULL,
+    value text NOT NULL,
+    PRIMARY KEY (hash_key, field)
+);
+
+COMMIT;

--- a/server/caches/kvcache/store_postgres.go
+++ b/server/caches/kvcache/store_postgres.go
@@ -33,7 +33,10 @@ var (
 const (
 	pgKVGet = `SELECT value FROM tl_kv_cache WHERE key = ? AND (expires_at IS NULL OR expires_at > now())`
 
-	pgKVGetMulti = `SELECT key, value FROM tl_kv_cache WHERE key IN (?) AND (expires_at IS NULL OR expires_at > now())`
+	// key = ANY(?) binds the whole key slice to one array parameter, so the
+	// query text is identical regardless of key count (one plan, one
+	// pg_stat_statements entry) — unlike an expanded IN (?,?,...).
+	pgKVGetMulti = `SELECT key, value FROM tl_kv_cache WHERE key = ANY(?) AND (expires_at IS NULL OR expires_at > now())`
 
 	pgKVSetTTL = `INSERT INTO tl_kv_cache (key, value, expires_at) VALUES (?, ?, now() + (? * interval '1 second'))
 ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, expires_at = EXCLUDED.expires_at`
@@ -76,11 +79,8 @@ func (s *PostgresStore) GetMulti(ctx context.Context, keys []string) (map[string
 	}
 	rctx, cancel := context.WithTimeout(ctx, s.Timeout)
 	defer cancel()
-	query, args, err := sqlx.In(pgKVGetMulti, keys)
-	if err != nil {
-		return nil, err
-	}
-	rows, err := s.db.QueryxContext(rctx, s.db.Rebind(query), args...)
+	// keys is bound as a single array parameter, not spread into args.
+	rows, err := s.db.QueryxContext(rctx, s.db.Rebind(pgKVGetMulti), keys)
 	if err != nil {
 		return nil, err
 	}

--- a/server/caches/kvcache/store_postgres.go
+++ b/server/caches/kvcache/store_postgres.go
@@ -1,0 +1,188 @@
+package kvcache
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"time"
+
+	"github.com/interline-io/log"
+	"github.com/jmoiron/sqlx"
+)
+
+// PostgresStore implements Store and the HashStore capability over two
+// unlogged tables (tl_kv_cache, tl_kv_hash). Expiry is enforced on read;
+// Sweep, run periodically via Start, reclaims lapsed rows.
+type PostgresStore struct {
+	// Timeout bounds each database operation (default 5s).
+	Timeout time.Duration
+	db      sqlx.ExtContext
+
+	tickerLock sync.Mutex
+	tickerStop chan struct{}
+	tickerWg   sync.WaitGroup
+}
+
+var (
+	_ Store     = (*PostgresStore)(nil)
+	_ HashStore = (*PostgresStore)(nil)
+)
+
+// Statements are static literals with bound parameters; the store never
+// assembles SQL from variables.
+const (
+	pgKVGet = `SELECT value FROM tl_kv_cache WHERE key = ? AND (expires_at IS NULL OR expires_at > now())`
+
+	pgKVGetMulti = `SELECT key, value FROM tl_kv_cache WHERE key IN (?) AND (expires_at IS NULL OR expires_at > now())`
+
+	pgKVSetTTL = `INSERT INTO tl_kv_cache (key, value, expires_at) VALUES (?, ?, now() + (? * interval '1 second'))
+ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, expires_at = EXCLUDED.expires_at`
+
+	pgKVSet = `INSERT INTO tl_kv_cache (key, value, expires_at) VALUES (?, ?, NULL)
+ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, expires_at = EXCLUDED.expires_at`
+
+	pgKVSweep = `DELETE FROM tl_kv_cache WHERE expires_at IS NOT NULL AND expires_at <= now()`
+
+	pgHashSet = `INSERT INTO tl_kv_hash (hash_key, field, value) VALUES (?, ?, ?)
+ON CONFLICT (hash_key, field) DO UPDATE SET value = EXCLUDED.value`
+
+	pgHashGetAll = `SELECT field, value FROM tl_kv_hash WHERE hash_key = ?`
+)
+
+func NewPostgresStore(db sqlx.ExtContext) *PostgresStore {
+	return &PostgresStore{
+		Timeout: 5 * time.Second,
+		db:      db,
+	}
+}
+
+func (s *PostgresStore) Get(ctx context.Context, key string) ([]byte, bool, error) {
+	rctx, cancel := context.WithTimeout(ctx, s.Timeout)
+	defer cancel()
+	var value []byte
+	err := s.db.QueryRowxContext(rctx, s.db.Rebind(pgKVGet), key).Scan(&value)
+	if err == sql.ErrNoRows {
+		return nil, false, nil
+	} else if err != nil {
+		return nil, false, err
+	}
+	return value, true, nil
+}
+
+func (s *PostgresStore) GetMulti(ctx context.Context, keys []string) (map[string][]byte, error) {
+	ret := map[string][]byte{}
+	if len(keys) == 0 {
+		return ret, nil
+	}
+	rctx, cancel := context.WithTimeout(ctx, s.Timeout)
+	defer cancel()
+	query, args, err := sqlx.In(pgKVGetMulti, keys)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.db.QueryxContext(rctx, s.db.Rebind(query), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var key string
+		var value []byte
+		if err := rows.Scan(&key, &value); err != nil {
+			return nil, err
+		}
+		ret[key] = value
+	}
+	return ret, rows.Err()
+}
+
+func (s *PostgresStore) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	rctx, cancel := context.WithTimeout(ctx, s.Timeout)
+	defer cancel()
+	// ttl <= 0 means no expiry; branch to a separate literal rather than
+	// build the expires_at expression conditionally.
+	if ttl > 0 {
+		_, err := s.db.ExecContext(rctx, s.db.Rebind(pgKVSetTTL), key, value, ttl.Seconds())
+		return err
+	}
+	_, err := s.db.ExecContext(rctx, s.db.Rebind(pgKVSet), key, value)
+	return err
+}
+
+func (s *PostgresStore) HSet(ctx context.Context, key string, field string, value string) error {
+	rctx, cancel := context.WithTimeout(ctx, s.Timeout)
+	defer cancel()
+	_, err := s.db.ExecContext(rctx, s.db.Rebind(pgHashSet), key, field, value)
+	return err
+}
+
+func (s *PostgresStore) HGetAll(ctx context.Context, key string) (map[string]string, error) {
+	ret := map[string]string{}
+	rctx, cancel := context.WithTimeout(ctx, s.Timeout)
+	defer cancel()
+	rows, err := s.db.QueryxContext(rctx, s.db.Rebind(pgHashGetAll), key)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var field, value string
+		if err := rows.Scan(&field, &value); err != nil {
+			return nil, err
+		}
+		ret[field] = value
+	}
+	return ret, rows.Err()
+}
+
+// Sweep deletes rows whose expiry has lapsed, returning the count removed.
+func (s *PostgresStore) Sweep(ctx context.Context) (int64, error) {
+	rctx, cancel := context.WithTimeout(ctx, s.Timeout)
+	defer cancel()
+	res, err := s.db.ExecContext(rctx, pgKVSweep)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// Start launches a background goroutine that Sweeps every interval. It is a
+// no-op if already running and panics on a non-positive interval.
+func (s *PostgresStore) Start(interval time.Duration) {
+	if interval <= 0 {
+		panic("kvcache: non-positive interval for Start")
+	}
+	s.tickerLock.Lock()
+	defer s.tickerLock.Unlock()
+	if s.tickerStop != nil {
+		return
+	}
+	stop := make(chan struct{})
+	s.tickerStop = stop
+	s.tickerWg.Add(1)
+	go func() {
+		defer s.tickerWg.Done()
+		for {
+			select {
+			case <-time.After(jitter(interval)):
+				if _, err := s.Sweep(context.Background()); err != nil {
+					log.Trace().Err(err).Msg("kvcache: postgres sweep failed")
+				}
+			case <-stop:
+				return
+			}
+		}
+	}()
+}
+
+// Stop halts the background sweeper and waits for an in-flight sweep.
+func (s *PostgresStore) Stop() {
+	s.tickerLock.Lock()
+	defer s.tickerLock.Unlock()
+	if s.tickerStop == nil {
+		return
+	}
+	close(s.tickerStop)
+	s.tickerStop = nil
+	s.tickerWg.Wait()
+}

--- a/server/caches/kvcache/store_postgres_test.go
+++ b/server/caches/kvcache/store_postgres_test.go
@@ -1,0 +1,63 @@
+package kvcache_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/interline-io/transitland-lib/server/caches/kvcache"
+	"github.com/interline-io/transitland-lib/server/caches/kvcache/storetest"
+	"github.com/interline-io/transitland-lib/server/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPostgresStore(t *testing.T) {
+	if a, ok := testutil.CheckTestDB(); !ok {
+		t.Skip(a)
+	}
+	db := testutil.MustOpenTestDB(t)
+	storetest.Run(t, func(t *testing.T) kvcache.Store {
+		// Clear conformance-suite rows from previous subtests.
+		if _, err := db.Exec(db.Rebind("DELETE FROM tl_kv_cache WHERE key LIKE ?"), "storetest:%"); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.Exec(db.Rebind("DELETE FROM tl_kv_hash WHERE hash_key LIKE ?"), "storetest:%"); err != nil {
+			t.Fatal(err)
+		}
+		return kvcache.NewPostgresStore(db)
+	})
+}
+
+func TestPostgresStore_Sweep(t *testing.T) {
+	if a, ok := testutil.CheckTestDB(); !ok {
+		t.Skip(a)
+	}
+	ctx := context.Background()
+	db := testutil.MustOpenTestDB(t)
+	if _, err := db.Exec(db.Rebind("DELETE FROM tl_kv_cache WHERE key LIKE ?"), "sweeptest:%"); err != nil {
+		t.Fatal(err)
+	}
+	store := kvcache.NewPostgresStore(db)
+
+	assert.NoError(t, store.Set(ctx, "sweeptest:gone", []byte("x"), 20*time.Millisecond))
+	assert.NoError(t, store.Set(ctx, "sweeptest:keep", []byte("y"), 0))
+
+	// Once lapsed, the expired key reads as a miss (filter-on-read).
+	assert.Eventually(t, func() bool {
+		_, ok, _ := store.Get(ctx, "sweeptest:gone")
+		return !ok
+	}, 3*time.Second, 50*time.Millisecond)
+
+	if _, err := store.Sweep(ctx); err != nil {
+		t.Fatal(err)
+	}
+	// The expired row is physically deleted; the no-expiry row survives.
+	var gone int
+	if err := db.Get(&gone, db.Rebind("SELECT count(*) FROM tl_kv_cache WHERE key = ?"), "sweeptest:gone"); err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 0, gone, "expired row should be swept")
+	_, ok, err := store.Get(ctx, "sweeptest:keep")
+	assert.NoError(t, err)
+	assert.True(t, ok, "no-expiry row should survive the sweep")
+}


### PR DESCRIPTION
## Summary

Adds a Postgres backend for `kvcache.Store`, the first storage implementation beyond Redis and in-memory. It backs the key-value tier and the `HashStore` capability with two unlogged tables, so the GBFS blob cache and bbox index (and any other `Store` consumer) can run against Postgres instead of Redis. This is a self-contained, additive change: no existing behavior is altered, and nothing is wired to use it yet.

### Migration

- New migration creating two unlogged tables: `tl_kv_cache (key primary key, value bytea, expires_at timestamptz)` with a partial index on `expires_at`, and `tl_kv_hash (hash_key, field, value, primary key (hash_key, field))`.
- Unlogged is deliberate: cached bytes are regenerable, so crash-truncation self-heals within a TTL or fetch cycle, and the tables carry none of the WAL or replication overhead of cache churn. A clean restart preserves them; an unclean stop resets them, which the cache tolerates.

### PostgresStore

- Implements `Store` (`Get`, `GetMulti`, `Set`) and the `HashStore` capability (`HSet`, `HGetAll`), taking a `sqlx.ExtContext` so it composes with the server's existing database handle.
- Expiry is enforced on read against the database clock (`expires_at IS NULL OR expires_at > now()`), removing any dependence on application/database clock agreement. `Set` branches to separate literals for the TTL and no-expiry cases rather than assembling the `expires_at` expression.
- `GetMulti` binds the key set as a single array parameter (`key = ANY(?)`) rather than an expanded `IN (?, ?, ...)`, so the query text is identical regardless of key count: one plan and one `pg_stat_statements` entry instead of a distinct statement per list length. This follows the existing `= ANY` array-binding pattern in the query layer.
- `Sweep` reclaims lapsed rows; `Start`/`Stop` run it on a background interval (reusing the package's existing jitter helper, mirroring the `Cache` lifecycle).
- All statements are static literals with bound parameters routed through `Rebind`; no SQL is assembled from variables.
- Does not implement the pub/sub capability; the realtime store's cross-process distribution over Postgres LISTEN/NOTIFY is left to a follow-up, since it needs a dedicated connection.

### Tests

- `store_postgres_test.go` runs the shared `storetest` conformance suite against `PostgresStore` (the Store and Hash subtests pass; the PubSub subtest skips, since this store advertises no pub/sub) plus a focused sweep test that checks an expired row is physically deleted while a no-expiry row survives.
- Because CI already provisions Postgres, this backend is actually exercised there, unlike the Redis-only paths.

## Test plan

- Apply the migration to the test database: `transitland dbmigrate up --dburl="$TL_TEST_SERVER_DATABASE_URL"`.
- With `TL_TEST_SERVER_DATABASE_URL` set, run `go test -race ./server/caches/kvcache/...` and confirm `TestPostgresStore` (conformance) and `TestPostgresStore_Sweep` pass; without it they skip.
