### PR TITLE
Census bbox & stopBuffer

### DIFF
--- a/internal/generated/gqlout/generated.go
+++ b/internal/generated/gqlout/generated.go
@@ -10805,7 +10805,7 @@ type CensusLayer {
 """
 A single spatial unit within a layer — for example, a specific Census Tract, a US State, or an NTD agency record.
 
-Geographies are the primary unit of analysis: they carry geometry, administrative context, and can be linked to statistical data via ` + "`" + `values` + "`" + `. When queried with a spatial filter (e.g. ` + "`" + `stop_buffer` + "`" + ` or ` + "`" + `bbox` + "`" + `), the ` + "`" + `intersection_area` + "`" + ` and ` + "`" + `intersection_geometry` + "`" + ` fields are populated to describe the overlap between the geography and the search area — useful for calculating what fraction of a geography (and its population) is covered by a transit service area.
+Geographies are the primary unit of analysis: they carry geometry, administrative context, and can be linked to statistical data via ` + "`" + `values` + "`" + `. When queried with a spatial filter, the ` + "`" + `intersection_area` + "`" + ` and ` + "`" + `intersection_geometry` + "`" + ` fields are populated to describe the overlap between the geography and the search area — useful for calculating what fraction of a geography (and its population) is covered by a transit service area.
 
 Note: spatial queries may return the same geography multiple times when it intersects a search area in multiple places (e.g. two separate stop buffers within the same tract). Use ` + "`" + `geoid` + "`" + ` to deduplicate if needed.
 """
@@ -10858,7 +10858,7 @@ type CensusGeography {
   geometry: MultiPolygon
 
   """
-  When this geography was returned by a spatial query (e.g. ` + "`" + `stop_buffer` + "`" + ` or ` + "`" + `bbox` + "`" + `), the area of overlap between this geography and the search area, in square meters.
+  When this geography was returned by a spatial query, the area of overlap between this geography and the search area, in square meters.
   Divide by ` + "`" + `geometry_area` + "`" + ` to get the fraction of the geography covered by the search area, then apply that fraction to a population value to estimate population served.
   """
   intersection_area: Float
@@ -11766,6 +11766,8 @@ input CensusSourceGeographyFilter {
 
 
 """Search options for census geographies
+
+A query area (` + "`" + `bbox` + "`" + `, or ` + "`" + `within` + "`" + ` when no bbox is given) composes with ` + "`" + `stop_buffer` + "`" + `: the search area is their intersection, so ` + "`" + `intersection_area` + "`" + ` reports the overlap inside both. A geography inside the query area but outside every stop buffer is not returned. ` + "`" + `near` + "`" + ` does not compose and takes effect only when no other filter applies.
 
 Note: when using spatial searches (radius, stop_buffer, etc.), individual census geographies may appear multiple times in the result set, each representing a different intersection with the search area. For example:
 - Two stops with small radius buffers in the same census tract will return that tract twice, once for each buffer intersection

--- a/schema/graphql/schema.graphqls
+++ b/schema/graphql/schema.graphqls
@@ -1949,7 +1949,7 @@ type CensusLayer {
 """
 A single spatial unit within a layer — for example, a specific Census Tract, a US State, or an NTD agency record.
 
-Geographies are the primary unit of analysis: they carry geometry, administrative context, and can be linked to statistical data via `values`. When queried with a spatial filter (e.g. `stop_buffer` or `bbox`), the `intersection_area` and `intersection_geometry` fields are populated to describe the overlap between the geography and the search area — useful for calculating what fraction of a geography (and its population) is covered by a transit service area.
+Geographies are the primary unit of analysis: they carry geometry, administrative context, and can be linked to statistical data via `values`. When queried with a spatial filter, the `intersection_area` and `intersection_geometry` fields are populated to describe the overlap between the geography and the search area — useful for calculating what fraction of a geography (and its population) is covered by a transit service area.
 
 Note: spatial queries may return the same geography multiple times when it intersects a search area in multiple places (e.g. two separate stop buffers within the same tract). Use `geoid` to deduplicate if needed.
 """
@@ -2002,7 +2002,7 @@ type CensusGeography {
   geometry: MultiPolygon
 
   """
-  When this geography was returned by a spatial query (e.g. `stop_buffer` or `bbox`), the area of overlap between this geography and the search area, in square meters.
+  When this geography was returned by a spatial query, the area of overlap between this geography and the search area, in square meters.
   Divide by `geometry_area` to get the fraction of the geography covered by the search area, then apply that fraction to a population value to estimate population served.
   """
   intersection_area: Float
@@ -2910,6 +2910,8 @@ input CensusSourceGeographyFilter {
 
 
 """Search options for census geographies
+
+A query area (`bbox`, or `within` when no bbox is given) composes with `stop_buffer`: the search area is their intersection, so `intersection_area` reports the overlap inside both. A geography inside the query area but outside every stop buffer is not returned. `near` does not compose and takes effect only when no other filter applies.
 
 Note: when using spatial searches (radius, stop_buffer, etc.), individual census geographies may appear multiple times in the result set, each representing a different intersection with the search area. For example:
 - Two stops with small radius buffers in the same census tract will return that tract twice, once for each buffer intersection

--- a/server/finders/dbfinder/census.go
+++ b/server/finders/dbfinder/census.go
@@ -462,8 +462,12 @@ func censusDatasetGeographySelect(limit *int, where *model.CensusDatasetGeograph
 		}
 
 		// Single-row clip-geometry builders (column `buffer`), shared between the
-		// standalone branches and the combined within+stop_buffer case so the
-		// geometry SQL lives in one place.
+		// standalone branches and the combined query-area + stop_buffer case so
+		// the geometry SQL lives in one place.
+		bboxClipSelect := func() sq.SelectBuilder {
+			return sq.StatementBuilder.Select().
+				Column("ST_MakeEnvelope(?,?,?,?,4326) as buffer", loc.Bbox.MinLon, loc.Bbox.MinLat, loc.Bbox.MaxLon, loc.Bbox.MaxLat)
+		}
 		withinClipSelect := func() sq.SelectBuilder {
 			jj, _ := geojson.Marshal(loc.Within.Val)
 			return sq.StatementBuilder.Select().Column("ST_GeomFromGeoJSON(?) as buffer", string(jj))
@@ -475,33 +479,38 @@ func censusDatasetGeographySelect(limit *int, where *model.CensusDatasetGeograph
 				Where(In("gtfs_stops.id", loc.StopBuffer.StopIds))
 		}
 
-		// Filter precedence: bbox wins outright; otherwise `within` and
-		// `stop_buffer` compose (clip intersection for a positive radius,
-		// polygon-restricted point matching for radius 0); otherwise the
-		// first filter present in this chain applies and the rest are
-		// ignored. Composition applies to the top-level query path only:
-		// in per-stop attribution mode (the internal by-entity loaders) a
-		// positive-radius stop_buffer takes precedence and `within` is
-		// not applied.
-		if loc.Bbox == nil && withinClip && stopBufferClip && stopBufferRadius > 0 && !fields.perStopAttribution {
-			// Clip to the intersection of the query-area polygon (`within`) and
-			// the stop-buffer union: census apportioned to where the polygon and
-			// the transit coverage overlap, not either alone. Compose the two
-			// single-row clip CTEs the standalone branches use. Without this case
-			// the chain below would honor only `within` and ignore the buffer.
+		// The query area, however it was expressed. `bbox` keeps precedence over
+		// `within` when both are set.
+		areaClipSelect := withinClipSelect
+		if loc.Bbox != nil {
+			areaClipSelect = bboxClipSelect
+		}
+		areaClip := loc.Bbox != nil || withinClip
+
+		// Filter precedence: the query area (`bbox`, or `within` when no bbox is
+		// given) composes with `stop_buffer` — clip intersection for a positive
+		// radius, area-restricted point matching for radius 0. Otherwise the
+		// first filter present in this chain applies and the rest are ignored.
+		// Composition applies to the top-level query path only: in per-stop
+		// attribution mode (the internal by-entity loaders) a positive-radius
+		// stop_buffer takes precedence and the query area is not applied.
+		if areaClip && stopBufferClip && stopBufferRadius > 0 && !fields.perStopAttribution {
+			// Clip to the intersection of the query area and the stop-buffer
+			// union: census apportioned to where the two overlap, not either
+			// alone. Compose the same single-row clip CTEs the standalone
+			// branches use. Without this case the chain below would honor only
+			// the query area and ignore the buffer.
 			qBufferUse = true
-			q = q.WithCTE(sq.CTE{Alias: "clip_within", Materialized: true, Expression: withinClipSelect()})
+			q = q.WithCTE(sq.CTE{Alias: "clip_area", Materialized: true, Expression: areaClipSelect()})
 			q = q.WithCTE(sq.CTE{Alias: "clip_stops", Materialized: true, Expression: stopUnionClipSelect()})
 			qBuffer = sq.StatementBuilder.Select().
-				Column("ST_Intersection(clip_within.buffer, clip_stops.buffer) as buffer").
+				Column("ST_Intersection(clip_area.buffer, clip_stops.buffer) as buffer").
 				Column("0 as match_entity_id").
-				From("clip_within").
+				From("clip_area").
 				JoinClause("CROSS JOIN clip_stops")
-		} else if loc.Bbox != nil {
+		} else if loc.Bbox != nil && !stopBufferClip {
 			qBufferUse = true
-			qBuffer = sq.StatementBuilder.Select().
-				Column("ST_MakeEnvelope(?,?,?,?,4326) as buffer", loc.Bbox.MinLon, loc.Bbox.MinLat, loc.Bbox.MaxLon, loc.Bbox.MaxLat).
-				Column("0 as match_entity_id")
+			qBuffer = bboxClipSelect().Column("0 as match_entity_id")
 		} else if withinClip && !stopBufferClip {
 			qBufferUse = true
 			qBuffer = withinClipSelect().Column("0 as match_entity_id")
@@ -519,13 +528,13 @@ func censusDatasetGeographySelect(limit *int, where *model.CensusDatasetGeograph
 					Column("gtfs_stops.id as match_entity_id").
 					From("gtfs_stops").
 					Where(In("gtfs_stops.id", loc.StopBuffer.StopIds))
-				if withinClip {
-					// A combined `within` restricts point matching to stops
-					// inside the polygon rather than being silently ignored.
-					q = q.WithCTE(sq.CTE{Alias: "clip_within", Materialized: true, Expression: withinClipSelect()})
+				if areaClip {
+					// A combined query area restricts point matching to stops
+					// inside it rather than being silently ignored.
+					q = q.WithCTE(sq.CTE{Alias: "clip_area", Materialized: true, Expression: areaClipSelect()})
 					qPoints = qPoints.
-						JoinClause("CROSS JOIN clip_within").
-						Where(sq.Expr("ST_Intersects(clip_within.buffer, gtfs_stops.geometry)"))
+						JoinClause("CROSS JOIN clip_area").
+						Where(sq.Expr("ST_Intersects(clip_area.buffer, gtfs_stops.geometry)"))
 				}
 			} else if fields.perStopAttribution {
 				// One buffer per stop, attribution preserved as

--- a/server/finders/dbfinder/census.go
+++ b/server/finders/dbfinder/census.go
@@ -514,7 +514,10 @@ func censusDatasetGeographySelect(limit *int, where *model.CensusDatasetGeograph
 		} else if withinClip && !stopBufferClip {
 			qBufferUse = true
 			qBuffer = withinClipSelect().Column("0 as match_entity_id")
-		} else if loc.Near != nil {
+		} else if loc.Near != nil && !stopBufferClip {
+			// Guarded like the branches above so a stop_buffer isn't discarded
+			// here: without it a radius-0 buffer alongside `near` would skip
+			// the point-matching branch entirely.
 			radius := checkFloat(&loc.Near.Radius, 0, 1_000_000)
 			qBufferUse = true
 			qBuffer = sq.StatementBuilder.Select().

--- a/server/gql/census_resolver_test.go
+++ b/server/gql/census_resolver_test.go
@@ -455,6 +455,87 @@ func TestCensusResolver(t *testing.T) {
 			},
 		},
 		{
+			// A bbox containing the whole buffer reduces to the
+			// stop-buffer-only result, the same as the `within` case above.
+			// Before bbox composed, bbox won outright and the buffer was
+			// ignored — this would have returned every tract in the box.
+			name:  "combined bbox and stop buffer - tract",
+			query: `query($bbox:BoundingBox, $stop_ids:[Int!]) { census_datasets(where:{name:"tiger2024"}) {name geographies(where:{layer: "tract", location:{bbox:$bbox, stop_buffer:{stop_ids:$stop_ids, radius:100}}}) { name geoid geometry_area intersection_area }} }`,
+			vars: hw{
+				"stop_ids": []int{bartFtvlStopId},
+				"bbox":     hw{"min_lon": -123.0, "min_lat": 37.0, "max_lon": -122.0, "max_lat": 38.0},
+			},
+			f: func(t *testing.T, jj string) {
+				testIntersectionArea(
+					t,
+					gjson.Get(jj, "census_datasets.0.geographies").Array(),
+					1,
+					1918910.47033,
+					31235.844716912135,
+				)
+			},
+		},
+		{
+			// Same rectangle as the `within` partial-overlap case, expressed
+			// as a bbox: its eastern edge runs through the FTVL stop, so the
+			// clip is the west half of the buffer. ST_MakeEnvelope and the
+			// equivalent polygon must therefore produce the identical area —
+			// this pins bbox composition to the same semantics as `within`,
+			// and fails in both directions if either filter is dropped.
+			name:  "combined bbox and stop buffer partial overlap - tract",
+			query: `query($bbox:BoundingBox, $stop_ids:[Int!]) { census_datasets(where:{name:"tiger2024"}) {name geographies(where:{layer: "tract", location:{bbox:$bbox, stop_buffer:{stop_ids:$stop_ids, radius:100}}}) { name geoid geometry_area intersection_area }} }`,
+			vars: hw{
+				"stop_ids": []int{bartFtvlStopId},
+				"bbox":     hw{"min_lon": -122.5, "min_lat": 37.5, "max_lon": -122.224175, "max_lat": 38.0},
+			},
+			f: func(t *testing.T, jj string) {
+				testIntersectionArea(
+					t,
+					gjson.Get(jj, "census_datasets.0.geographies").Array(),
+					1,
+					1918910.47033,
+					15617.923982297536,
+				)
+			},
+		},
+		{
+			// Disjoint bbox and buffer: empty clip, no geographies, rather
+			// than falling back to either filter alone.
+			name:  "combined bbox and stop buffer disjoint - tract",
+			query: `query($bbox:BoundingBox, $stop_ids:[Int!]) { census_datasets(where:{name:"tiger2024"}) {name geographies(where:{layer: "tract", location:{bbox:$bbox, stop_buffer:{stop_ids:$stop_ids, radius:100}}}) { name geoid intersection_area }} }`,
+			vars: hw{
+				"stop_ids": []int{bartFtvlStopId},
+				"bbox":     hw{"min_lon": -121.6, "min_lat": 38.4, "max_lon": -121.4, "max_lat": 38.7},
+			},
+			f: func(t *testing.T, jj string) {
+				assert.Empty(t, gjson.Get(jj, "census_datasets.0.geographies").Array(), "disjoint clip must match no geographies")
+			},
+		},
+		{
+			// Radius 0 with a bbox is bbox-restricted point matching, matching
+			// the `within` behavior rather than dropping the stop filter.
+			name:  "combined bbox and stop buffer radius 0 - tract",
+			query: `query($bbox:BoundingBox, $stop_ids:[Int!]) { census_datasets(where:{name:"tiger2024"}) {name geographies(where:{layer: "tract", location:{bbox:$bbox, stop_buffer:{stop_ids:$stop_ids, radius:0}}}) { name geoid }} }`,
+			vars: hw{
+				"stop_ids": []int{bartFtvlStopId},
+				"bbox":     hw{"min_lon": -123.0, "min_lat": 37.0, "max_lon": -122.0, "max_lat": 38.0},
+			},
+			expect: `{"census_datasets":[{"name":"tiger2024","geographies":[{"geoid":"1400000US06001406100","name":"4061"}]}]}`,
+		},
+		{
+			// Radius 0 with the stop outside the bbox: filtered out, not
+			// silently matched.
+			name:  "combined bbox and stop buffer radius 0 outside bbox - tract",
+			query: `query($bbox:BoundingBox, $stop_ids:[Int!]) { census_datasets(where:{name:"tiger2024"}) {name geographies(where:{layer: "tract", location:{bbox:$bbox, stop_buffer:{stop_ids:$stop_ids, radius:0}}}) { name geoid }} }`,
+			vars: hw{
+				"stop_ids": []int{bartFtvlStopId},
+				"bbox":     hw{"min_lon": -121.6, "min_lat": 38.4, "max_lon": -121.4, "max_lat": 38.7},
+			},
+			f: func(t *testing.T, jj string) {
+				assert.Empty(t, gjson.Get(jj, "census_datasets.0.geographies").Array(), "stop outside the bbox must not match")
+			},
+		},
+		{
 			name:  "agency intersection areas - county",
 			query: `query { agencies(where:{agency_id:"BART"}) { agency_id census_geographies(where:{layer:"county", radius:1000.0}) { name geoid geometry_area intersection_geometry intersection_area } } }`,
 			vars:  vars,

--- a/server/gql/census_resolver_test.go
+++ b/server/gql/census_resolver_test.go
@@ -500,12 +500,14 @@ func TestCensusResolver(t *testing.T) {
 		},
 		{
 			// Disjoint bbox and buffer: empty clip, no geographies, rather
-			// than falling back to either filter alone.
+			// than falling back to either filter alone. The bbox is inside the
+			// fixture extent and covers 22 tracts, ~10km from the FTVL stop, so
+			// dropping the buffer would return those 22 rather than nothing.
 			name:  "combined bbox and stop buffer disjoint - tract",
 			query: `query($bbox:BoundingBox, $stop_ids:[Int!]) { census_datasets(where:{name:"tiger2024"}) {name geographies(where:{layer: "tract", location:{bbox:$bbox, stop_buffer:{stop_ids:$stop_ids, radius:100}}}) { name geoid intersection_area }} }`,
 			vars: hw{
 				"stop_ids": []int{bartFtvlStopId},
-				"bbox":     hw{"min_lon": -121.6, "min_lat": 38.4, "max_lon": -121.4, "max_lat": 38.7},
+				"bbox":     hw{"min_lon": -122.30, "min_lat": 37.86, "max_lon": -122.26, "max_lat": 37.88},
 			},
 			f: func(t *testing.T, jj string) {
 				assert.Empty(t, gjson.Get(jj, "census_datasets.0.geographies").Array(), "disjoint clip must match no geographies")
@@ -524,16 +526,43 @@ func TestCensusResolver(t *testing.T) {
 		},
 		{
 			// Radius 0 with the stop outside the bbox: filtered out, not
-			// silently matched.
+			// silently matched. Sole cover for the bbox arm of the
+			// area-restricted point match.
 			name:  "combined bbox and stop buffer radius 0 outside bbox - tract",
 			query: `query($bbox:BoundingBox, $stop_ids:[Int!]) { census_datasets(where:{name:"tiger2024"}) {name geographies(where:{layer: "tract", location:{bbox:$bbox, stop_buffer:{stop_ids:$stop_ids, radius:0}}}) { name geoid }} }`,
 			vars: hw{
 				"stop_ids": []int{bartFtvlStopId},
-				"bbox":     hw{"min_lon": -121.6, "min_lat": 38.4, "max_lon": -121.4, "max_lat": 38.7},
+				"bbox":     hw{"min_lon": -122.30, "min_lat": 37.86, "max_lon": -122.26, "max_lat": 37.88},
 			},
 			f: func(t *testing.T, jj string) {
 				assert.Empty(t, gjson.Get(jj, "census_datasets.0.geographies").Array(), "stop outside the bbox must not match")
 			},
+		},
+		{
+			// `near` yields to a stop_buffer rather than preempting it, so a
+			// radius-0 buffer still reaches the area-restricted point match.
+			// Without the guard on the `near` branch this returns the tracts
+			// around the `near` point and drops both other filters.
+			name:  "bbox and stop buffer radius 0 with near - tract",
+			query: `query($bbox:BoundingBox, $near:PointRadius, $stop_ids:[Int!]) { census_datasets(where:{name:"tiger2024"}) {name geographies(where:{layer: "tract", location:{bbox:$bbox, near:$near, stop_buffer:{stop_ids:$stop_ids, radius:0}}}) { name geoid }} }`,
+			vars: hw{
+				"stop_ids": []int{bartFtvlStopId},
+				"bbox":     hw{"min_lon": -123.0, "min_lat": 37.0, "max_lon": -122.0, "max_lat": 38.0},
+				"near":     hw{"lon": -122.270, "lat": 37.805, "radius": 1000.0},
+			},
+			expect: `{"census_datasets":[{"name":"tiger2024","geographies":[{"geoid":"1400000US06001406100","name":"4061"}]}]}`,
+		},
+		{
+			// `near` alongside a positive-radius stop_buffer: the buffer wins.
+			// The FTVL 100m buffer touches one tract; the `near` circle covers
+			// many, so this discriminates which filter took effect.
+			name:  "stop buffer with near - tract",
+			query: `query($near:PointRadius, $stop_ids:[Int!]) { census_datasets(where:{name:"tiger2024"}) {name geographies(where:{layer: "tract", location:{near:$near, stop_buffer:{stop_ids:$stop_ids, radius:100}}}) { name geoid }} }`,
+			vars: hw{
+				"stop_ids": []int{bartFtvlStopId},
+				"near":     hw{"lon": -122.270, "lat": 37.805, "radius": 1000.0},
+			},
+			expect: `{"census_datasets":[{"name":"tiger2024","geographies":[{"geoid":"1400000US06001406100","name":"4061"}]}]}`,
 		},
 		{
 			name:  "agency intersection areas - county",

--- a/server/model/models_gen.go
+++ b/server/model/models_gen.go
@@ -194,6 +194,8 @@ type CensusDatasetGeographyFilter struct {
 
 // Search options for census geographies
 //
+// A query area (`bbox`, or `within` when no bbox is given) composes with `stop_buffer`: the search area is their intersection, so `intersection_area` reports the overlap inside both. A geography inside the query area but outside every stop buffer is not returned. `near` does not compose and takes effect only when no other filter applies.
+//
 // Note: when using spatial searches (radius, stop_buffer, etc.), individual census geographies may appear multiple times in the result set, each representing a different intersection with the search area. For example:
 // - Two stops with small radius buffers in the same census tract will return that tract twice, once for each buffer intersection
 // - A complex polygon search that touches multiple disconnected areas of the same geography will return separate entries for each intersection
@@ -239,7 +241,7 @@ type CensusField struct {
 
 // A single spatial unit within a layer — for example, a specific Census Tract, a US State, or an NTD agency record.
 //
-// Geographies are the primary unit of analysis: they carry geometry, administrative context, and can be linked to statistical data via `values`. When queried with a spatial filter (e.g. `stop_buffer` or `bbox`), the `intersection_area` and `intersection_geometry` fields are populated to describe the overlap between the geography and the search area — useful for calculating what fraction of a geography (and its population) is covered by a transit service area.
+// Geographies are the primary unit of analysis: they carry geometry, administrative context, and can be linked to statistical data via `values`. When queried with a spatial filter, the `intersection_area` and `intersection_geometry` fields are populated to describe the overlap between the geography and the search area — useful for calculating what fraction of a geography (and its population) is covered by a transit service area.
 //
 // Note: spatial queries may return the same geography multiple times when it intersects a search area in multiple places (e.g. two separate stop buffers within the same tract). Use `geoid` to deduplicate if needed.
 type CensusGeography struct {
@@ -274,7 +276,7 @@ type CensusGeography struct {
 	Adm0Iso *string `json:"adm0_iso,omitempty"`
 	// Boundary geometry for this geography as a MultiPolygon
 	Geometry *tt.MultiPolygon `json:"geometry,omitempty"`
-	// When this geography was returned by a spatial query (e.g. `stop_buffer` or `bbox`), the area of overlap between this geography and the search area, in square meters.
+	// When this geography was returned by a spatial query, the area of overlap between this geography and the search area, in square meters.
 	// Divide by `geometry_area` to get the fraction of the geography covered by the search area, then apply that fraction to a population value to estimate population served.
 	IntersectionArea *float64 `json:"intersection_area,omitempty"`
 	// When this geography was returned by a spatial query, the geometry of the intersection between this geography and the search area.


### PR DESCRIPTION
## Summary

The `census_datasets.geographies` location filter resolves `bbox`, `within`, `near`, and `stop_buffer` through a first-match-wins chain. #681 made `within` and `stop_buffer` compose into `ST_Intersection(clip_within, clip_stops)`, but gated that on `loc.Bbox == nil`, so a `bbox` still won outright and silently dropped the stop buffer. That left the composition unreachable for the client's default query mode, which is a drawn bbox rather than an administrative boundary — see interline-io/calact-network-analysis-tool#422, where the census intersection column reports query-area overlap while ignoring the stop buffers.

This change generalizes #681 from "the `within` polygon" to "the query area, however it was expressed", so `bbox` composes with `stop_buffer` exactly as `within` already does. It also closes two ordering holes in the same chain that let a supplied filter be discarded without any signal.

## Behavior changes

All of these are widening: filters that were being ignored now apply. Callers who supplied a single filter, or the `within` + `stop_buffer` pair #681 addressed, see no change.

- `bbox` + `stop_buffer` (positive radius) now clips to the intersection of the two. Previously the bbox won and the buffer was dropped, so `intersection_area` described the bbox overlap alone.
- `bbox` + `stop_buffer` at radius 0 now performs bbox-restricted point matching, matching the `within` behavior. Previously the bbox won and the stop filter was dropped.
- `near` + `stop_buffer` now applies the stop buffer. Previously `near` preceded the stop-buffer branch and won, discarding the buffer.
- `near` alongside a query area and a radius-0 `stop_buffer` no longer discards both. This combination previously collapsed to `near` alone.

`bbox` retains precedence over `within` when both are supplied, and `near` still does not compose — it applies only when no other filter does, which is now true as documented rather than only against `bbox` and `within`.

Per-stop attribution is unaffected: the by-entity loaders synthesize a filter carrying only `StopBuffer`, and the composed branch remains gated on `!perStopAttribution`.

## Implementation

- Adds `bboxClipSelect()` alongside the `withinClipSelect()` and `stopUnionClipSelect()` builders introduced by #681, so all three clip geometries are constructed in one place.
- Introduces `areaClipSelect` / `areaClip`, resolving to whichever query area was supplied. The composed branch's guard drops `loc.Bbox == nil` in favour of `areaClip`, and the CTE alias becomes `clip_area`. The `ST_Intersection`, the cross join, and everything downstream of the clip are unchanged.
- Generalizes the radius-0 point-matching restriction from `within` to any query area.
- Adds `&& !stopBufferClip` to the `bbox` and `near` branches, mirroring the guard `within` already carried. Without it on `bbox` the radius-0 composition is unreachable; without it on `near` a supplied `stop_buffer` is discarded, and `near` could preempt an otherwise-composable pair.
- Removes the two "(e.g. `stop_buffer` or `bbox`)" examples from the `CensusGeography` and `intersection_area` descriptions, and documents the actual composition rules on `CensusDatasetGeographyLocationFilter`, which previously said nothing about precedence. Generated output regenerated with `go generate ./...`.

## Testing

Seven new resolver cases, all of which fail against an unmodified `census.go`:

- `combined bbox and stop buffer - tract`: a bbox containing the whole buffer reduces to the stop-buffer-only result (one tract, ~31235 m²). Under the old chain this returned all 310 tracts in the box.
- `combined bbox and stop buffer partial overlap - tract`: the same rectangle as the existing `within` partial-overlap case, expressed as a bbox. `ST_MakeEnvelope` and the equivalent polygon must produce the identical 15617.92 m², which is what pins bbox composition to the same semantics rather than merely a plausible number. Discriminates in both directions: ignoring the bbox gives the full 31235.84, ignoring the buffer gives every tract in the box.
- `combined bbox and stop buffer disjoint - tract`: empty clip returns no geographies rather than erroring or falling back.
- `combined bbox and stop buffer radius 0 - tract` and `radius 0 outside bbox - tract`: point matching honours the bbox. The latter is the only cover for the bbox arm of that restriction.
- `bbox and stop buffer radius 0 with near - tract` and `stop buffer with near - tract`: pin that `near` yields to a stop buffer instead of preempting it.

The disjoint cases use a bbox inside the fixture extent covering 22 tracts, roughly 10km from the stop, so dropping either filter produces rows rather than a coincidentally empty result.

## Test plan

- `go test ./server/gql/ ./server/finders/dbfinder/` against the test database. The pre-existing `TestCensusResolver` spatial cases pass unchanged, confirming the `areaClipSelect` refactor is behavior-preserving for `bbox`-only, `within`-only, `near`-only, and stop-buffer-only queries.
- Reverting `census.go` to main while keeping the tests fails all seven new cases; reverting only the `near` guard fails the two `near` cases; reverting only the radius-0 area restriction fails `radius 0 outside bbox`.

## Future work

The chain now encodes composition in its branch ordering, and each new combination has needed its own guard. Replacing it with a clip-slice model — intersect every area clip present, and treat radius-0 point matching and per-stop attribution as matchers restricted by that area rather than as members of it — would remove precedence as a concept and make `bbox` + `within` and a composable `near` fall out for free. Tracked separately, since each of those is a further widening change that wants its own decision.
