### PR TITLE
Fix REST OpenAPI serving: mount-aware servers URL, drop kin-openapi fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ Open http://localhost:8080/ in your web browser to see the GraphQL browser, or u
 
 The REST API is documented with OpenAPI 3.0:
 - **Interactive documentation**: http://localhost:8080/rest/openapi.json
-- **Static schema**: [docs/openapi/rest.json](docs/openapi/rest.json)
+- **Static schema**: [doc/openapi/rest.json](doc/openapi/rest.json)
 
-The "example" server instance configured by the  `transitland server` command runs without authentication or authorization. Auth configuration is beyond the scope of this example command but can be added by configuring the server in your own package and adding HTTP middlewares to set user context and permissions data. You can use `cmd/tlserver/main.go` as an example to get started; it uses only public APIs from this package. (Earlier versions of `transitland server` included more built-in auth middlewares, but in our experience these are almost always custom per-installation, and were removed from this repo.) Additionally, this example server configuration exposes Go profiler endpoints on `/debug/pprof/...`. 
+The "example" server instance configured by the  `transitland server` command runs without authentication or authorization. Auth configuration is beyond the scope of this example command but can be added by configuring the server in your own package and adding HTTP middlewares to set user context and permissions data. You can use `cmd/transitland/main.go` as an example to get started; it uses only public APIs from this package. (Earlier versions of `transitland server` included more built-in auth middlewares, but in our experience these are almost always custom per-installation, and were removed from this repo.) Additionally, this example server configuration exposes Go profiler endpoints on `/debug/pprof/...`. 
 
 ## Database migrations
 
@@ -126,7 +126,7 @@ For running tests locally, the following instructions should help get started:
    - Will halt with an error (intentionally) if this database already exists
    - Runs migrations in `transitland-lib/schema/postgres/migrations`
    - Unpacks and imports the Natural Earth datasets bundled with `transitland-lib`
-   - Builds and installs the `cmd/tlserver` command
+   - Builds and installs the `cmd/transitland` command
    - Sets up test feeds contained in `testdata/server/server-test.dmfr.json`
    - Fetches and imports feeds contained in `testdata/server/gtfs`
    - Creates additional fixtures defined in `testdata/server/test_supplement.pgsql`

--- a/cmds/server_cmd.go
+++ b/cmds/server_cmd.go
@@ -82,7 +82,7 @@ func (cmd *ServerCommand) AddFlags(fl *pflag.FlagSet) {
 	fl.StringVar(&cmd.Storage, "storage", "", "Static storage backend")
 	fl.StringVar(&cmd.RTStorage, "rt-storage", "", "RT storage backend")
 	fl.BoolVar(&cmd.ValidateLargeFiles, "validate-large-files", false, "Allow validation of large files")
-	fl.StringVar(&cmd.RestPrefix, "rest-prefix", "", "REST prefix for generating pagination links")
+	fl.StringVar(&cmd.RestPrefix, "rest-prefix", "", "Public prefix of the REST mount's parent (e.g. https://transit.land/api/v2), used for pagination links, redirects, and the OpenAPI servers block")
 	fl.StringVar(&cmd.Port, "port", "8080", "")
 	fl.StringVar(&cmd.SecretsFile, "secrets", "", "DMFR file containing secrets")
 	fl.IntVar(&cmd.Timeout, "timeout", 60, "")

--- a/cmds/server_cmd.go
+++ b/cmds/server_cmd.go
@@ -82,7 +82,7 @@ func (cmd *ServerCommand) AddFlags(fl *pflag.FlagSet) {
 	fl.StringVar(&cmd.Storage, "storage", "", "Static storage backend")
 	fl.StringVar(&cmd.RTStorage, "rt-storage", "", "RT storage backend")
 	fl.BoolVar(&cmd.ValidateLargeFiles, "validate-large-files", false, "Allow validation of large files")
-	fl.StringVar(&cmd.RestPrefix, "rest-prefix", "", "Public prefix of the REST mount's parent (e.g. https://transit.land/api/v2), used for pagination links, redirects, and the OpenAPI servers block")
+	fl.StringVar(&cmd.RestPrefix, "rest-prefix", "", "Public URL prefix for generated links (e.g. https://transit.land/api/v2)")
 	fl.StringVar(&cmd.Port, "port", "8080", "")
 	fl.StringVar(&cmd.SecretsFile, "secrets", "", "DMFR file containing secrets")
 	fl.IntVar(&cmd.Timeout, "timeout", 60, "")

--- a/doc/cli/transitland_server.md
+++ b/doc/cli/transitland_server.md
@@ -24,7 +24,7 @@ transitland server [flags]
       --max-radius float                  Maximum radius for nearby stops (default 100000)
       --port string                        (default "8080")
       --redisurl string                   Redis URL (default: $TL_REDIS_URL)
-      --rest-prefix string                Public prefix of the REST mount's parent (e.g. https://transit.land/api/v2), used for pagination links, redirects, and the OpenAPI servers block
+      --rest-prefix string                Public URL prefix for generated links (e.g. https://transit.land/api/v2)
       --rt-storage string                 RT storage backend
       --secrets string                    DMFR file containing secrets
       --storage string                    Static storage backend

--- a/doc/cli/transitland_server.md
+++ b/doc/cli/transitland_server.md
@@ -24,7 +24,7 @@ transitland server [flags]
       --max-radius float                  Maximum radius for nearby stops (default 100000)
       --port string                        (default "8080")
       --redisurl string                   Redis URL (default: $TL_REDIS_URL)
-      --rest-prefix string                REST prefix for generating pagination links
+      --rest-prefix string                Public prefix of the REST mount's parent (e.g. https://transit.land/api/v2), used for pagination links, redirects, and the OpenAPI servers block
       --rt-storage string                 RT storage backend
       --secrets string                    DMFR file containing secrets
       --storage string                    Static storage backend

--- a/doc/openapi/gen.go
+++ b/doc/openapi/gen.go
@@ -36,7 +36,11 @@ func main() {
 	if err != nil {
 		exit(err)
 	}
-	var validationOpts []oa.ValidationOption
+	// Aggregate independent problems across paths, operations, responses, and
+	// components instead of stopping at the first, so a regeneration that breaks
+	// several things reports all of them in one run. Validation inside a single
+	// schema is still fail-fast — those checks build on each other.
+	validationOpts := []oa.ValidationOption{oa.EnableMultiError()}
 	if err := schema.Validate(ctx, validationOpts...); err != nil {
 		exit(err)
 	}

--- a/doc/openapi/gen.go
+++ b/doc/openapi/gen.go
@@ -36,10 +36,8 @@ func main() {
 	if err != nil {
 		exit(err)
 	}
-	// Aggregate independent problems across paths, operations, responses, and
-	// components instead of stopping at the first, so a regeneration that breaks
-	// several things reports all of them in one run. Validation inside a single
-	// schema is still fail-fast — those checks build on each other.
+	// Report every broken path/operation/response in one run instead of stopping
+	// at the first. Checks within a single schema are still fail-fast.
 	validationOpts := []oa.ValidationOption{oa.EnableMultiError()}
 	if err := schema.Validate(ctx, validationOpts...); err != nil {
 		exit(err)

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/location v1.51.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.103.3
 	github.com/dimchansky/utfbom v1.1.1
-	github.com/getkin/kin-openapi v0.133.0
+	github.com/getkin/kin-openapi v0.139.0
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/go-chi/cors v1.2.2
 	github.com/go-redis/redis/v8 v8.11.5
@@ -128,8 +128,8 @@ require (
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/natefinch/wrap v0.2.0 // indirect
-	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
-	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
+	github.com/oasdiff/yaml v0.1.0 // indirect
+	github.com/oasdiff/yaml3 v0.0.13 // indirect
 	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
@@ -141,6 +141,7 @@ require (
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.9.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/sosodev/duration v1.4.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
@@ -187,9 +188,6 @@ require (
 tool github.com/99designs/gqlgen
 
 tool google.golang.org/protobuf/cmd/protoc-gen-go
-
-// Fork to allow exporting x- extensions
-replace github.com/getkin/kin-openapi => github.com/irees/kin-openapi v0.0.0-20250915211515-c3bd85109028
 
 // replace github.com/twpayne/go-shapefile => /Users/irees/src/irees/go-shapefile
 // replace github.com/interline-io/log => /Users/irees/src/interline-io/log

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docker/docker v28.3.3+incompatible h1:Dypm25kh4rmk49v1eiVbsAtpAsYURjYkaKubwuBdxEI=
 github.com/docker/docker v28.3.3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.7.0 h1:6SsRfJddP22WMrCkj19x9WKjEDTB+ahsdiGYf0mN39c=
@@ -159,6 +161,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/getkin/kin-openapi v0.139.0 h1:pBFXcZJFwz9J1X64jzxlOoNgFm+TF7kNrs9+HJVN6Ic=
+github.com/getkin/kin-openapi v0.139.0/go.mod h1:NGxPfE4PwS/TRXEbyx2RrxDFPZvxcWw31Tw8XXjPZLs=
 github.com/go-chi/chi/v5 v5.3.0 h1:halUjDxhshgXHMrao5bB8eNBXo/rnzwr8m5m36glehM=
 github.com/go-chi/chi/v5 v5.3.0/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
 github.com/go-chi/cors v1.2.2 h1:Jmey33TE+b+rB7fT8MUy1u0I4L+NARQlK6LhzKPSyQE=
@@ -237,8 +241,6 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/interline-io/log v0.0.0-20260609094544-2ef9b819bc27 h1:7jWGwGH5o3t7MiZuuHy6yu+/pnqxxMzz3O1lV5dzch4=
 github.com/interline-io/log v0.0.0-20260609094544-2ef9b819bc27/go.mod h1:BPqaYgLxRz5fL421VIUs00cwrAKuxbV+Iev2Ksk7jxY=
-github.com/irees/kin-openapi v0.0.0-20250915211515-c3bd85109028 h1:AbcDN2lXWPCxmfLGiW/NzKKPEDpk2HkaSs7fL2XUeJE=
-github.com/irees/kin-openapi v0.0.0-20250915211515-c3bd85109028/go.mod h1:boAciF6cXk5FhPqe/NQeBTeenbjqU4LhWBf09ILVvWE=
 github.com/irees/squirrel v1.6.0 h1:r1hDAw1YccIiXqcvCVl20/a5dyx9UeSBd9HTmd50e5s=
 github.com/irees/squirrel v1.6.0/go.mod h1:wCz5pT6Imdp6KW0CDgra/CmG5br34QLt04Kn+HWCoqM=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
@@ -328,10 +330,10 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
-github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 h1:G7ERwszslrBzRxj//JalHPu/3yz+De2J+4aLtSRlHiY=
-github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037/go.mod h1:2bpvgLBZEtENV5scfDFEtB/5+1M4hkQhDQrccEJ/qGw=
-github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 h1:bQx3WeLcUWy+RletIKwUIt4x3t8n2SxavmoclizMb8c=
-github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
+github.com/oasdiff/yaml v0.1.0 h1:0bqZjfKc/8S9urj4JuwepX41WX9EoA6ifhU3SV06cXg=
+github.com/oasdiff/yaml v0.1.0/go.mod h1:kOlRmMdL2X3vucLCEQO5u61SU22RysnfXvcttrZA1O0=
+github.com/oasdiff/yaml3 v0.0.13 h1:06svmvOHOVBqF81+sY2EUScvUI/iS/vl2VIeUUxZQwg=
+github.com/oasdiff/yaml3 v0.0.13/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
 github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
@@ -387,6 +389,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.9.0 h1:GbgQGNtTrEmddYDSAH9QLRyfAHY12md+8YFTqyMTC9k=
 github.com/sagikazarmark/locafero v0.9.0/go.mod h1:UBUyz37V+EdMS3hDF3QWIiVr/2dPrx49OMO0Bn0hJqk=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=

--- a/server/model/config.go
+++ b/server/model/config.go
@@ -40,9 +40,10 @@ type Config struct {
 	// RestPrefix is the public prefix of the REST mount's *parent*, e.g.
 	// https://transit.land/api/v2 when the REST server is mounted at /rest and
 	// reachable at https://transit.land/api/v2/rest. It does not include the
-	// mount segment itself, which is only known at request time; use
-	// rest.mountPrefix to recover the full base URL. Empty yields host-relative
-	// links.
+	// mount segment itself, which is not known at configuration time; the REST
+	// server recovers that from the request path when it builds pagination
+	// links, redirects, and the OpenAPI servers block. Empty yields
+	// host-relative links.
 	RestPrefix string
 	// JobsPrefix is the public prefix of the jobserver mount (analogue of
 	// RestPrefix for the REST mount), used to build absolute artifact download

--- a/server/model/config.go
+++ b/server/model/config.go
@@ -38,12 +38,9 @@ type Config struct {
 	UseGeohashFilter         bool
 	AllowHTTPFetchUnfiltered bool
 	// RestPrefix is the public prefix of the REST mount's *parent*, e.g.
-	// https://transit.land/api/v2 when the REST server is mounted at /rest and
-	// reachable at https://transit.land/api/v2/rest. It does not include the
-	// mount segment itself, which is not known at configuration time; the REST
-	// server recovers that from the request path when it builds pagination
-	// links, redirects, and the OpenAPI servers block. Empty yields
-	// host-relative links.
+	// https://transit.land/api/v2 for a server reachable at .../api/v2/rest. The
+	// mount segment is not known at config time; the server recovers it from the
+	// request path. Empty yields host-relative links.
 	RestPrefix string
 	// JobsPrefix is the public prefix of the jobserver mount (analogue of
 	// RestPrefix for the REST mount), used to build absolute artifact download

--- a/server/model/config.go
+++ b/server/model/config.go
@@ -37,7 +37,13 @@ type Config struct {
 	UseMaterialized          bool
 	UseGeohashFilter         bool
 	AllowHTTPFetchUnfiltered bool
-	RestPrefix               string
+	// RestPrefix is the public prefix of the REST mount's *parent*, e.g.
+	// https://transit.land/api/v2 when the REST server is mounted at /rest and
+	// reachable at https://transit.land/api/v2/rest. It does not include the
+	// mount segment itself, which is only known at request time; use
+	// rest.mountPrefix to recover the full base URL. Empty yields host-relative
+	// links.
+	RestPrefix string
 	// JobsPrefix is the public prefix of the jobserver mount (analogue of
 	// RestPrefix for the REST mount), used to build absolute artifact download
 	// links that are correct behind a path-rewriting ingress. Empty yields

--- a/server/rest/onestop_id_entity_request.go
+++ b/server/rest/onestop_id_entity_request.go
@@ -52,16 +52,20 @@ func (handler OnestopIdEntityRedirectRequest) RequestInfo() RequestInfo {
 func (handler *OnestopIdEntityRedirectRequest) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cfg := model.ForContext(r.Context())
 	onestop_id := chi.URLParam(r, "onestop_id")
+	// Redirect targets must include the mount segment, same as the root redirect
+	// and pagination links. cfg.RestPrefix alone omits it, which sends clients to
+	// /api/v2/feeds/... instead of /api/v2/rest/feeds/...
+	prefix := mountPrefix(cfg.RestPrefix, r.URL.Path, "/onestop_id/"+onestop_id)
 	var redirectUrl string
 	if strings.HasPrefix(onestop_id, "f-") {
-		redirectUrl = fmt.Sprintf("%s/feeds/%s", cfg.RestPrefix, onestop_id)
+		redirectUrl = fmt.Sprintf("%s/feeds/%s", prefix, onestop_id)
 		// redirect to feeds/
 	} else if strings.HasPrefix(onestop_id, "o-") {
-		redirectUrl = fmt.Sprintf("%s/operators/%s", cfg.RestPrefix, onestop_id)
+		redirectUrl = fmt.Sprintf("%s/operators/%s", prefix, onestop_id)
 	} else if strings.HasPrefix(onestop_id, "s-") {
-		redirectUrl = fmt.Sprintf("%s/stops/%s", cfg.RestPrefix, onestop_id)
+		redirectUrl = fmt.Sprintf("%s/stops/%s", prefix, onestop_id)
 	} else if strings.HasPrefix(onestop_id, "r-") {
-		redirectUrl = fmt.Sprintf("%s/routes/%s", cfg.RestPrefix, onestop_id)
+		redirectUrl = fmt.Sprintf("%s/routes/%s", prefix, onestop_id)
 	}
 	if redirectUrl != "" {
 		w.Header().Add("Location", redirectUrl)

--- a/server/rest/onestop_id_entity_request.go
+++ b/server/rest/onestop_id_entity_request.go
@@ -52,15 +52,8 @@ func (handler OnestopIdEntityRedirectRequest) RequestInfo() RequestInfo {
 func (handler *OnestopIdEntityRedirectRequest) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cfg := model.ForContext(r.Context())
 	onestop_id := chi.URLParam(r, "onestop_id")
-	// Redirect targets must include the mount segment, same as the root redirect
-	// and pagination links. cfg.RestPrefix alone omits it, which sends clients to
+	// Targets need the mount segment; cfg.RestPrefix alone sends clients to
 	// /api/v2/feeds/... instead of /api/v2/rest/feeds/...
-	//
-	// The marker is the route's literal segment, not "/onestop_id/"+onestop_id:
-	// chi.URLParam yields the raw percent-encoded value while r.URL.Path is
-	// decoded, so interpolating the parameter fails to match for any id
-	// containing an encoded character (e.g. ~ sent as %7E, common in route
-	// Onestop IDs).
 	prefix := mountPrefix(cfg.RestPrefix, r.URL.Path, "/onestop_id/")
 	var redirectUrl string
 	if strings.HasPrefix(onestop_id, "f-") {

--- a/server/rest/onestop_id_entity_request.go
+++ b/server/rest/onestop_id_entity_request.go
@@ -55,7 +55,13 @@ func (handler *OnestopIdEntityRedirectRequest) ServeHTTP(w http.ResponseWriter, 
 	// Redirect targets must include the mount segment, same as the root redirect
 	// and pagination links. cfg.RestPrefix alone omits it, which sends clients to
 	// /api/v2/feeds/... instead of /api/v2/rest/feeds/...
-	prefix := mountPrefix(cfg.RestPrefix, r.URL.Path, "/onestop_id/"+onestop_id)
+	//
+	// The marker is the route's literal segment, not "/onestop_id/"+onestop_id:
+	// chi.URLParam yields the raw percent-encoded value while r.URL.Path is
+	// decoded, so interpolating the parameter fails to match for any id
+	// containing an encoded character (e.g. ~ sent as %7E, common in route
+	// Onestop IDs).
+	prefix := mountPrefix(cfg.RestPrefix, r.URL.Path, "/onestop_id/")
 	var redirectUrl string
 	if strings.HasPrefix(onestop_id, "f-") {
 		redirectUrl = fmt.Sprintf("%s/feeds/%s", prefix, onestop_id)

--- a/server/rest/openapi_handler.go
+++ b/server/rest/openapi_handler.go
@@ -1,0 +1,89 @@
+package rest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"sync"
+
+	"github.com/interline-io/log"
+	"github.com/interline-io/transitland-lib/server/model"
+)
+
+// openAPICacheControl is sent with every schema response. The document changes
+// only when the binary does, so a few minutes of client-side caching is safe
+// and keeps repeat fetches of a large document cheap.
+const openAPICacheControl = "public, max-age=300"
+
+// openAPIDocument is a generated schema, marshaled once and reused.
+type openAPIDocument struct {
+	body []byte
+	etag string
+}
+
+// NewOpenAPIHandler returns a handler that serves the REST OpenAPI document.
+//
+// The document's servers[0].url is built with mountPrefix, so it includes the
+// mount segment and a client resolving a documented path against it reaches the
+// same URL the root redirect and pagination links produce.
+//
+// Callers outside this package need this constructor rather than the route
+// NewServer registers: mounting the REST server elsewhere just to reach its
+// schema would hand chi a path it does not own.
+func NewOpenAPIHandler(opts ...SchemaOption) http.Handler {
+	docs := &openAPICache{opts: opts, docs: map[string]*openAPIDocument{}}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cfg := model.ForContext(r.Context())
+		doc, err := docs.get(mountPrefix(cfg.RestPrefix, r.URL.Path, "/openapi.json"))
+		if err != nil {
+			log.For(r.Context()).Error().Err(err).Msg("rest: failed to generate openapi schema")
+			http.Error(w, "Failed to generate schema", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", openAPICacheControl)
+		w.Header().Set("ETag", doc.etag)
+		if r.Header.Get("If-None-Match") == doc.etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Write(doc.body)
+	})
+}
+
+// openAPICache memoizes generated documents by server URL.
+type openAPICache struct {
+	opts []SchemaOption
+	mu   sync.Mutex
+	docs map[string]*openAPIDocument
+}
+
+// get returns the document for serverURL, generating it on first use.
+//
+// Generating rebuilds the gqlgen executable schema and walks every REST query's
+// response tree, which costs on the order of 100ms and produces hundreds of
+// kilobytes of JSON. The lock is deliberately held across generation so that
+// cost is paid once per server URL rather than once per request; a burst of
+// concurrent cold requests waits rather than duplicating the work.
+func (c *openAPICache) get(serverURL string) (*openAPIDocument, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if doc, ok := c.docs[serverURL]; ok {
+		return doc, nil
+	}
+	schema, err := GenerateOpenAPI(serverURL, c.opts...)
+	if err != nil {
+		return nil, err
+	}
+	// Marshal eagerly: GenerateOpenAPI hands back a shared mutable *oa.T, and
+	// the bytes are what both the response body and the ETag derive from.
+	body, err := json.Marshal(schema)
+	if err != nil {
+		return nil, err
+	}
+	sum := sha256.Sum256(body)
+	doc := &openAPIDocument{body: body, etag: `"` + hex.EncodeToString(sum[:16]) + `"`}
+	c.docs[serverURL] = doc
+	return doc, nil
+}

--- a/server/rest/openapi_handler.go
+++ b/server/rest/openapi_handler.go
@@ -53,6 +53,13 @@ func NewOpenAPIHandler(opts ...SchemaOption) http.Handler {
 }
 
 // openAPICache memoizes generated documents by server URL.
+//
+// The map is unbounded, which is safe because the number of distinct keys is
+// fixed by how the handler is registered, not by request input: a key derives
+// from the mount path, and chi only routes the exact registered path (verified:
+// /rest//openapi.json, /rest/./openapi.json, /rest/%6fpenapi.json and friends
+// all 404). A caller registering this handler under a wildcard route would
+// break that assumption.
 type openAPICache struct {
 	opts []SchemaOption
 	mu   sync.Mutex
@@ -66,6 +73,10 @@ type openAPICache struct {
 // kilobytes of JSON. The lock is deliberately held across generation so that
 // cost is paid once per server URL rather than once per request; a burst of
 // concurrent cold requests waits rather than duplicating the work.
+//
+// This serializes lookups for every key, not just the one being generated. That
+// is fine at the one or two keys a deployment actually has, and only worth
+// revisiting if a caller registers many.
 func (c *openAPICache) get(serverURL string) (*openAPIDocument, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/server/rest/openapi_handler.go
+++ b/server/rest/openapi_handler.go
@@ -1,105 +1,32 @@
 package rest
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"net/http"
-	"strings"
-	"sync"
 
 	"github.com/interline-io/log"
 	"github.com/interline-io/transitland-lib/server/model"
 )
 
-// openAPICacheControl is sent with every schema response; the document changes
-// only when the binary does.
-const openAPICacheControl = "public, max-age=300"
-
-// openAPIDocument is a generated schema, marshaled once and reused.
-type openAPIDocument struct {
-	body []byte
-	etag string
-}
-
 // NewOpenAPIHandler returns a handler serving the REST OpenAPI document, with
 // servers[0].url built from mountPrefix so documented paths resolve against it.
 // Exported for callers mounting the REST server outside this package.
+//
+// The document is regenerated per request, which is fine for the example server
+// this package wires up. Callers serving it under load should generate once at
+// startup with GenerateOpenAPI and serve the bytes themselves.
 func NewOpenAPIHandler(opts ...SchemaOption) http.Handler {
-	docs := &openAPICache{opts: opts, docs: map[string]*openAPIDocument{}}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		cfg := model.ForContext(r.Context())
-		doc, err := docs.get(mountPrefix(cfg.RestPrefix, r.URL.Path, "/openapi.json"))
+		schema, err := GenerateOpenAPI(mountPrefix(cfg.RestPrefix, r.URL.Path, "/openapi.json"), opts...)
 		if err != nil {
 			log.For(r.Context()).Error().Err(err).Msg("rest: failed to generate openapi schema")
 			http.Error(w, "Failed to generate schema", http.StatusInternalServerError)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Cache-Control", openAPICacheControl)
-		w.Header().Set("ETag", doc.etag)
-		if etagMatch(r.Header.Get("If-None-Match"), doc.etag) {
-			w.WriteHeader(http.StatusNotModified)
-			return
+		if err := json.NewEncoder(w).Encode(schema); err != nil {
+			log.For(r.Context()).Error().Err(err).Msg("rest: failed to encode openapi schema")
 		}
-		w.Write(doc.body)
 	})
-}
-
-// etagMatch reports whether an If-None-Match field value matches etag, using
-// the weak comparison RFC 9110 13.1.2 requires: "*", lists, and W/ prefixes all
-// match. Splitting on commas is safe only because our tags are hex.
-func etagMatch(ifNoneMatch string, etag string) bool {
-	ifNoneMatch = strings.TrimSpace(ifNoneMatch)
-	if ifNoneMatch == "" {
-		return false
-	}
-	if ifNoneMatch == "*" {
-		return true
-	}
-	for _, candidate := range strings.Split(ifNoneMatch, ",") {
-		if trimWeakETag(candidate) == trimWeakETag(etag) {
-			return true
-		}
-	}
-	return false
-}
-
-// trimWeakETag drops surrounding space and the weak-validator prefix, leaving
-// the opaque tag with its quotes.
-func trimWeakETag(s string) string {
-	return strings.TrimPrefix(strings.TrimSpace(s), "W/")
-}
-
-// openAPICache memoizes generated documents by server URL. The map is unbounded
-// but keys derive from the registered mount path, not request input — which
-// holds unless a caller registers this handler under a wildcard route.
-type openAPICache struct {
-	opts []SchemaOption
-	mu   sync.Mutex
-	docs map[string]*openAPIDocument
-}
-
-// get returns the document for serverURL, generating it on first use.
-// Generation costs ~100ms, so the lock is held across it: concurrent cold
-// requests wait rather than duplicating the work.
-func (c *openAPICache) get(serverURL string) (*openAPIDocument, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if doc, ok := c.docs[serverURL]; ok {
-		return doc, nil
-	}
-	schema, err := GenerateOpenAPI(serverURL, c.opts...)
-	if err != nil {
-		return nil, err
-	}
-	// Marshal eagerly: GenerateOpenAPI hands back a shared mutable *oa.T.
-	body, err := json.Marshal(schema)
-	if err != nil {
-		return nil, err
-	}
-	sum := sha256.Sum256(body)
-	doc := &openAPIDocument{body: body, etag: `"` + hex.EncodeToString(sum[:16]) + `"`}
-	c.docs[serverURL] = doc
-	return doc, nil
 }

--- a/server/rest/openapi_handler.go
+++ b/server/rest/openapi_handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/interline-io/log"
@@ -44,12 +45,46 @@ func NewOpenAPIHandler(opts ...SchemaOption) http.Handler {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Cache-Control", openAPICacheControl)
 		w.Header().Set("ETag", doc.etag)
-		if r.Header.Get("If-None-Match") == doc.etag {
+		if etagMatch(r.Header.Get("If-None-Match"), doc.etag) {
 			w.WriteHeader(http.StatusNotModified)
 			return
 		}
 		w.Write(doc.body)
 	})
+}
+
+// etagMatch reports whether an If-None-Match field value matches etag.
+//
+// RFC 9110 section 13.1.2 specifies the weak comparison function for
+// If-None-Match, so W/"x" matches "x", and the field may be "*" or a
+// comma-separated list. Comparing the raw header against our tag missed all
+// three, which costs a full re-download of a large document whenever an
+// intermediary weakens the validator — something CDNs do routinely when they
+// re-encode a response.
+//
+// Splitting on commas is not strictly correct, since an entity-tag may itself
+// contain a comma, but our tags are hex and cannot, so no real tag can be split
+// into something that matches ours.
+func etagMatch(ifNoneMatch string, etag string) bool {
+	ifNoneMatch = strings.TrimSpace(ifNoneMatch)
+	if ifNoneMatch == "" {
+		return false
+	}
+	if ifNoneMatch == "*" {
+		return true
+	}
+	for _, candidate := range strings.Split(ifNoneMatch, ",") {
+		if trimWeakETag(candidate) == trimWeakETag(etag) {
+			return true
+		}
+	}
+	return false
+}
+
+// trimWeakETag drops surrounding space and the weak-validator prefix, leaving
+// the opaque tag with its quotes.
+func trimWeakETag(s string) string {
+	return strings.TrimPrefix(strings.TrimSpace(s), "W/")
 }
 
 // openAPICache memoizes generated documents by server URL.

--- a/server/rest/openapi_handler.go
+++ b/server/rest/openapi_handler.go
@@ -12,9 +12,8 @@ import (
 	"github.com/interline-io/transitland-lib/server/model"
 )
 
-// openAPICacheControl is sent with every schema response. The document changes
-// only when the binary does, so a few minutes of client-side caching is safe
-// and keeps repeat fetches of a large document cheap.
+// openAPICacheControl is sent with every schema response; the document changes
+// only when the binary does.
 const openAPICacheControl = "public, max-age=300"
 
 // openAPIDocument is a generated schema, marshaled once and reused.
@@ -23,15 +22,9 @@ type openAPIDocument struct {
 	etag string
 }
 
-// NewOpenAPIHandler returns a handler that serves the REST OpenAPI document.
-//
-// The document's servers[0].url is built with mountPrefix, so it includes the
-// mount segment and a client resolving a documented path against it reaches the
-// same URL the root redirect and pagination links produce.
-//
-// Callers outside this package need this constructor rather than the route
-// NewServer registers: mounting the REST server elsewhere just to reach its
-// schema would hand chi a path it does not own.
+// NewOpenAPIHandler returns a handler serving the REST OpenAPI document, with
+// servers[0].url built from mountPrefix so documented paths resolve against it.
+// Exported for callers mounting the REST server outside this package.
 func NewOpenAPIHandler(opts ...SchemaOption) http.Handler {
 	docs := &openAPICache{opts: opts, docs: map[string]*openAPIDocument{}}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -53,18 +46,9 @@ func NewOpenAPIHandler(opts ...SchemaOption) http.Handler {
 	})
 }
 
-// etagMatch reports whether an If-None-Match field value matches etag.
-//
-// RFC 9110 section 13.1.2 specifies the weak comparison function for
-// If-None-Match, so W/"x" matches "x", and the field may be "*" or a
-// comma-separated list. Comparing the raw header against our tag missed all
-// three, which costs a full re-download of a large document whenever an
-// intermediary weakens the validator — something CDNs do routinely when they
-// re-encode a response.
-//
-// Splitting on commas is not strictly correct, since an entity-tag may itself
-// contain a comma, but our tags are hex and cannot, so no real tag can be split
-// into something that matches ours.
+// etagMatch reports whether an If-None-Match field value matches etag, using
+// the weak comparison RFC 9110 13.1.2 requires: "*", lists, and W/ prefixes all
+// match. Splitting on commas is safe only because our tags are hex.
 func etagMatch(ifNoneMatch string, etag string) bool {
 	ifNoneMatch = strings.TrimSpace(ifNoneMatch)
 	if ifNoneMatch == "" {
@@ -87,14 +71,9 @@ func trimWeakETag(s string) string {
 	return strings.TrimPrefix(strings.TrimSpace(s), "W/")
 }
 
-// openAPICache memoizes generated documents by server URL.
-//
-// The map is unbounded, which is safe because the number of distinct keys is
-// fixed by how the handler is registered, not by request input: a key derives
-// from the mount path, and chi only routes the exact registered path (verified:
-// /rest//openapi.json, /rest/./openapi.json, /rest/%6fpenapi.json and friends
-// all 404). A caller registering this handler under a wildcard route would
-// break that assumption.
+// openAPICache memoizes generated documents by server URL. The map is unbounded
+// but keys derive from the registered mount path, not request input — which
+// holds unless a caller registers this handler under a wildcard route.
 type openAPICache struct {
 	opts []SchemaOption
 	mu   sync.Mutex
@@ -102,16 +81,8 @@ type openAPICache struct {
 }
 
 // get returns the document for serverURL, generating it on first use.
-//
-// Generating rebuilds the gqlgen executable schema and walks every REST query's
-// response tree, which costs on the order of 100ms and produces hundreds of
-// kilobytes of JSON. The lock is deliberately held across generation so that
-// cost is paid once per server URL rather than once per request; a burst of
-// concurrent cold requests waits rather than duplicating the work.
-//
-// This serializes lookups for every key, not just the one being generated. That
-// is fine at the one or two keys a deployment actually has, and only worth
-// revisiting if a caller registers many.
+// Generation costs ~100ms, so the lock is held across it: concurrent cold
+// requests wait rather than duplicating the work.
 func (c *openAPICache) get(serverURL string) (*openAPIDocument, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -122,8 +93,7 @@ func (c *openAPICache) get(serverURL string) (*openAPIDocument, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Marshal eagerly: GenerateOpenAPI hands back a shared mutable *oa.T, and
-	// the bytes are what both the response body and the ETag derive from.
+	// Marshal eagerly: GenerateOpenAPI hands back a shared mutable *oa.T.
 	body, err := json.Marshal(schema)
 	if err != nil {
 		return nil, err

--- a/server/rest/openapi_handler_test.go
+++ b/server/rest/openapi_handler_test.go
@@ -59,7 +59,7 @@ func TestMountPrefix(t *testing.T) {
 
 // serveRest mounts h under mountPath with cfg on the context and returns the
 // response for a GET of reqPath. mountPath may be empty to serve at the root.
-func serveRest(t testing.TB, h http.Handler, mountPath string, cfg model.Config, reqPath string, header http.Header) *httptest.ResponseRecorder {
+func serveRest(t testing.TB, h http.Handler, mountPath string, cfg model.Config, reqPath string) *httptest.ResponseRecorder {
 	t.Helper()
 	root := chi.NewRouter()
 	if mountPath == "" {
@@ -68,9 +68,6 @@ func serveRest(t testing.TB, h http.Handler, mountPath string, cfg model.Config,
 		root.Mount(mountPath, h)
 	}
 	req := httptest.NewRequest(http.MethodGet, reqPath, nil)
-	if header != nil {
-		req.Header = header
-	}
 	req = req.WithContext(model.WithConfig(req.Context(), cfg))
 	rr := httptest.NewRecorder()
 	root.ServeHTTP(rr, req)
@@ -91,7 +88,7 @@ func TestOpenAPIHandlerServers(t *testing.T) {
 	// a client resolves /stops to /api/v2/stops (404) not /api/v2/rest/stops.
 	t.Run("mounted with absolute prefix includes mount segment", func(t *testing.T) {
 		cfg := model.Config{RestPrefix: "https://example.test/api/v2"}
-		rr := serveRest(t, NewOpenAPIHandler(), "/rest", cfg, "/rest/openapi.json", nil)
+		rr := serveRest(t, NewOpenAPIHandler(), "/rest", cfg, "/rest/openapi.json")
 		require.Equal(t, http.StatusOK, rr.Code)
 		servers := openAPIServers(t, rr.Body.Bytes())
 		require.Len(t, servers, 1)
@@ -99,98 +96,10 @@ func TestOpenAPIHandlerServers(t *testing.T) {
 	})
 
 	t.Run("unmounted with no prefix emits no servers block", func(t *testing.T) {
-		rr := serveRest(t, NewOpenAPIHandler(), "", model.Config{}, "/openapi.json", nil)
+		rr := serveRest(t, NewOpenAPIHandler(), "", model.Config{}, "/openapi.json")
 		require.Equal(t, http.StatusOK, rr.Code)
 		assert.Empty(t, openAPIServers(t, rr.Body.Bytes()))
 	})
-}
-
-// If-None-Match uses weak comparison and may be "*" or a list, so an exact
-// compare re-sends the document whenever an intermediary weakens the validator.
-func TestETagMatch(t *testing.T) {
-	const etag = `"abc123"`
-	tcs := []struct {
-		name         string
-		ifNoneMatch  string
-		expectsMatch bool
-	}{
-		{"exact", `"abc123"`, true},
-		{"weak validator from client", `W/"abc123"`, true},
-		{"wildcard", "*", true},
-		{"list containing ours", `"other", "abc123"`, true},
-		{"list of weak validators containing ours", `W/"other", W/"abc123"`, true},
-		{"surrounding whitespace", `  "abc123"  `, true},
-		{"empty", "", false},
-		{"different tag", `"nope"`, false},
-		{"list without ours", `"a", "b"`, false},
-		{"unquoted", "abc123", false},
-		{"prefix only", `"abc"`, false},
-	}
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expectsMatch, etagMatch(tc.ifNoneMatch, etag))
-		})
-	}
-
-	// Our tag is what we would send, so a weak form of it must also match.
-	assert.True(t, etagMatch(`W/"abc123"`, `W/"abc123"`))
-}
-
-func TestOpenAPIHandlerCaching(t *testing.T) {
-	cfg := model.Config{RestPrefix: "https://example.test/api/v2"}
-	h := NewOpenAPIHandler()
-
-	first := serveRest(t, h, "/rest", cfg, "/rest/openapi.json", nil)
-	require.Equal(t, http.StatusOK, first.Code)
-	etag := first.Header().Get("ETag")
-	require.NotEmpty(t, etag)
-	assert.Equal(t, "application/json", first.Header().Get("Content-Type"))
-	assert.Equal(t, openAPICacheControl, first.Header().Get("Cache-Control"))
-
-	t.Run("repeat request is byte-identical with a stable etag", func(t *testing.T) {
-		second := serveRest(t, h, "/rest", cfg, "/rest/openapi.json", nil)
-		require.Equal(t, http.StatusOK, second.Code)
-		assert.Equal(t, etag, second.Header().Get("ETag"))
-		assert.Equal(t, first.Body.Bytes(), second.Body.Bytes())
-	})
-
-	t.Run("If-None-Match revalidates to 304 with no body", func(t *testing.T) {
-		hdr := http.Header{"If-None-Match": []string{etag}}
-		rr := serveRest(t, h, "/rest", cfg, "/rest/openapi.json", hdr)
-		assert.Equal(t, http.StatusNotModified, rr.Code)
-		assert.Empty(t, rr.Body.Bytes())
-	})
-
-	t.Run("a weakened validator still revalidates", func(t *testing.T) {
-		hdr := http.Header{"If-None-Match": []string{"W/" + etag}}
-		rr := serveRest(t, h, "/rest", cfg, "/rest/openapi.json", hdr)
-		assert.Equal(t, http.StatusNotModified, rr.Code)
-	})
-
-	t.Run("a stale etag still gets the document", func(t *testing.T) {
-		hdr := http.Header{"If-None-Match": []string{`"stale"`}}
-		rr := serveRest(t, h, "/rest", cfg, "/rest/openapi.json", hdr)
-		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.Equal(t, first.Body.Bytes(), rr.Body.Bytes())
-	})
-}
-
-func TestOpenAPICacheGeneratesOncePerServerURL(t *testing.T) {
-	c := &openAPICache{docs: map[string]*openAPIDocument{}}
-
-	first, err := c.get("https://example.test/api/v2/rest")
-	require.NoError(t, err)
-	second, err := c.get("https://example.test/api/v2/rest")
-	require.NoError(t, err)
-	// Same pointer means the second call was served from the cache rather than
-	// re-walking every REST query against the GraphQL schema.
-	assert.Same(t, first, second, "expected the cached document to be reused")
-
-	other, err := c.get("https://saas.example.test/api/v2/rest")
-	require.NoError(t, err)
-	assert.NotSame(t, first, other, "a distinct server URL needs its own document")
-	assert.NotEqual(t, first.etag, other.etag)
-	assert.Equal(t, "https://saas.example.test/api/v2/rest", openAPIServers(t, other.body)[0]["url"])
 }
 
 func TestOnestopIdRedirectIncludesMountSegment(t *testing.T) {
@@ -209,14 +118,14 @@ func TestOnestopIdRedirectIncludesMountSegment(t *testing.T) {
 	cfg := model.Config{RestPrefix: "https://example.test/api/v2"}
 	for _, tc := range tcs {
 		t.Run(tc.onestopId, func(t *testing.T) {
-			rr := serveRest(t, r, "/rest", cfg, "/rest/onestop_id/"+tc.onestopId, nil)
+			rr := serveRest(t, r, "/rest", cfg, "/rest/onestop_id/"+tc.onestopId)
 			assert.Equal(t, http.StatusFound, rr.Code)
 			assert.Equal(t, tc.expect, rr.Header().Get("Location"))
 		})
 	}
 
 	t.Run("unrecognized prefix is a 404", func(t *testing.T) {
-		rr := serveRest(t, r, "/rest", cfg, "/rest/onestop_id/x-nope", nil)
+		rr := serveRest(t, r, "/rest", cfg, "/rest/onestop_id/x-nope")
 		assert.Equal(t, http.StatusNotFound, rr.Code)
 	})
 
@@ -235,7 +144,7 @@ func TestOnestopIdRedirectIncludesMountSegment(t *testing.T) {
 			{"/rest/onestop_id/f-%2Fonestop_id%2Fevil", "https://example.test/api/v2/rest/feeds/f-%2Fonestop_id%2Fevil"},
 		}
 		for _, tc := range encoded {
-			rr := serveRest(t, r, "/rest", cfg, tc.path, nil)
+			rr := serveRest(t, r, "/rest", cfg, tc.path)
 			assert.Equal(t, http.StatusFound, rr.Code)
 			assert.Equal(t, tc.expect, rr.Header().Get("Location"))
 		}

--- a/server/rest/openapi_handler_test.go
+++ b/server/rest/openapi_handler_test.go
@@ -20,22 +20,26 @@ func TestMountPrefix(t *testing.T) {
 		name        string
 		restPrefix  string
 		urlPath     string
-		routeSuffix string
+		routeMarker string
 		expect      string
 	}{
 		{"mounted, absolute prefix", "https://transit.land/api/v2", "/rest/openapi.json", "/openapi.json", "https://transit.land/api/v2/rest"},
 		{"mounted, root redirect", "https://transit.land/api/v2", "/rest/", "", "https://transit.land/api/v2/rest"},
 		{"mounted, no trailing slash", "https://transit.land/api/v2", "/rest", "", "https://transit.land/api/v2/rest"},
-		{"mounted, onestop_id", "https://transit.land/api/v2", "/rest/onestop_id/f-9q9-bart", "/onestop_id/f-9q9-bart", "https://transit.land/api/v2/rest"},
+		{"mounted, onestop_id", "https://transit.land/api/v2", "/rest/onestop_id/f-9q9-bart", "/onestop_id/", "https://transit.land/api/v2/rest"},
 		{"nested mount", "https://transit.land/api/v2", "/a/b/openapi.json", "/openapi.json", "https://transit.land/api/v2/a/b"},
 		{"unmounted, absolute prefix", "https://transit.land/api/v2", "/openapi.json", "/openapi.json", "https://transit.land/api/v2"},
 		{"no prefix, mounted", "", "/rest/openapi.json", "/openapi.json", "/rest"},
 		{"no prefix, unmounted", "", "/openapi.json", "/openapi.json", ""},
 		{"no prefix, root redirect", "", "/", "", ""},
+		// A marker the path does not contain means something rewrote the path.
+		// Falling back to the bare prefix is merely incomplete; splicing the
+		// request path in would be actively wrong.
+		{"marker absent falls back to prefix", "https://transit.land/api/v2", "/rest/something-else", "/openapi.json", "https://transit.land/api/v2"},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expect, mountPrefix(tc.restPrefix, tc.urlPath, tc.routeSuffix))
+			assert.Equal(t, tc.expect, mountPrefix(tc.restPrefix, tc.urlPath, tc.routeMarker))
 		})
 	}
 }
@@ -166,5 +170,25 @@ func TestOnestopIdRedirectIncludesMountSegment(t *testing.T) {
 	t.Run("unrecognized prefix is a 404", func(t *testing.T) {
 		rr := serveRest(t, r, "/rest", cfg, "/rest/onestop_id/x-nope", nil)
 		assert.Equal(t, http.StatusNotFound, rr.Code)
+	})
+
+	// chi.URLParam returns the raw percent-encoded value while r.URL.Path is
+	// decoded. Deriving the mount from the parameter rather than the route's
+	// literal segment produced a redirect containing the whole request path,
+	// e.g. .../rest/onestop_id/r-9q9-antioch~sfia/routes/r-9q9-antioch%7Esfia.
+	// Route Onestop IDs routinely contain ~, and clients do encode it.
+	t.Run("percent-encoded onestop_id still resolves the mount", func(t *testing.T) {
+		encoded := []struct {
+			path   string
+			expect string
+		}{
+			{"/rest/onestop_id/r-9q9-antioch%7Esfia", "https://example.test/api/v2/rest/routes/r-9q9-antioch%7Esfia"},
+			{"/rest/onestop_id/f-9q9-bart%2Fx", "https://example.test/api/v2/rest/feeds/f-9q9-bart%2Fx"},
+		}
+		for _, tc := range encoded {
+			rr := serveRest(t, r, "/rest", cfg, tc.path, nil)
+			assert.Equal(t, http.StatusFound, rr.Code)
+			assert.Equal(t, tc.expect, rr.Header().Get("Location"))
+		}
 	})
 }

--- a/server/rest/openapi_handler_test.go
+++ b/server/rest/openapi_handler_test.go
@@ -101,6 +101,38 @@ func TestOpenAPIHandlerServers(t *testing.T) {
 	})
 }
 
+// If-None-Match uses weak comparison and may be "*" or a list, so an exact
+// string compare against our tag re-sends the whole document whenever an
+// intermediary weakens the validator.
+func TestETagMatch(t *testing.T) {
+	const etag = `"abc123"`
+	tcs := []struct {
+		name         string
+		ifNoneMatch  string
+		expectsMatch bool
+	}{
+		{"exact", `"abc123"`, true},
+		{"weak validator from client", `W/"abc123"`, true},
+		{"wildcard", "*", true},
+		{"list containing ours", `"other", "abc123"`, true},
+		{"list of weak validators containing ours", `W/"other", W/"abc123"`, true},
+		{"surrounding whitespace", `  "abc123"  `, true},
+		{"empty", "", false},
+		{"different tag", `"nope"`, false},
+		{"list without ours", `"a", "b"`, false},
+		{"unquoted", "abc123", false},
+		{"prefix only", `"abc"`, false},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectsMatch, etagMatch(tc.ifNoneMatch, etag))
+		})
+	}
+
+	// Our tag is what we would send, so a weak form of it must also match.
+	assert.True(t, etagMatch(`W/"abc123"`, `W/"abc123"`))
+}
+
 func TestOpenAPIHandlerCaching(t *testing.T) {
 	cfg := model.Config{RestPrefix: "https://example.test/api/v2"}
 	h := NewOpenAPIHandler()
@@ -124,6 +156,12 @@ func TestOpenAPIHandlerCaching(t *testing.T) {
 		rr := serveRest(t, h, "/rest", cfg, "/rest/openapi.json", hdr)
 		assert.Equal(t, http.StatusNotModified, rr.Code)
 		assert.Empty(t, rr.Body.Bytes())
+	})
+
+	t.Run("a weakened validator still revalidates", func(t *testing.T) {
+		hdr := http.Header{"If-None-Match": []string{"W/" + etag}}
+		rr := serveRest(t, h, "/rest", cfg, "/rest/openapi.json", hdr)
+		assert.Equal(t, http.StatusNotModified, rr.Code)
 	})
 
 	t.Run("a stale etag still gets the document", func(t *testing.T) {

--- a/server/rest/openapi_handler_test.go
+++ b/server/rest/openapi_handler_test.go
@@ -36,6 +36,13 @@ func TestMountPrefix(t *testing.T) {
 		// Falling back to the bare prefix is merely incomplete; splicing the
 		// request path in would be actively wrong.
 		{"marker absent falls back to prefix", "https://transit.land/api/v2", "/rest/something-else", "/openapi.json", "https://transit.land/api/v2"},
+		// A relative result must never start with "//" — a Location header built
+		// from it would be protocol-relative and redirect off-site.
+		{"protocol-relative mount refused", "", "//evil.com/openapi.json", "/openapi.json", ""},
+		{"protocol-relative mount refused, deep", "", "//evil.com/a/openapi.json", "/openapi.json", ""},
+		// An absolute prefix already fixes the authority, so the same mount is
+		// only path noise and is kept.
+		{"absolute prefix keeps odd mount", "https://transit.land/api/v2", "//evil.com/openapi.json", "/openapi.json", "https://transit.land/api/v2//evil.com"},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/rest/openapi_handler_test.go
+++ b/server/rest/openapi_handler_test.go
@@ -1,0 +1,170 @@
+package rest
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/interline-io/transitland-lib/server/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests do not touch the database: GenerateOpenAPI walks the compiled
+// gqlgen schema, and the redirect handlers only read config off the context.
+
+func TestMountPrefix(t *testing.T) {
+	tcs := []struct {
+		name        string
+		restPrefix  string
+		urlPath     string
+		routeSuffix string
+		expect      string
+	}{
+		{"mounted, absolute prefix", "https://transit.land/api/v2", "/rest/openapi.json", "/openapi.json", "https://transit.land/api/v2/rest"},
+		{"mounted, root redirect", "https://transit.land/api/v2", "/rest/", "", "https://transit.land/api/v2/rest"},
+		{"mounted, no trailing slash", "https://transit.land/api/v2", "/rest", "", "https://transit.land/api/v2/rest"},
+		{"mounted, onestop_id", "https://transit.land/api/v2", "/rest/onestop_id/f-9q9-bart", "/onestop_id/f-9q9-bart", "https://transit.land/api/v2/rest"},
+		{"nested mount", "https://transit.land/api/v2", "/a/b/openapi.json", "/openapi.json", "https://transit.land/api/v2/a/b"},
+		{"unmounted, absolute prefix", "https://transit.land/api/v2", "/openapi.json", "/openapi.json", "https://transit.land/api/v2"},
+		{"no prefix, mounted", "", "/rest/openapi.json", "/openapi.json", "/rest"},
+		{"no prefix, unmounted", "", "/openapi.json", "/openapi.json", ""},
+		{"no prefix, root redirect", "", "/", "", ""},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expect, mountPrefix(tc.restPrefix, tc.urlPath, tc.routeSuffix))
+		})
+	}
+}
+
+// serveRest mounts h under mountPath with cfg on the context and returns the
+// response for a GET of reqPath. mountPath may be empty to serve at the root.
+func serveRest(t testing.TB, h http.Handler, mountPath string, cfg model.Config, reqPath string, header http.Header) *httptest.ResponseRecorder {
+	t.Helper()
+	root := chi.NewRouter()
+	if mountPath == "" {
+		root.Mount("/", h)
+	} else {
+		root.Mount(mountPath, h)
+	}
+	req := httptest.NewRequest(http.MethodGet, reqPath, nil)
+	if header != nil {
+		req.Header = header
+	}
+	req = req.WithContext(model.WithConfig(req.Context(), cfg))
+	rr := httptest.NewRecorder()
+	root.ServeHTTP(rr, req)
+	return rr
+}
+
+func openAPIServers(t testing.TB, body []byte) []map[string]any {
+	t.Helper()
+	var doc struct {
+		Servers []map[string]any `json:"servers"`
+	}
+	require.NoError(t, json.Unmarshal(body, &doc))
+	return doc.Servers
+}
+
+func TestOpenAPIHandlerServers(t *testing.T) {
+	// The bug this guards: passing RestPrefix straight through drops the mount
+	// segment, so a generated client resolves /stops to
+	// https://transit.land/api/v2/stops (404) instead of
+	// https://transit.land/api/v2/rest/stops.
+	t.Run("mounted with absolute prefix includes mount segment", func(t *testing.T) {
+		cfg := model.Config{RestPrefix: "https://example.test/api/v2"}
+		rr := serveRest(t, NewOpenAPIHandler(), "/rest", cfg, "/rest/openapi.json", nil)
+		require.Equal(t, http.StatusOK, rr.Code)
+		servers := openAPIServers(t, rr.Body.Bytes())
+		require.Len(t, servers, 1)
+		assert.Equal(t, "https://example.test/api/v2/rest", servers[0]["url"])
+	})
+
+	t.Run("unmounted with no prefix emits no servers block", func(t *testing.T) {
+		rr := serveRest(t, NewOpenAPIHandler(), "", model.Config{}, "/openapi.json", nil)
+		require.Equal(t, http.StatusOK, rr.Code)
+		assert.Empty(t, openAPIServers(t, rr.Body.Bytes()))
+	})
+}
+
+func TestOpenAPIHandlerCaching(t *testing.T) {
+	cfg := model.Config{RestPrefix: "https://example.test/api/v2"}
+	h := NewOpenAPIHandler()
+
+	first := serveRest(t, h, "/rest", cfg, "/rest/openapi.json", nil)
+	require.Equal(t, http.StatusOK, first.Code)
+	etag := first.Header().Get("ETag")
+	require.NotEmpty(t, etag)
+	assert.Equal(t, "application/json", first.Header().Get("Content-Type"))
+	assert.Equal(t, openAPICacheControl, first.Header().Get("Cache-Control"))
+
+	t.Run("repeat request is byte-identical with a stable etag", func(t *testing.T) {
+		second := serveRest(t, h, "/rest", cfg, "/rest/openapi.json", nil)
+		require.Equal(t, http.StatusOK, second.Code)
+		assert.Equal(t, etag, second.Header().Get("ETag"))
+		assert.Equal(t, first.Body.Bytes(), second.Body.Bytes())
+	})
+
+	t.Run("If-None-Match revalidates to 304 with no body", func(t *testing.T) {
+		hdr := http.Header{"If-None-Match": []string{etag}}
+		rr := serveRest(t, h, "/rest", cfg, "/rest/openapi.json", hdr)
+		assert.Equal(t, http.StatusNotModified, rr.Code)
+		assert.Empty(t, rr.Body.Bytes())
+	})
+
+	t.Run("a stale etag still gets the document", func(t *testing.T) {
+		hdr := http.Header{"If-None-Match": []string{`"stale"`}}
+		rr := serveRest(t, h, "/rest", cfg, "/rest/openapi.json", hdr)
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, first.Body.Bytes(), rr.Body.Bytes())
+	})
+}
+
+func TestOpenAPICacheGeneratesOncePerServerURL(t *testing.T) {
+	c := &openAPICache{docs: map[string]*openAPIDocument{}}
+
+	first, err := c.get("https://example.test/api/v2/rest")
+	require.NoError(t, err)
+	second, err := c.get("https://example.test/api/v2/rest")
+	require.NoError(t, err)
+	// Same pointer means the second call was served from the cache rather than
+	// re-walking every REST query against the GraphQL schema.
+	assert.Same(t, first, second, "expected the cached document to be reused")
+
+	other, err := c.get("https://saas.example.test/api/v2/rest")
+	require.NoError(t, err)
+	assert.NotSame(t, first, other, "a distinct server URL needs its own document")
+	assert.NotEqual(t, first.etag, other.etag)
+	assert.Equal(t, "https://saas.example.test/api/v2/rest", openAPIServers(t, other.body)[0]["url"])
+}
+
+func TestOnestopIdRedirectIncludesMountSegment(t *testing.T) {
+	r := chi.NewRouter()
+	r.Handle("/onestop_id/{onestop_id}", &OnestopIdEntityRedirectRequest{})
+
+	tcs := []struct {
+		onestopId string
+		expect    string
+	}{
+		{"f-9q9-bayarearapidtransit", "https://example.test/api/v2/rest/feeds/f-9q9-bayarearapidtransit"},
+		{"o-9q9-bart", "https://example.test/api/v2/rest/operators/o-9q9-bart"},
+		{"s-9q9p1-embarcadero", "https://example.test/api/v2/rest/stops/s-9q9p1-embarcadero"},
+		{"r-9q9-antioch~sfia", "https://example.test/api/v2/rest/routes/r-9q9-antioch~sfia"},
+	}
+	cfg := model.Config{RestPrefix: "https://example.test/api/v2"}
+	for _, tc := range tcs {
+		t.Run(tc.onestopId, func(t *testing.T) {
+			rr := serveRest(t, r, "/rest", cfg, "/rest/onestop_id/"+tc.onestopId, nil)
+			assert.Equal(t, http.StatusFound, rr.Code)
+			assert.Equal(t, tc.expect, rr.Header().Get("Location"))
+		})
+	}
+
+	t.Run("unrecognized prefix is a 404", func(t *testing.T) {
+		rr := serveRest(t, r, "/rest", cfg, "/rest/onestop_id/x-nope", nil)
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+	})
+}

--- a/server/rest/openapi_handler_test.go
+++ b/server/rest/openapi_handler_test.go
@@ -36,6 +36,11 @@ func TestMountPrefix(t *testing.T) {
 		// Falling back to the bare prefix is merely incomplete; splicing the
 		// request path in would be actively wrong.
 		{"marker absent falls back to prefix", "https://transit.land/api/v2", "/rest/something-else", "/openapi.json", "https://transit.land/api/v2"},
+		// The marker is matched at its first occurrence. r.URL.Path is decoded,
+		// so an onestop_id sent as f-%2Fonestop_id%2Fevil arrives with a second
+		// literal /onestop_id/ in it; matching the last one would anchor the
+		// mount inside caller-controlled input.
+		{"marker recurring in a path parameter", "https://transit.land/api/v2", "/rest/onestop_id/f-/onestop_id/evil", "/onestop_id/", "https://transit.land/api/v2/rest"},
 		// A relative result must never start with "//" — a Location header built
 		// from it would be protocol-relative and redirect off-site.
 		{"protocol-relative mount refused", "", "//evil.com/openapi.json", "/openapi.json", ""},
@@ -229,6 +234,9 @@ func TestOnestopIdRedirectIncludesMountSegment(t *testing.T) {
 		}{
 			{"/rest/onestop_id/r-9q9-antioch%7Esfia", "https://example.test/api/v2/rest/routes/r-9q9-antioch%7Esfia"},
 			{"/rest/onestop_id/f-9q9-bart%2Fx", "https://example.test/api/v2/rest/feeds/f-9q9-bart%2Fx"},
+			// The decoded path here contains a second "/onestop_id/", which is
+			// why the mount is recovered from the marker's first occurrence.
+			{"/rest/onestop_id/f-%2Fonestop_id%2Fevil", "https://example.test/api/v2/rest/feeds/f-%2Fonestop_id%2Fevil"},
 		}
 		for _, tc := range encoded {
 			rr := serveRest(t, r, "/rest", cfg, tc.path, nil)

--- a/server/rest/openapi_handler_test.go
+++ b/server/rest/openapi_handler_test.go
@@ -41,13 +41,19 @@ func TestMountPrefix(t *testing.T) {
 		// literal /onestop_id/ in it; matching the last one would anchor the
 		// mount inside caller-controlled input.
 		{"marker recurring in a path parameter", "https://transit.land/api/v2", "/rest/onestop_id/f-/onestop_id/evil", "/onestop_id/", "https://transit.land/api/v2/rest"},
-		// A relative result must never start with "//" — a Location header built
-		// from it would be protocol-relative and redirect off-site.
+		// A relative result must never read as protocol-relative — a Location
+		// header built from it would redirect off-site. Backslashes count: the
+		// WHATWG URL parser treats \ as / for special schemes, so browsers
+		// resolve /\evil.com exactly like //evil.com.
 		{"protocol-relative mount refused", "", "//evil.com/openapi.json", "/openapi.json", ""},
 		{"protocol-relative mount refused, deep", "", "//evil.com/a/openapi.json", "/openapi.json", ""},
-		// An absolute prefix already fixes the authority, so the same mount is
-		// only path noise and is kept.
+		{"backslash mount refused", "", `/\evil.com/openapi.json`, "/openapi.json", ""},
+		{"mixed slash mount refused", "", `/\/evil.com/openapi.json`, "/openapi.json", ""},
+		{"backslash mount refused, root redirect", "", `/\evil.com/`, "", ""},
+		// An absolute prefix already fixes the authority, so the same mounts are
+		// only path noise and are kept.
 		{"absolute prefix keeps odd mount", "https://transit.land/api/v2", "//evil.com/openapi.json", "/openapi.json", "https://transit.land/api/v2//evil.com"},
+		{"absolute prefix keeps backslash mount", "https://transit.land/api/v2", `/\evil.com/openapi.json`, "/openapi.json", `https://transit.land/api/v2/\evil.com`},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/rest/openapi_handler_test.go
+++ b/server/rest/openapi_handler_test.go
@@ -32,19 +32,14 @@ func TestMountPrefix(t *testing.T) {
 		{"no prefix, mounted", "", "/rest/openapi.json", "/openapi.json", "/rest"},
 		{"no prefix, unmounted", "", "/openapi.json", "/openapi.json", ""},
 		{"no prefix, root redirect", "", "/", "", ""},
-		// A marker the path does not contain means something rewrote the path.
-		// Falling back to the bare prefix is merely incomplete; splicing the
-		// request path in would be actively wrong.
+		// An absent marker means the path was rewritten; the bare prefix is
+		// incomplete, but splicing the request path in would be wrong.
 		{"marker absent falls back to prefix", "https://transit.land/api/v2", "/rest/something-else", "/openapi.json", "https://transit.land/api/v2"},
-		// The marker is matched at its first occurrence. r.URL.Path is decoded,
-		// so an onestop_id sent as f-%2Fonestop_id%2Fevil arrives with a second
-		// literal /onestop_id/ in it; matching the last one would anchor the
-		// mount inside caller-controlled input.
+		// Decoded paths can carry a second literal marker, so matching the last
+		// one would anchor the mount inside caller-controlled input.
 		{"marker recurring in a path parameter", "https://transit.land/api/v2", "/rest/onestop_id/f-/onestop_id/evil", "/onestop_id/", "https://transit.land/api/v2/rest"},
-		// A relative result must never read as protocol-relative — a Location
-		// header built from it would redirect off-site. Backslashes count: the
-		// WHATWG URL parser treats \ as / for special schemes, so browsers
-		// resolve /\evil.com exactly like //evil.com.
+		// A relative result reading as protocol-relative would redirect off-site.
+		// Backslashes count: browsers resolve /\evil.com like //evil.com.
 		{"protocol-relative mount refused", "", "//evil.com/openapi.json", "/openapi.json", ""},
 		{"protocol-relative mount refused, deep", "", "//evil.com/a/openapi.json", "/openapi.json", ""},
 		{"backslash mount refused", "", `/\evil.com/openapi.json`, "/openapi.json", ""},
@@ -92,10 +87,8 @@ func openAPIServers(t testing.TB, body []byte) []map[string]any {
 }
 
 func TestOpenAPIHandlerServers(t *testing.T) {
-	// The bug this guards: passing RestPrefix straight through drops the mount
-	// segment, so a generated client resolves /stops to
-	// https://transit.land/api/v2/stops (404) instead of
-	// https://transit.land/api/v2/rest/stops.
+	// Guards the bug where RestPrefix passed straight through drops the mount, so
+	// a client resolves /stops to /api/v2/stops (404) not /api/v2/rest/stops.
 	t.Run("mounted with absolute prefix includes mount segment", func(t *testing.T) {
 		cfg := model.Config{RestPrefix: "https://example.test/api/v2"}
 		rr := serveRest(t, NewOpenAPIHandler(), "/rest", cfg, "/rest/openapi.json", nil)
@@ -113,8 +106,7 @@ func TestOpenAPIHandlerServers(t *testing.T) {
 }
 
 // If-None-Match uses weak comparison and may be "*" or a list, so an exact
-// string compare against our tag re-sends the whole document whenever an
-// intermediary weakens the validator.
+// compare re-sends the document whenever an intermediary weakens the validator.
 func TestETagMatch(t *testing.T) {
 	const etag = `"abc123"`
 	tcs := []struct {
@@ -228,11 +220,9 @@ func TestOnestopIdRedirectIncludesMountSegment(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, rr.Code)
 	})
 
-	// chi.URLParam returns the raw percent-encoded value while r.URL.Path is
-	// decoded. Deriving the mount from the parameter rather than the route's
-	// literal segment produced a redirect containing the whole request path,
-	// e.g. .../rest/onestop_id/r-9q9-antioch~sfia/routes/r-9q9-antioch%7Esfia.
-	// Route Onestop IDs routinely contain ~, and clients do encode it.
+	// chi.URLParam stays encoded while r.URL.Path is decoded, so deriving the
+	// mount from the parameter broke for any id containing ~ — which route
+	// Onestop IDs routinely do.
 	t.Run("percent-encoded onestop_id still resolves the mount", func(t *testing.T) {
 		encoded := []struct {
 			path   string

--- a/server/rest/rest.go
+++ b/server/rest/rest.go
@@ -34,17 +34,34 @@ const MAXRADIUS = 100 * 1000.0
 // https://transit.land/api/v2) plus the segment the server is mounted under.
 //
 // chi does not strip r.URL.Path — it holds the full public path, e.g.
-// /rest/openapi.json — so trimming off the part of the path the route itself
-// owns recovers the mount segment. Callers pass that part as routeSuffix; a
-// route mounted at "/" owns nothing and passes "".
+// /rest/openapi.json — so removing the part of the path the route itself owns
+// recovers the mount segment. routeMarker is the literal head of the matched
+// route ("/openapi.json", "/onestop_id/"); everything from its last occurrence
+// onward is dropped. A route mounted at "/" owns nothing and passes "", which
+// keeps the whole path.
+//
+// routeMarker must be a literal taken from the route pattern, never a value
+// interpolated from a path parameter: chi.URLParam returns the raw
+// percent-encoded value while r.URL.Path is decoded, so the two disagree for
+// any parameter containing an encoded character, and the marker would not be
+// found.
 //
 // This is the one construction pagination links, the root redirect, the
 // onestop_id redirects, and the OpenAPI servers block all need. restPrefix
 // alone is not enough: it does not include the mount segment, so using it
 // directly yields https://transit.land/api/v2/stops, which 404s, rather than
 // https://transit.land/api/v2/rest/stops.
-func mountPrefix(restPrefix string, urlPath string, routeSuffix string) string {
-	return restPrefix + strings.TrimSuffix(strings.TrimRight(urlPath, "/"), routeSuffix)
+func mountPrefix(restPrefix string, urlPath string, routeMarker string) string {
+	p := strings.TrimRight(urlPath, "/")
+	i := strings.LastIndex(p, routeMarker)
+	if i < 0 {
+		// The marker is always present for a request the route actually matched.
+		// If something upstream rewrote the path so it is not, fall back to the
+		// bare prefix: merely missing the mount segment, rather than splicing the
+		// whole request path into a redirect or a servers URL.
+		return restPrefix
+	}
+	return restPrefix + p[:i]
 }
 
 // NewServer .

--- a/server/rest/rest.go
+++ b/server/rest/rest.go
@@ -61,7 +61,18 @@ func mountPrefix(restPrefix string, urlPath string, routeMarker string) string {
 		// whole request path into a redirect or a servers URL.
 		return restPrefix
 	}
-	return restPrefix + p[:i]
+	mount := p[:i]
+	// With an empty restPrefix the result is a relative URL, and a mount segment
+	// beginning with "//" would read as protocol-relative — //evil.com/... — in a
+	// Location header. chi does not route such a path to these handlers today,
+	// but this value reaches Location headers and the servers block, the handler
+	// is exported for callers whose routing this package does not control, and
+	// the schema endpoint is served without authentication. Refuse it outright
+	// rather than depending on the router to keep it unreachable.
+	if restPrefix == "" && strings.HasPrefix(mount, "//") {
+		return ""
+	}
+	return restPrefix + mount
 }
 
 // NewServer .

--- a/server/rest/rest.go
+++ b/server/rest/rest.go
@@ -29,74 +29,35 @@ var MAXLIMIT = 1_000
 // MAXRADIUS is the maximum point search radius
 const MAXRADIUS = 100 * 1000.0
 
-// mountPrefix returns the absolute public base URL of the REST mount for this
-// request: restPrefix (the public prefix of the mount's parent, e.g.
-// https://transit.land/api/v2) plus the segment the server is mounted under.
-//
-// chi does not strip r.URL.Path — it holds the full public path, e.g.
-// /rest/openapi.json — so removing the part of the path the route itself owns
-// recovers the mount segment. routeMarker is the literal head of the matched
-// route ("/openapi.json", "/onestop_id/"); everything from its first occurrence
-// onward is dropped. A route mounted at "/" owns nothing and passes "", which
-// keeps the whole path.
-//
-// First occurrence, not last: everything after the marker is route-owned, and
-// for a route ending in a parameter that means caller-controlled. r.URL.Path is
-// decoded, so an id sent as f-%2Fonestop_id%2Fevil arrives here as a second
-// literal /onestop_id/ and would re-anchor the mount at /rest/onestop_id/f-.
-// The mount comes from deployment config and the parameter does not, so
-// matching the earliest marker keeps the untrusted half out of the result.
-//
-// routeMarker must be a literal taken from the route pattern, never a value
-// interpolated from a path parameter: chi.URLParam returns the raw
-// percent-encoded value while r.URL.Path is decoded, so the two disagree for
-// any parameter containing an encoded character, and the marker would not be
-// found.
-//
-// The root redirect, the onestop_id redirects, and the OpenAPI servers block
-// all share this construction. restPrefix alone is not enough: it does not
-// include the mount segment, so using it directly yields
-// https://transit.land/api/v2/stops, which 404s, rather than
-// https://transit.land/api/v2/rest/stops. Pagination links reach the same
-// result without this helper, by appending restPrefix to the whole request URL,
-// which already carries the mount segment.
+// mountPrefix returns the mount's absolute public base URL: restPrefix (the
+// mount's parent) plus the mount segment, recovered by cutting the route-owned
+// tail off urlPath. routeMarker is the matched route's literal head ("" for a
+// route at "/"), and must come from the route pattern — chi.URLParam values
+// stay percent-encoded while urlPath is decoded.
 func mountPrefix(restPrefix string, urlPath string, routeMarker string) string {
 	p := strings.TrimRight(urlPath, "/")
 	mount := p
 	if routeMarker != "" {
+		// First occurrence, not last: urlPath is decoded, so a path parameter can
+		// carry a second literal marker and re-anchor the mount inside it.
 		i := strings.Index(p, routeMarker)
 		if i < 0 {
-			// The marker is always present for a request the route actually
-			// matched. If something upstream rewrote the path so it is not, fall
-			// back to the bare prefix: merely missing the mount segment, rather
-			// than splicing the whole request path into a redirect or a servers
-			// URL.
+			// Only reachable if something upstream rewrote the path. Fall back to
+			// the bare prefix rather than splice the request path into a URL.
 			return restPrefix
 		}
 		mount = p[:i]
 	}
-	// With an empty restPrefix the result is a relative URL, and a mount segment
-	// that reads as protocol-relative — //evil.com/... — would redirect off-site
-	// from a Location header. chi does not route such a path to these handlers
-	// today, but this value reaches Location headers and the servers block, the
-	// handler is exported for callers whose routing this package does not
-	// control, and the schema endpoint is served without authentication. Refuse
-	// it outright rather than depending on the router to keep it unreachable.
-	// A non-empty restPrefix already fixes the authority, so the same mount is
-	// only path noise there and is kept.
+	// A protocol-relative mount would redirect off-site from a relative Location.
+	// A non-empty restPrefix already fixes the authority, so only guard here.
 	if restPrefix == "" && isProtocolRelative(mount) {
 		return ""
 	}
 	return restPrefix + mount
 }
 
-// isProtocolRelative reports whether s would be read as a protocol-relative
-// reference — //host/... — rather than as a path.
-//
-// Backslashes count. The WHATWG URL parser treats \ as equivalent to / while
-// parsing a special scheme, so browsers resolve /\evil.com and /\/evil.com the
-// same way they resolve //evil.com. Checking only for "//" would leave the
-// cheapest bypass of that check open.
+// isProtocolRelative reports whether s reads as //host/... rather than a path.
+// Backslashes count: browsers treat \ as / when parsing a special scheme.
 func isProtocolRelative(s string) bool {
 	isSlash := func(c byte) bool { return c == '/' || c == '\\' }
 	return len(s) > 1 && isSlash(s[0]) && isSlash(s[1])

--- a/server/rest/rest.go
+++ b/server/rest/rest.go
@@ -76,16 +76,30 @@ func mountPrefix(restPrefix string, urlPath string, routeMarker string) string {
 		mount = p[:i]
 	}
 	// With an empty restPrefix the result is a relative URL, and a mount segment
-	// beginning with "//" would read as protocol-relative — //evil.com/... — in a
-	// Location header. chi does not route such a path to these handlers today,
-	// but this value reaches Location headers and the servers block, the handler
-	// is exported for callers whose routing this package does not control, and
-	// the schema endpoint is served without authentication. Refuse it outright
-	// rather than depending on the router to keep it unreachable.
-	if restPrefix == "" && strings.HasPrefix(mount, "//") {
+	// that reads as protocol-relative — //evil.com/... — would redirect off-site
+	// from a Location header. chi does not route such a path to these handlers
+	// today, but this value reaches Location headers and the servers block, the
+	// handler is exported for callers whose routing this package does not
+	// control, and the schema endpoint is served without authentication. Refuse
+	// it outright rather than depending on the router to keep it unreachable.
+	// A non-empty restPrefix already fixes the authority, so the same mount is
+	// only path noise there and is kept.
+	if restPrefix == "" && isProtocolRelative(mount) {
 		return ""
 	}
 	return restPrefix + mount
+}
+
+// isProtocolRelative reports whether s would be read as a protocol-relative
+// reference — //host/... — rather than as a path.
+//
+// Backslashes count. The WHATWG URL parser treats \ as equivalent to / while
+// parsing a special scheme, so browsers resolve /\evil.com and /\/evil.com the
+// same way they resolve //evil.com. Checking only for "//" would leave the
+// cheapest bypass of that check open.
+func isProtocolRelative(s string) bool {
+	isSlash := func(c byte) bool { return c == '/' || c == '\\' }
+	return len(s) > 1 && isSlash(s[0]) && isSlash(s[1])
 }
 
 // NewServer .

--- a/server/rest/rest.go
+++ b/server/rest/rest.go
@@ -29,6 +29,24 @@ var MAXLIMIT = 1_000
 // MAXRADIUS is the maximum point search radius
 const MAXRADIUS = 100 * 1000.0
 
+// mountPrefix returns the absolute public base URL of the REST mount for this
+// request: restPrefix (the public prefix of the mount's parent, e.g.
+// https://transit.land/api/v2) plus the segment the server is mounted under.
+//
+// chi does not strip r.URL.Path — it holds the full public path, e.g.
+// /rest/openapi.json — so trimming off the part of the path the route itself
+// owns recovers the mount segment. Callers pass that part as routeSuffix; a
+// route mounted at "/" owns nothing and passes "".
+//
+// This is the one construction pagination links, the root redirect, the
+// onestop_id redirects, and the OpenAPI servers block all need. restPrefix
+// alone is not enough: it does not include the mount segment, so using it
+// directly yields https://transit.land/api/v2/stops, which 404s, rather than
+// https://transit.land/api/v2/rest/stops.
+func mountPrefix(restPrefix string, urlPath string, routeSuffix string) string {
+	return restPrefix + strings.TrimSuffix(strings.TrimRight(urlPath, "/"), routeSuffix)
+}
+
 // NewServer .
 func NewServer(graphqlHandler http.Handler) (http.Handler, error) {
 	r := chi.NewRouter()
@@ -52,26 +70,11 @@ func NewServer(graphqlHandler http.Handler) (http.Handler, error) {
 	// Redirect root to OpenAPI documentation
 	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		cfg := model.ForContext(r.Context())
-		// chi does not strip r.URL.Path; it contains the full path (e.g. /rest/)
-		// Use it to build the absolute redirect URL, consistent with how pagination links work
-		path := strings.TrimRight(r.URL.Path, "/")
-		http.Redirect(w, r, cfg.RestPrefix+path+"/openapi.json", http.StatusMovedPermanently)
+		http.Redirect(w, r, mountPrefix(cfg.RestPrefix, r.URL.Path, "")+"/openapi.json", http.StatusMovedPermanently)
 	})
 
 	// OpenAPI Schema endpoint
-	r.HandleFunc("/openapi.json", func(w http.ResponseWriter, r *http.Request) {
-		cfg := model.ForContext(r.Context())
-		schema, err := GenerateOpenAPI(cfg.RestPrefix)
-		if err != nil {
-			http.Error(w, "Failed to generate schema", http.StatusInternalServerError)
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(schema); err != nil {
-			http.Error(w, "Failed to encode schema", http.StatusInternalServerError)
-			return
-		}
-	})
+	r.Handle("/openapi.json", NewOpenAPIHandler())
 
 	r.HandleFunc("/feeds.{format}", feedIndexHandler)
 	r.HandleFunc("/feeds", feedIndexHandler)

--- a/server/rest/rest.go
+++ b/server/rest/rest.go
@@ -36,9 +36,16 @@ const MAXRADIUS = 100 * 1000.0
 // chi does not strip r.URL.Path — it holds the full public path, e.g.
 // /rest/openapi.json — so removing the part of the path the route itself owns
 // recovers the mount segment. routeMarker is the literal head of the matched
-// route ("/openapi.json", "/onestop_id/"); everything from its last occurrence
+// route ("/openapi.json", "/onestop_id/"); everything from its first occurrence
 // onward is dropped. A route mounted at "/" owns nothing and passes "", which
 // keeps the whole path.
+//
+// First occurrence, not last: everything after the marker is route-owned, and
+// for a route ending in a parameter that means caller-controlled. r.URL.Path is
+// decoded, so an id sent as f-%2Fonestop_id%2Fevil arrives here as a second
+// literal /onestop_id/ and would re-anchor the mount at /rest/onestop_id/f-.
+// The mount comes from deployment config and the parameter does not, so
+// matching the earliest marker keeps the untrusted half out of the result.
 //
 // routeMarker must be a literal taken from the route pattern, never a value
 // interpolated from a path parameter: chi.URLParam returns the raw
@@ -46,22 +53,28 @@ const MAXRADIUS = 100 * 1000.0
 // any parameter containing an encoded character, and the marker would not be
 // found.
 //
-// This is the one construction pagination links, the root redirect, the
-// onestop_id redirects, and the OpenAPI servers block all need. restPrefix
-// alone is not enough: it does not include the mount segment, so using it
-// directly yields https://transit.land/api/v2/stops, which 404s, rather than
-// https://transit.land/api/v2/rest/stops.
+// The root redirect, the onestop_id redirects, and the OpenAPI servers block
+// all share this construction. restPrefix alone is not enough: it does not
+// include the mount segment, so using it directly yields
+// https://transit.land/api/v2/stops, which 404s, rather than
+// https://transit.land/api/v2/rest/stops. Pagination links reach the same
+// result without this helper, by appending restPrefix to the whole request URL,
+// which already carries the mount segment.
 func mountPrefix(restPrefix string, urlPath string, routeMarker string) string {
 	p := strings.TrimRight(urlPath, "/")
-	i := strings.LastIndex(p, routeMarker)
-	if i < 0 {
-		// The marker is always present for a request the route actually matched.
-		// If something upstream rewrote the path so it is not, fall back to the
-		// bare prefix: merely missing the mount segment, rather than splicing the
-		// whole request path into a redirect or a servers URL.
-		return restPrefix
+	mount := p
+	if routeMarker != "" {
+		i := strings.Index(p, routeMarker)
+		if i < 0 {
+			// The marker is always present for a request the route actually
+			// matched. If something upstream rewrote the path so it is not, fall
+			// back to the bare prefix: merely missing the mount segment, rather
+			// than splicing the whole request path into a redirect or a servers
+			// URL.
+			return restPrefix
+		}
+		mount = p[:i]
 	}
-	mount := p[:i]
 	// With an empty restPrefix the result is a relative URL, and a mount segment
 	// beginning with "//" would read as protocol-relative — //evil.com/... — in a
 	// Location header. chi does not route such a path to these handlers today,

--- a/server/rest/schema.go
+++ b/server/rest/schema.go
@@ -1,7 +1,6 @@
 package rest
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -411,7 +410,6 @@ func queryRecurse(gs *ast.Schema, recurseValue any, parentSchema oa.Schemas, lev
 		return order
 	}
 
-	fmt.Printf("%s %s (%s : %s : order %d)\n", strings.Repeat(" ", level*4), schema.Title, namedType, gqlType, order)
 	order += 1
 	schema.Extensions["x-order"] = order
 


### PR DESCRIPTION
## Summary

The REST server builds three kinds of absolute URL — the root redirect, the `/onestop_id/{onestop_id}` redirects, and the OpenAPI `servers` block — and two of the three dropped the mount segment, because `Config.RestPrefix` is the public prefix of the mount's *parent* and was being used as though it were the mount's own URL. Production runs `--rest-prefix=https://transit.land/api/v2` against a server mounted at `/rest`, so the published schema advertised `https://transit.land/api/v2`, and a generated client resolving `GET /stops` reached `https://transit.land/api/v2/stops` — a 404, where `.../api/v2/rest/stops` is correct. The onestop redirects were wrong the same way. This routes all three through one helper that recovers the mount segment from the request path.

### Mount-aware URLs

`mountPrefix` returns `RestPrefix` plus the segment the server is mounted under, recovered by cutting the route-owned tail off `r.URL.Path` — chi does not strip it, so the full public path is available. The root redirect already did this inline and was correct; it now shares the helper with the two sites that did not. Pagination links reach the same result without the helper, by appending `RestPrefix` to the whole request URL, and are unchanged.

Two hardening rounds came out of review. The marker is matched at its first occurrence rather than its last, because `r.URL.Path` is decoded and an id sent as `f-%2Fonestop_id%2Fevil` arrives carrying a second literal `/onestop_id/`, which would anchor the mount inside caller-controlled input. And a mount that reads as protocol-relative is refused when `RestPrefix` is empty, since a relative `Location` built from `//evil.com/...` redirects off-site; the check counts backslashes, because the WHATWG URL parser treats `\` as `/` for special schemes and browsers resolve `/\evil.com` the same way. Neither shape is reachable through chi's router today, but `NewOpenAPIHandler` is exported for callers whose routing this package does not control.

Callers must pass a literal from the route pattern as the marker, never a value interpolated from a path parameter: `chi.URLParam` returns the raw percent-encoded value while `r.URL.Path` is decoded, so the two disagree for any id containing an encoded character. Route Onestop IDs routinely contain `~`.

### Schema serving

`NewOpenAPIHandler` replaces the inline `/openapi.json` closure so the `servers` URL is built with `mountPrefix` like the other two sites. It is exported because mounting the whole REST server elsewhere just to reach its schema would hand chi a path it does not own.

The document is still generated per request. That is deliberate: the server this package wires up is the unauthenticated example server described in the README, generation costs around 30 ms, and adding a cache to it buys nothing worth the surface. Callers serving the schema under real load should generate once at startup with `GenerateOpenAPI` and serve the bytes themselves, which the constructor's doc comment now says.

Also drops the unconditional `fmt.Printf` schema-tree dump from `queryRecurse`. With per-request generation that wrote the full tree to stdout on every fetch of the document.

### Dependency and docs

Removes the `replace github.com/getkin/kin-openapi => github.com/irees/kin-openapi` directive and moves to upstream `v0.139.0`. The fork existed to export `x-` extensions, which is upstream now, and `replace` directives are ignored in dependent modules anyway, so downstream builds were already using upstream code — the fork only skewed what this repo compiled against. The regenerated `doc/openapi/rest.json` is byte-identical, which is the check that the swap preserved extension export; `check-go-generate` enforces it.

`Config.RestPrefix` now documents that it is the mount's parent and that the mount segment is recovered per request. `gen.go` validates with `EnableMultiError` so a regeneration that breaks several paths reports all of them in one run. README fixes two stale paths (`docs/openapi/` and `cmd/tlserver`).

### CodeQL

Two open-redirect alerts on this flow are dismissed as false positives, with the reasoning in the review thread. The taint is real — `r.URL.Path` does reach a `Location` header — but no reachable input yields an attacker-controlled destination: a non-empty `RestPrefix` fixes the authority, and the empty-prefix case is refused outright by the protocol-relative guard rather than depending on the router. The alerts persist after the fix because a `strings.HasPrefix` guard is not a sanitizer CodeQL models.

## Test plan

Behavior worth checking by hand; `go test` and `check-go-generate` are covered by CI.

Run the example server mounted behind a prefix and confirm the three URL sites agree:

```
transitland server --rest-prefix=http://localhost:8080

curl -s localhost:8080/rest/openapi.json | jq -r '.servers[0].url'
# expect http://localhost:8080/rest

curl -sI localhost:8080/rest/ | grep -i location
# expect http://localhost:8080/rest/openapi.json

curl -sI 'localhost:8080/rest/onestop_id/f-9q9-bart' | grep -i location
# expect http://localhost:8080/rest/feeds/f-9q9-bart, not .../feeds/...
```

Confirm a path from the document resolves against the document's own base:

```
BASE=$(curl -s localhost:8080/rest/openapi.json | jq -r '.servers[0].url')
curl -s -o /dev/null -w '%{http_code}\n' "$BASE/stops?limit=1"   # 200, not 404
```

Confirm an encoded Onestop ID still resolves the mount rather than splicing the request path into the target:

```
curl -sI 'localhost:8080/rest/onestop_id/r-9q9-antioch%7Esfia' | grep -i location
# expect .../rest/routes/r-9q9-antioch%7Esfia
```

And that fetching the document no longer prints the schema tree to the server's stdout.
