### PR TITLE
Scheduled departures service dates

### DIFF
--- a/internal/generated/gqlout/generated.go
+++ b/internal/generated/gqlout/generated.go
@@ -1180,7 +1180,6 @@ type ComplexityRoot struct {
 		PickupType               func(childComplexity int) int
 		ScheduleRelationship     func(childComplexity int) int
 		ServiceDate              func(childComplexity int) int
-		ServiceDates             func(childComplexity int) int
 		ShapeDistTraveled        func(childComplexity int) int
 		StartPickupDropOffWindow func(childComplexity int) int
 		Stop                     func(childComplexity int) int
@@ -7011,12 +7010,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.StopTime.ServiceDate(childComplexity), true
-	case "StopTime.service_dates":
-		if e.ComplexityRoot.StopTime.ServiceDates == nil {
-			break
-		}
-
-		return e.ComplexityRoot.StopTime.ServiceDates(childComplexity), true
 	case "StopTime.shape_dist_traveled":
 		if e.ComplexityRoot.StopTime.ShapeDistTraveled == nil {
 			break
@@ -9930,9 +9923,7 @@ type Trip {
   stop_pattern_id: Int!
 
   """
-  Every GTFS service date on which this trip runs, out of those matched by a ` + "`" + `dates` + "`" + ` or ` + "`" + `service_dates` + "`" + ` query. All of a trip's stop times run on these same dates, so grouping departures by trip states them once rather than once per stop time; a departure's wall calendar date is ` + "`" + `service_date + floor(departure_time / 86400)` + "`" + `.
-
-  Dates are reported in the frame the query was expressed in: a date relocated into the feed version's fallback week by ` + "`" + `use_service_window` + "`" + ` is reported as the date that was asked for. Under ` + "`" + `dates` + "`" + ` this list can extend one day before the earliest requested calendar date, since that day's after-midnight departures fall on it.
+  Every GTFS service date matched by a ` + "`" + `dates` + "`" + ` or ` + "`" + `service_dates` + "`" + ` query, reported as the date that was asked for rather than where ` + "`" + `use_service_window` + "`" + ` relocated it. All of a trip's stop times run on these dates; a departure's wall calendar date is ` + "`" + `service_date + floor(departure_time / 86400)` + "`" + `.
   """
   service_dates: [Date!]
 
@@ -10129,14 +10120,6 @@ type StopTime {
 
   "When part of an arrival/departure query, the calendar date for this scheduled stop time"
   date: Date
-
-  """
-  Every requested service date on which this stop time runs. Populated only when
-  the query used ` + "`" + `service_dates` + "`" + `, which returns one row per departure rather than
-  one row per departure per date. Real-time fields are per-instance and cannot be
-  requested alongside multiple dates.
-  """
-  service_dates: [Date!]
 
   "Real-time status of the parent trip. ` + "`" + `STATIC` + "`" + ` means no GTFS-RT data was matched. See ` + "`" + `ScheduleRelationship` + "`" + ` for per-value semantics"
   schedule_relationship: ScheduleRelationship
@@ -11670,10 +11653,6 @@ input StopTimeFilter {
   relative_date: RelativeDate
   "GTFS service date (which may differ from the calendar date for trips that cross midnight)"
   service_date: Date
-  """
-  Several GTFS service dates, which need not be contiguous. Returns one row per departure with every matching date in ` + "`" + `service_dates` + "`" + `, rather than repeating the row once per date. Intended for bulk timetable extraction; real-time fields cannot be selected alongside more than one date.
-  """
-  service_dates: [Date!]
   "If true and the requested date falls outside the feed version's normal service window, use the feed version's ` + "`" + `fallback_week` + "`" + ` instead"
   use_service_window: Boolean
   "Lower bound for departure time, in seconds since midnight"
@@ -11731,7 +11710,7 @@ input TripFilter {
   """
   service_dates: [Date!]
   """
-  Several wall calendar dates, which need not be contiguous. Unlike ` + "`" + `service_dates` + "`" + ` these are calendar days rather than GTFS service days, so a trip departing after midnight is selected for the calendar date it actually departs on: each requested date also matches the service date before it, whose late-night departures roll over. ` + "`" + `Trip.service_dates` + "`" + ` reports the service dates matched, from which each departure's calendar date is ` + "`" + `service_date + floor(departure_time / 86400)` + "`" + `. Departures more than 48 hours into their service date are not reached.
+  Several wall calendar dates, which need not be contiguous. Unlike ` + "`" + `service_dates` + "`" + `, a trip departing after midnight is matched for the calendar date it departs on, so each requested date also matches the service date before it. Departures more than 48 hours into their service date are not reached.
   """
   dates: [Date!]
   "Calendar date relative to today; see ` + "`" + `RelativeDate` + "`" + `"
@@ -14214,8 +14193,6 @@ func (ec *executionContext) childFields_StopTime(ctx context.Context, field grap
 		return ec.fieldContext_StopTime_service_date(ctx, field)
 	case "date":
 		return ec.fieldContext_StopTime_date(ctx, field)
-	case "service_dates":
-		return ec.fieldContext_StopTime_service_dates(ctx, field)
 	case "schedule_relationship":
 		return ec.fieldContext_StopTime_schedule_relationship(ctx, field)
 	}
@@ -38638,29 +38615,6 @@ func (ec *executionContext) fieldContext_StopTime_date(_ context.Context, field 
 	return graphql.NewScalarFieldContext("StopTime", field, false, false, errors.New("field of type Date does not have child fields"))
 }
 
-func (ec *executionContext) _StopTime_service_dates(ctx context.Context, field graphql.CollectedField, obj *model.StopTime) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_StopTime_service_dates(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.ServiceDates, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v []tt.Date) graphql.Marshaler {
-			return ec.marshalODate2ᚕgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDateᚄ(ctx, selections, v)
-		},
-		true,
-		false,
-	)
-}
-func (ec *executionContext) fieldContext_StopTime_service_dates(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("StopTime", field, false, false, errors.New("field of type Date does not have child fields"))
-}
-
 func (ec *executionContext) _StopTime_schedule_relationship(ctx context.Context, field graphql.CollectedField, obj *model.StopTime) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -45483,7 +45437,7 @@ func (ec *executionContext) unmarshalInputStopTimeFilter(ctx context.Context, ob
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"date", "relative_date", "service_date", "service_dates", "use_service_window", "start_time", "end_time", "start", "end", "next", "route_onestop_ids", "allow_previous_route_onestop_ids", "exclude_first", "exclude_last"}
+	fieldsInOrder := [...]string{"date", "relative_date", "service_date", "use_service_window", "start_time", "end_time", "start", "end", "next", "route_onestop_ids", "allow_previous_route_onestop_ids", "exclude_first", "exclude_last"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -45511,13 +45465,6 @@ func (ec *executionContext) unmarshalInputStopTimeFilter(ctx context.Context, ob
 				return it, err
 			}
 			it.ServiceDate = data
-		case "service_dates":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("service_dates"))
-			data, err := ec.unmarshalODate2ᚕᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDateᚄ(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ServiceDates = data
 		case "use_service_window":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("use_service_window"))
 			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
@@ -56421,8 +56368,6 @@ func (ec *executionContext) _StopTime(ctx context.Context, sel ast.SelectionSet,
 			out.Values[i] = ec._StopTime_service_date(ctx, field, obj)
 		case "date":
 			out.Values[i] = ec._StopTime_date(ctx, field, obj)
-		case "service_dates":
-			out.Values[i] = ec._StopTime_service_dates(ctx, field, obj)
 		case "schedule_relationship":
 			field := field
 
@@ -60517,42 +60462,6 @@ func (ec *executionContext) unmarshalODate2githubᚗcomᚋinterlineᚑioᚋtrans
 
 func (ec *executionContext) marshalODate2githubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDate(ctx context.Context, sel ast.SelectionSet, v tt.Date) graphql.Marshaler {
 	return v
-}
-
-func (ec *executionContext) unmarshalODate2ᚕgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDateᚄ(ctx context.Context, v any) ([]tt.Date, error) {
-	if v == nil {
-		return nil, nil
-	}
-	var vSlice []any
-	vSlice = graphql.CoerceList(v)
-	var err error
-	res := make([]tt.Date, len(vSlice))
-	for i := range vSlice {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalNDate2githubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDate(ctx, vSlice[i])
-		if err != nil {
-			return nil, err
-		}
-	}
-	return res, nil
-}
-
-func (ec *executionContext) marshalODate2ᚕgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDateᚄ(ctx context.Context, sel ast.SelectionSet, v []tt.Date) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	for i := range v {
-		ret[i] = ec.marshalNDate2githubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDate(ctx, sel, v[i])
-	}
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
 }
 
 func (ec *executionContext) unmarshalODate2ᚕᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDateᚄ(ctx context.Context, v any) ([]*tt.Date, error) {

--- a/internal/generated/gqlout/generated.go
+++ b/internal/generated/gqlout/generated.go
@@ -1180,6 +1180,7 @@ type ComplexityRoot struct {
 		PickupType               func(childComplexity int) int
 		ScheduleRelationship     func(childComplexity int) int
 		ServiceDate              func(childComplexity int) int
+		ServiceDates             func(childComplexity int) int
 		ShapeDistTraveled        func(childComplexity int) int
 		StartPickupDropOffWindow func(childComplexity int) int
 		Stop                     func(childComplexity int) int
@@ -7009,6 +7010,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.StopTime.ServiceDate(childComplexity), true
+	case "StopTime.service_dates":
+		if e.ComplexityRoot.StopTime.ServiceDates == nil {
+			break
+		}
+
+		return e.ComplexityRoot.StopTime.ServiceDates(childComplexity), true
 	case "StopTime.shape_dist_traveled":
 		if e.ComplexityRoot.StopTime.ShapeDistTraveled == nil {
 			break
@@ -10109,6 +10116,14 @@ type StopTime {
   "When part of an arrival/departure query, the calendar date for this scheduled stop time"
   date: Date
 
+  """
+  Every requested service date on which this stop time runs. Populated only when
+  the query used ` + "`" + `service_dates` + "`" + `, which returns one row per departure rather than
+  one row per departure per date. Real-time fields are per-instance and cannot be
+  requested alongside multiple dates.
+  """
+  service_dates: [Date!]
+
   "Real-time status of the parent trip. ` + "`" + `STATIC` + "`" + ` means no GTFS-RT data was matched. See ` + "`" + `ScheduleRelationship` + "`" + ` for per-value semantics"
   schedule_relationship: ScheduleRelationship
 }
@@ -11641,6 +11656,10 @@ input StopTimeFilter {
   relative_date: RelativeDate
   "GTFS service date (which may differ from the calendar date for trips that cross midnight)"
   service_date: Date
+  """
+  Several GTFS service dates, which need not be contiguous. Returns one row per departure with every matching date in ` + "`" + `service_dates` + "`" + `, rather than repeating the row once per date. Intended for bulk timetable extraction; real-time fields cannot be selected alongside more than one date.
+  """
+  service_dates: [Date!]
   "If true and the requested date falls outside the feed version's normal service window, use the feed version's ` + "`" + `fallback_week` + "`" + ` instead"
   use_service_window: Boolean
   "Lower bound for departure time, in seconds since midnight"
@@ -14171,6 +14190,8 @@ func (ec *executionContext) childFields_StopTime(ctx context.Context, field grap
 		return ec.fieldContext_StopTime_service_date(ctx, field)
 	case "date":
 		return ec.fieldContext_StopTime_date(ctx, field)
+	case "service_dates":
+		return ec.fieldContext_StopTime_service_dates(ctx, field)
 	case "schedule_relationship":
 		return ec.fieldContext_StopTime_schedule_relationship(ctx, field)
 	}
@@ -38591,6 +38612,29 @@ func (ec *executionContext) fieldContext_StopTime_date(_ context.Context, field 
 	return graphql.NewScalarFieldContext("StopTime", field, false, false, errors.New("field of type Date does not have child fields"))
 }
 
+func (ec *executionContext) _StopTime_service_dates(ctx context.Context, field graphql.CollectedField, obj *model.StopTime) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_StopTime_service_dates(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.ServiceDates, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []tt.Date) graphql.Marshaler {
+			return ec.marshalODate2ᚕgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDateᚄ(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_StopTime_service_dates(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("StopTime", field, false, false, errors.New("field of type Date does not have child fields"))
+}
+
 func (ec *executionContext) _StopTime_schedule_relationship(ctx context.Context, field graphql.CollectedField, obj *model.StopTime) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -45390,7 +45434,7 @@ func (ec *executionContext) unmarshalInputStopTimeFilter(ctx context.Context, ob
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"date", "relative_date", "service_date", "use_service_window", "start_time", "end_time", "start", "end", "next", "route_onestop_ids", "allow_previous_route_onestop_ids", "exclude_first", "exclude_last"}
+	fieldsInOrder := [...]string{"date", "relative_date", "service_date", "service_dates", "use_service_window", "start_time", "end_time", "start", "end", "next", "route_onestop_ids", "allow_previous_route_onestop_ids", "exclude_first", "exclude_last"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -45418,6 +45462,13 @@ func (ec *executionContext) unmarshalInputStopTimeFilter(ctx context.Context, ob
 				return it, err
 			}
 			it.ServiceDate = data
+		case "service_dates":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("service_dates"))
+			data, err := ec.unmarshalODate2ᚕᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDateᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ServiceDates = data
 		case "use_service_window":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("use_service_window"))
 			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
@@ -56300,6 +56351,8 @@ func (ec *executionContext) _StopTime(ctx context.Context, sel ast.SelectionSet,
 			out.Values[i] = ec._StopTime_service_date(ctx, field, obj)
 		case "date":
 			out.Values[i] = ec._StopTime_date(ctx, field, obj)
+		case "service_dates":
+			out.Values[i] = ec._StopTime_service_dates(ctx, field, obj)
 		case "schedule_relationship":
 			field := field
 
@@ -60392,6 +60445,78 @@ func (ec *executionContext) unmarshalODate2githubᚗcomᚋinterlineᚑioᚋtrans
 
 func (ec *executionContext) marshalODate2githubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDate(ctx context.Context, sel ast.SelectionSet, v tt.Date) graphql.Marshaler {
 	return v
+}
+
+func (ec *executionContext) unmarshalODate2ᚕgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDateᚄ(ctx context.Context, v any) ([]tt.Date, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]tt.Date, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNDate2githubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDate(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalODate2ᚕgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDateᚄ(ctx context.Context, sel ast.SelectionSet, v []tt.Date) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalNDate2githubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDate(ctx, sel, v[i])
+	}
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) unmarshalODate2ᚕᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDateᚄ(ctx context.Context, v any) ([]*tt.Date, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]*tt.Date, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNDate2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDate(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalODate2ᚕᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDateᚄ(ctx context.Context, sel ast.SelectionSet, v []*tt.Date) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalNDate2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDate(ctx, sel, v[i])
+	}
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalODate2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDate(ctx context.Context, v any) (*tt.Date, error) {

--- a/internal/generated/gqlout/generated.go
+++ b/internal/generated/gqlout/generated.go
@@ -1229,6 +1229,7 @@ type ComplexityRoot struct {
 		SafeDurationFactor   func(childComplexity int) int
 		SafeDurationOffset   func(childComplexity int) int
 		ScheduleRelationship func(childComplexity int) int
+		ServiceDates         func(childComplexity int) int
 		Shape                func(childComplexity int) int
 		StopPatternID        func(childComplexity int) int
 		StopTimes            func(childComplexity int, limit *int, where *model.TripStopTimeFilter) int
@@ -7273,6 +7274,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Trip.ScheduleRelationship(childComplexity), true
+	case "Trip.service_dates":
+		if e.ComplexityRoot.Trip.ServiceDates == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Trip.ServiceDates(childComplexity), true
 	case "Trip.shape":
 		if e.ComplexityRoot.Trip.Shape == nil {
 			break
@@ -9921,7 +9928,12 @@ type Trip {
 
   "Calculated stop pattern ID; an integer scoped to the feed version"
   stop_pattern_id: Int!
-  
+
+  """
+  Every requested service date on which this trip runs. Populated only when the query used ` + "`" + `service_dates` + "`" + `. All of a trip's stop times run on these same dates, so grouping departures by trip states them once rather than once per stop time.
+  """
+  service_dates: [Date!]
+
   "Calendar for this trip"
   calendar: Calendar!
   
@@ -11688,6 +11700,8 @@ input TripStopTimeFilter {
   start: Seconds
   "Upper bound for arrival time, in local ` + "`" + `HH:MM:SS` + "`" + `"
   end: Seconds
+  "Restrict to stop times at these stops (database integer IDs)"
+  stop_ids: [Int!]
 }
 
 """Filters for querying archived stop observations. All three fields are required."""
@@ -11710,6 +11724,10 @@ input PathwayFilter {
 input TripFilter {
   "GTFS service date on which trips run"
   service_date: Date
+  """
+  Several GTFS service dates, which need not be contiguous. Returns each trip once, with the matching dates in ` + "`" + `Trip.service_dates` + "`" + `, rather than requiring one query per date.
+  """
+  service_dates: [Date!]
   "Calendar date relative to today; see ` + "`" + `RelativeDate` + "`" + `"
   relative_date: RelativeDate
   "If true and the requested date falls outside the feed version's normal service window, use the feed version's ` + "`" + `fallback_week` + "`" + ` instead"
@@ -14272,6 +14290,8 @@ func (ec *executionContext) childFields_Trip(ctx context.Context, field graphql.
 		return ec.fieldContext_Trip_safe_duration_offset(ctx, field)
 	case "stop_pattern_id":
 		return ec.fieldContext_Trip_stop_pattern_id(ctx, field)
+	case "service_dates":
+		return ec.fieldContext_Trip_service_dates(ctx, field)
 	case "calendar":
 		return ec.fieldContext_Trip_calendar(ctx, field)
 	case "route":
@@ -39378,6 +39398,29 @@ func (ec *executionContext) fieldContext_Trip_stop_pattern_id(_ context.Context,
 	return graphql.NewScalarFieldContext("Trip", field, false, false, errors.New("field of type Int does not have child fields"))
 }
 
+func (ec *executionContext) _Trip_service_dates(ctx context.Context, field graphql.CollectedField, obj *model.Trip) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Trip_service_dates(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.ServiceDates, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []*tt.Date) graphql.Marshaler {
+			return ec.marshalODate2ᚕᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDateᚄ(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_Trip_service_dates(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Trip", field, false, false, errors.New("field of type Date does not have child fields"))
+}
+
 func (ec *executionContext) _Trip_calendar(ctx context.Context, field graphql.CollectedField, obj *model.Trip) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -45555,7 +45598,7 @@ func (ec *executionContext) unmarshalInputTripFilter(ctx context.Context, obj an
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"service_date", "relative_date", "use_service_window", "trip_id", "stop_pattern_id", "license", "route_ids", "route_onestop_ids", "feed_version_sha1", "feed_onestop_id"}
+	fieldsInOrder := [...]string{"service_date", "service_dates", "relative_date", "use_service_window", "trip_id", "stop_pattern_id", "license", "route_ids", "route_onestop_ids", "feed_version_sha1", "feed_onestop_id"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -45569,6 +45612,13 @@ func (ec *executionContext) unmarshalInputTripFilter(ctx context.Context, obj an
 				return it, err
 			}
 			it.ServiceDate = data
+		case "service_dates":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("service_dates"))
+			data, err := ec.unmarshalODate2ᚕᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDateᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ServiceDates = data
 		case "relative_date":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("relative_date"))
 			data, err := ec.unmarshalORelativeDate2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐRelativeDate(ctx, v)
@@ -45648,7 +45698,7 @@ func (ec *executionContext) unmarshalInputTripStopTimeFilter(ctx context.Context
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"start", "end"}
+	fieldsInOrder := [...]string{"start", "end", "stop_ids"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -45669,6 +45719,13 @@ func (ec *executionContext) unmarshalInputTripStopTimeFilter(ctx context.Context
 				return it, err
 			}
 			it.End = data
+		case "stop_ids":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("stop_ids"))
+			data, err := ec.unmarshalOInt2ᚕintᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.StopIds = data
 		}
 	}
 	return it, nil
@@ -56631,6 +56688,8 @@ func (ec *executionContext) _Trip(ctx context.Context, sel ast.SelectionSet, obj
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "service_dates":
+			out.Values[i] = ec._Trip_service_dates(ctx, field, obj)
 		case "calendar":
 			field := field
 

--- a/internal/generated/gqlout/generated.go
+++ b/internal/generated/gqlout/generated.go
@@ -9924,6 +9924,8 @@ type Trip {
 
   """
   Every GTFS service date matched by a ` + "`" + `dates` + "`" + ` or ` + "`" + `service_dates` + "`" + ` query, reported as the date that was asked for rather than where ` + "`" + `use_service_window` + "`" + ` relocated it. All of a trip's stop times run on these dates; a departure's wall calendar date is ` + "`" + `service_date + floor(departure_time / 86400)` + "`" + `.
+
+  Under ` + "`" + `service_dates` + "`" + ` these are exactly the dates requested. Under ` + "`" + `dates` + "`" + ` they remain service dates and can fall before the requested range, so a caller wanting only the calendar days it asked for must apply the formula per stop time rather than read this list directly.
   """
   service_dates: [Date!]
 
@@ -11703,17 +11705,17 @@ input PathwayFilter {
 
 """Search options for trips"""
 input TripFilter {
-  "GTFS service date on which trips run"
+  "GTFS service date on which trips run. Lowest precedence: ignored if ` + "`" + `dates` + "`" + `, ` + "`" + `service_dates` + "`" + ` or ` + "`" + `relative_date` + "`" + ` is set"
   service_date: Date
   """
-  Several GTFS service dates, which need not be contiguous. Returns each trip once, with the matching dates in ` + "`" + `Trip.service_dates` + "`" + `, rather than requiring one query per date.
+  Several GTFS service dates, which need not be contiguous. Returns each trip once, with the matching dates in ` + "`" + `Trip.service_dates` + "`" + `, rather than requiring one query per date. Dates are matched exactly as given: unlike ` + "`" + `dates` + "`" + `, no neighbouring service date is brought in for after-midnight departures. Ignored if ` + "`" + `dates` + "`" + ` is set.
   """
   service_dates: [Date!]
   """
-  Several wall calendar dates, which need not be contiguous. Unlike ` + "`" + `service_dates` + "`" + `, a trip departing after midnight is matched for the calendar date it departs on, so each requested date also matches the service date before it. Departures more than 48 hours into their service date are not reached.
+  Several wall calendar dates, which need not be contiguous. Unlike ` + "`" + `service_dates` + "`" + `, a trip departing after midnight is matched for the calendar date it departs on, so each requested date also matches the service date before it — and ` + "`" + `Trip.service_dates` + "`" + ` can therefore name a day earlier than any requested here. Departures more than 48 hours into their service date are not reached. Takes precedence over ` + "`" + `service_date` + "`" + `, ` + "`" + `service_dates` + "`" + ` and ` + "`" + `relative_date` + "`" + `.
   """
   dates: [Date!]
-  "Calendar date relative to today; see ` + "`" + `RelativeDate` + "`" + `"
+  "Calendar date relative to today; see ` + "`" + `RelativeDate` + "`" + `. Ignored if ` + "`" + `dates` + "`" + ` or ` + "`" + `service_dates` + "`" + ` is set"
   relative_date: RelativeDate
   "If true and the requested date falls outside the feed version's normal service window, use the feed version's ` + "`" + `fallback_week` + "`" + ` instead"
   use_service_window: Boolean

--- a/internal/generated/gqlout/generated.go
+++ b/internal/generated/gqlout/generated.go
@@ -9930,7 +9930,9 @@ type Trip {
   stop_pattern_id: Int!
 
   """
-  Every requested service date on which this trip runs. Populated only when the query used ` + "`" + `service_dates` + "`" + `. All of a trip's stop times run on these same dates, so grouping departures by trip states them once rather than once per stop time.
+  Every GTFS service date on which this trip runs, out of those matched by a ` + "`" + `dates` + "`" + ` or ` + "`" + `service_dates` + "`" + ` query. All of a trip's stop times run on these same dates, so grouping departures by trip states them once rather than once per stop time; a departure's wall calendar date is ` + "`" + `service_date + floor(departure_time / 86400)` + "`" + `.
+
+  Dates are reported in the frame the query was expressed in: a date relocated into the feed version's fallback week by ` + "`" + `use_service_window` + "`" + ` is reported as the date that was asked for. Under ` + "`" + `dates` + "`" + ` this list can extend one day before the earliest requested calendar date, since that day's after-midnight departures fall on it.
   """
   service_dates: [Date!]
 
@@ -11728,6 +11730,10 @@ input TripFilter {
   Several GTFS service dates, which need not be contiguous. Returns each trip once, with the matching dates in ` + "`" + `Trip.service_dates` + "`" + `, rather than requiring one query per date.
   """
   service_dates: [Date!]
+  """
+  Several wall calendar dates, which need not be contiguous. Unlike ` + "`" + `service_dates` + "`" + ` these are calendar days rather than GTFS service days, so a trip departing after midnight is selected for the calendar date it actually departs on: each requested date also matches the service date before it, whose late-night departures roll over. ` + "`" + `Trip.service_dates` + "`" + ` reports the service dates matched, from which each departure's calendar date is ` + "`" + `service_date + floor(departure_time / 86400)` + "`" + `. Departures more than 48 hours into their service date are not reached.
+  """
+  dates: [Date!]
   "Calendar date relative to today; see ` + "`" + `RelativeDate` + "`" + `"
   relative_date: RelativeDate
   "If true and the requested date falls outside the feed version's normal service window, use the feed version's ` + "`" + `fallback_week` + "`" + ` instead"
@@ -45598,7 +45604,7 @@ func (ec *executionContext) unmarshalInputTripFilter(ctx context.Context, obj an
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"service_date", "service_dates", "relative_date", "use_service_window", "trip_id", "stop_pattern_id", "license", "route_ids", "route_onestop_ids", "feed_version_sha1", "feed_onestop_id"}
+	fieldsInOrder := [...]string{"service_date", "service_dates", "dates", "relative_date", "use_service_window", "trip_id", "stop_pattern_id", "license", "route_ids", "route_onestop_ids", "feed_version_sha1", "feed_onestop_id"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -45619,6 +45625,13 @@ func (ec *executionContext) unmarshalInputTripFilter(ctx context.Context, obj an
 				return it, err
 			}
 			it.ServiceDates = data
+		case "dates":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dates"))
+			data, err := ec.unmarshalODate2ᚕᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDateᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Dates = data
 		case "relative_date":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("relative_date"))
 			data, err := ec.unmarshalORelativeDate2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐRelativeDate(ctx, v)

--- a/schema/graphql/schema.graphqls
+++ b/schema/graphql/schema.graphqls
@@ -1061,6 +1061,8 @@ type Trip {
 
   """
   Every GTFS service date matched by a `dates` or `service_dates` query, reported as the date that was asked for rather than where `use_service_window` relocated it. All of a trip's stop times run on these dates; a departure's wall calendar date is `service_date + floor(departure_time / 86400)`.
+
+  Under `service_dates` these are exactly the dates requested. Under `dates` they remain service dates and can fall before the requested range, so a caller wanting only the calendar days it asked for must apply the formula per stop time rather than read this list directly.
   """
   service_dates: [Date!]
 
@@ -2840,17 +2842,17 @@ input PathwayFilter {
 
 """Search options for trips"""
 input TripFilter {
-  "GTFS service date on which trips run"
+  "GTFS service date on which trips run. Lowest precedence: ignored if `dates`, `service_dates` or `relative_date` is set"
   service_date: Date
   """
-  Several GTFS service dates, which need not be contiguous. Returns each trip once, with the matching dates in `Trip.service_dates`, rather than requiring one query per date.
+  Several GTFS service dates, which need not be contiguous. Returns each trip once, with the matching dates in `Trip.service_dates`, rather than requiring one query per date. Dates are matched exactly as given: unlike `dates`, no neighbouring service date is brought in for after-midnight departures. Ignored if `dates` is set.
   """
   service_dates: [Date!]
   """
-  Several wall calendar dates, which need not be contiguous. Unlike `service_dates`, a trip departing after midnight is matched for the calendar date it departs on, so each requested date also matches the service date before it. Departures more than 48 hours into their service date are not reached.
+  Several wall calendar dates, which need not be contiguous. Unlike `service_dates`, a trip departing after midnight is matched for the calendar date it departs on, so each requested date also matches the service date before it — and `Trip.service_dates` can therefore name a day earlier than any requested here. Departures more than 48 hours into their service date are not reached. Takes precedence over `service_date`, `service_dates` and `relative_date`.
   """
   dates: [Date!]
-  "Calendar date relative to today; see `RelativeDate`"
+  "Calendar date relative to today; see `RelativeDate`. Ignored if `dates` or `service_dates` is set"
   relative_date: RelativeDate
   "If true and the requested date falls outside the feed version's normal service window, use the feed version's `fallback_week` instead"
   use_service_window: Boolean

--- a/schema/graphql/schema.graphqls
+++ b/schema/graphql/schema.graphqls
@@ -1253,6 +1253,14 @@ type StopTime {
   "When part of an arrival/departure query, the calendar date for this scheduled stop time"
   date: Date
 
+  """
+  Every requested service date on which this stop time runs. Populated only when
+  the query used `service_dates`, which returns one row per departure rather than
+  one row per departure per date. Real-time fields are per-instance and cannot be
+  requested alongside multiple dates.
+  """
+  service_dates: [Date!]
+
   "Real-time status of the parent trip. `STATIC` means no GTFS-RT data was matched. See `ScheduleRelationship` for per-value semantics"
   schedule_relationship: ScheduleRelationship
 }
@@ -2785,6 +2793,10 @@ input StopTimeFilter {
   relative_date: RelativeDate
   "GTFS service date (which may differ from the calendar date for trips that cross midnight)"
   service_date: Date
+  """
+  Several GTFS service dates, which need not be contiguous. Returns one row per departure with every matching date in `service_dates`, rather than repeating the row once per date. Intended for bulk timetable extraction; real-time fields cannot be selected alongside more than one date.
+  """
+  service_dates: [Date!]
   "If true and the requested date falls outside the feed version's normal service window, use the feed version's `fallback_week` instead"
   use_service_window: Boolean
   "Lower bound for departure time, in seconds since midnight"

--- a/schema/graphql/schema.graphqls
+++ b/schema/graphql/schema.graphqls
@@ -1058,7 +1058,12 @@ type Trip {
 
   "Calculated stop pattern ID; an integer scoped to the feed version"
   stop_pattern_id: Int!
-  
+
+  """
+  Every requested service date on which this trip runs. Populated only when the query used `service_dates`. All of a trip's stop times run on these same dates, so grouping departures by trip states them once rather than once per stop time.
+  """
+  service_dates: [Date!]
+
   "Calendar for this trip"
   calendar: Calendar!
   
@@ -2825,6 +2830,8 @@ input TripStopTimeFilter {
   start: Seconds
   "Upper bound for arrival time, in local `HH:MM:SS`"
   end: Seconds
+  "Restrict to stop times at these stops (database integer IDs)"
+  stop_ids: [Int!]
 }
 
 """Filters for querying archived stop observations. All three fields are required."""
@@ -2847,6 +2854,10 @@ input PathwayFilter {
 input TripFilter {
   "GTFS service date on which trips run"
   service_date: Date
+  """
+  Several GTFS service dates, which need not be contiguous. Returns each trip once, with the matching dates in `Trip.service_dates`, rather than requiring one query per date.
+  """
+  service_dates: [Date!]
   "Calendar date relative to today; see `RelativeDate`"
   relative_date: RelativeDate
   "If true and the requested date falls outside the feed version's normal service window, use the feed version's `fallback_week` instead"

--- a/schema/graphql/schema.graphqls
+++ b/schema/graphql/schema.graphqls
@@ -1060,7 +1060,7 @@ type Trip {
   stop_pattern_id: Int!
 
   """
-  Every requested service date on which this trip runs. Populated only when the query used `service_dates`. All of a trip's stop times run on these same dates, so grouping departures by trip states them once rather than once per stop time.
+  Every GTFS service date matched by a `dates` or `service_dates` query, reported as the date that was asked for rather than where `use_service_window` relocated it. All of a trip's stop times run on these dates; a departure's wall calendar date is `service_date + floor(departure_time / 86400)`.
   """
   service_dates: [Date!]
 
@@ -1259,10 +1259,7 @@ type StopTime {
   date: Date
 
   """
-  Every requested service date on which this stop time runs. Populated only when
-  the query used `service_dates`, which returns one row per departure rather than
-  one row per departure per date. Real-time fields are per-instance and cannot be
-  requested alongside multiple dates.
+  Every requested service date this departure runs, folded into one row rather than one row per date. Real-time fields are per-instance and cannot be requested alongside several dates.
   """
   service_dates: [Date!]
 
@@ -2799,7 +2796,7 @@ input StopTimeFilter {
   "GTFS service date (which may differ from the calendar date for trips that cross midnight)"
   service_date: Date
   """
-  Several GTFS service dates, which need not be contiguous. Returns one row per departure with every matching date in `service_dates`, rather than repeating the row once per date. Intended for bulk timetable extraction; real-time fields cannot be selected alongside more than one date.
+  Several GTFS service dates, which need not be contiguous. Returns one row per departure carrying every matching date in `service_dates`, rather than repeating the row once per date. Real-time fields cannot be selected alongside more than one date.
   """
   service_dates: [Date!]
   "If true and the requested date falls outside the feed version's normal service window, use the feed version's `fallback_week` instead"
@@ -2858,6 +2855,10 @@ input TripFilter {
   Several GTFS service dates, which need not be contiguous. Returns each trip once, with the matching dates in `Trip.service_dates`, rather than requiring one query per date.
   """
   service_dates: [Date!]
+  """
+  Several wall calendar dates, which need not be contiguous. Unlike `service_dates`, a trip departing after midnight is matched for the calendar date it departs on, so each requested date also matches the service date before it. Departures more than 48 hours into their service date are not reached.
+  """
+  dates: [Date!]
   "Calendar date relative to today; see `RelativeDate`"
   relative_date: RelativeDate
   "If true and the requested date falls outside the feed version's normal service window, use the feed version's `fallback_week` instead"

--- a/schema/graphql/schema.graphqls
+++ b/schema/graphql/schema.graphqls
@@ -1258,11 +1258,6 @@ type StopTime {
   "When part of an arrival/departure query, the calendar date for this scheduled stop time"
   date: Date
 
-  """
-  Every requested service date this departure runs, folded into one row rather than one row per date. Real-time fields are per-instance and cannot be requested alongside several dates.
-  """
-  service_dates: [Date!]
-
   "Real-time status of the parent trip. `STATIC` means no GTFS-RT data was matched. See `ScheduleRelationship` for per-value semantics"
   schedule_relationship: ScheduleRelationship
 }
@@ -2795,10 +2790,6 @@ input StopTimeFilter {
   relative_date: RelativeDate
   "GTFS service date (which may differ from the calendar date for trips that cross midnight)"
   service_date: Date
-  """
-  Several GTFS service dates, which need not be contiguous. Returns one row per departure carrying every matching date in `service_dates`, rather than repeating the row once per date. Real-time fields cannot be selected alongside more than one date.
-  """
-  service_dates: [Date!]
   "If true and the requested date falls outside the feed version's normal service window, use the feed version's `fallback_week` instead"
   use_service_window: Boolean
   "Lower bound for departure time, in seconds since midnight"

--- a/server/finders/dbfinder/service_dates.go
+++ b/server/finders/dbfinder/service_dates.go
@@ -1,0 +1,35 @@
+package dbfinder
+
+import (
+	"sort"
+	"time"
+)
+
+// DepartureLookbackDays bounds how far back a wall calendar date query reaches
+// for after-midnight departures. 1 covers departures up to 48:00; raising it
+// covers services that run longer, at one more service date per query.
+const DepartureLookbackDays = 1
+
+// calendarServiceDates returns the GTFS service dates that can carry a departure
+// falling on any of the given wall calendar dates. A departure at time t on
+// service date S falls on calendar date S + floor(t/86400), so calendar date D
+// is served by service dates D-k for k in 0..lookback. Deduplicated, so a run of
+// consecutive dates costs len(run)+lookback service dates, not
+// len(run)*(lookback+1).
+func calendarServiceDates(dates []time.Time, lookback int) []time.Time {
+	seen := map[string]bool{}
+	var out []time.Time
+	for _, d := range dates {
+		for k := 0; k <= lookback; k++ {
+			s := d.AddDate(0, 0, -k)
+			key := s.Format("2006-01-02")
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, s)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Before(out[j]) })
+	return out
+}

--- a/server/finders/dbfinder/service_dates_test.go
+++ b/server/finders/dbfinder/service_dates_test.go
@@ -1,0 +1,73 @@
+package dbfinder
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCalendarServiceDates(t *testing.T) {
+	parse := func(dates ...string) []time.Time {
+		var out []time.Time
+		for _, d := range dates {
+			v, err := time.Parse("2006-01-02", d)
+			if err != nil {
+				t.Fatal(err)
+			}
+			out = append(out, v)
+		}
+		return out
+	}
+	format := func(dates []time.Time) []string {
+		var out []string
+		for _, d := range dates {
+			out = append(out, d.Format("2006-01-02"))
+		}
+		return out
+	}
+	tcs := []struct {
+		name     string
+		dates    []string
+		lookback int
+		expect   []string
+	}{
+		{
+			"no lookback sorts and deduplicates",
+			[]string{"2026-05-11", "2026-05-10", "2026-05-11"}, 0,
+			[]string{"2026-05-10", "2026-05-11"},
+		},
+		{
+			"single date reaches back one day",
+			[]string{"2026-05-10"}, 1,
+			[]string{"2026-05-09", "2026-05-10"},
+		},
+		{
+			// A week is 8 service dates, not 14.
+			"consecutive dates overlap",
+			[]string{"2026-05-10", "2026-05-11", "2026-05-12", "2026-05-13", "2026-05-14", "2026-05-15", "2026-05-16"}, 1,
+			[]string{"2026-05-09", "2026-05-10", "2026-05-11", "2026-05-12", "2026-05-13", "2026-05-14", "2026-05-15", "2026-05-16"},
+		},
+		{
+			"gaps are not filled in",
+			[]string{"2026-05-10", "2026-05-11", "2026-05-15"}, 1,
+			[]string{"2026-05-09", "2026-05-10", "2026-05-11", "2026-05-14", "2026-05-15"},
+		},
+		{
+			"lookback covers multi-day trips",
+			[]string{"2026-05-10"}, 3,
+			[]string{"2026-05-07", "2026-05-08", "2026-05-09", "2026-05-10"},
+		},
+		{
+			"crosses a month boundary",
+			[]string{"2026-06-01"}, 1,
+			[]string{"2026-05-31", "2026-06-01"},
+		},
+		{"no dates", nil, 1, nil},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expect, format(calendarServiceDates(parse(tc.dates...), tc.lookback)))
+		})
+	}
+}

--- a/server/finders/dbfinder/stop_time.go
+++ b/server/finders/dbfinder/stop_time.go
@@ -81,8 +81,15 @@ func (f *Finder) stopTimesByEntityIDs(ctx context.Context, entityType stopTimeEn
 		if err != nil {
 			return nil, err
 		}
+		// Copied: the expansion rewrites the filter's date in place, and each
+		// feed version resolves it against its own service window.
+		fvWhere := where
+		if where != nil {
+			w := *where
+			fvWhere = &w
+		}
 		// Run separate queries for each possible service day
-		for _, w := range stopTimeFilterExpandDates(where, fvsw) {
+		for _, w := range stopTimeFilterExpandDates(fvWhere, fvsw) {
 			var serviceDate *tt.Date
 			if w != nil && w.ServiceDate != nil {
 				serviceDate = w.ServiceDate
@@ -125,14 +132,10 @@ func (f *Finder) stopTimesByEntityIDs(ctx context.Context, entityType stopTimeEn
 }
 
 // Collapse rows that differ only by service date into one row carrying every
-// date it runs. A departure is identified by its trip, stop and times — none of
-// which vary by date — so the per-date copies the queries return are redundant
-// once the caller asked for a set of dates rather than one.
-//
-// Trips are keyed by the feed-version-scoped numeric id, not the GTFS trip_id
-// string: a query spanning two feed versions of the same feed can carry the
-// same string with different times.
+// date it runs.
 func foldServiceDates(ents []*model.StopTime) []*model.StopTime {
+	// Trip keyed by numeric id rather than GTFS trip_id, which one query can
+	// see on two feed versions of the same feed.
 	type foldKey struct {
 		feedVersionID int
 		tripID        int
@@ -154,8 +157,8 @@ func foldServiceDates(ents []*model.StopTime) []*model.StopTime {
 		}
 		prev, ok := byKey[k]
 		if !ok {
-			// Keep the first row's ServiceDate/Date so single-date callers and
-			// the folded shape agree on what the earliest instance was.
+			// The first row keeps its ServiceDate/Date, so a folded row still
+			// reports its earliest instance.
 			ent.ServiceDates = append(ent.ServiceDates, ent.ServiceDate)
 			byKey[k] = ent
 			folded = append(folded, ent)
@@ -215,8 +218,8 @@ func stopTimeSelect(pairs []model.FVPair, entityType stopTimeEntityType, where *
 		if where.End != nil {
 			q = q.Where(sq.LtOrEq{"sts.arrival_time + gtfs_trips.journey_pattern_offset": where.End.Int()})
 		}
-		// Keeps a trip-oriented query selective: without it a route crossing a
-		// small query area returns every stop on the route.
+		// Without this a route crossing a small query area returns every stop
+		// on the route.
 		if len(where.StopIds) > 0 {
 			q = q.Where(In("sts.stop_id", where.StopIds))
 		}
@@ -404,8 +407,7 @@ func stopDeparturesSelect(fvid int, entityIDs []int, entityType stopTimeEntityTy
 	return q
 }
 
-// A `service_dates` request is the single-date expansion run once per requested
-// date. Each still splits around midnight on its own, so a date set and a
+// Run the single-date expansion once per requested date, so a date set and a
 // sequence of single-date queries produce identical rows before folding.
 func stopTimeFilterExpandDates(where *model.StopTimeFilter, fvsw *model.ServiceWindow) []*model.StopTimeFilter {
 	if where == nil || len(where.ServiceDates) == 0 {
@@ -420,8 +422,7 @@ func stopTimeFilterExpandDates(where *model.StopTimeFilter, fvsw *model.ServiceW
 		w.ServiceDates = nil
 		w.Date = nil
 		w.RelativeDate = nil
-		// Copied, because stopTimeFilterExpand rewrites ServiceDate in place
-		// when it maps a date into the feed version's service window.
+		// Copied: stopTimeFilterExpand rewrites ServiceDate in place.
 		w.ServiceDate = ptr(*sd)
 		out = append(out, stopTimeFilterExpand(&w, fvsw)...)
 	}

--- a/server/finders/dbfinder/stop_time.go
+++ b/server/finders/dbfinder/stop_time.go
@@ -89,7 +89,7 @@ func (f *Finder) stopTimesByEntityIDs(ctx context.Context, entityType stopTimeEn
 			fvWhere = &w
 		}
 		// Run separate queries for each possible service day
-		for _, w := range stopTimeFilterExpandDates(fvWhere, fvsw) {
+		for _, w := range stopTimeFilterExpand(fvWhere, fvsw) {
 			var serviceDate *tt.Date
 			if w != nil && w.ServiceDate != nil {
 				serviceDate = w.ServiceDate
@@ -125,48 +125,7 @@ func (f *Finder) stopTimesByEntityIDs(ctx context.Context, entityType stopTimeEn
 			ents = append(ents, sts...)
 		}
 	}
-	if where != nil && len(where.ServiceDates) > 0 {
-		ents = foldServiceDates(ents)
-	}
 	return ents, nil
-}
-
-// Collapse rows that differ only by service date into one row carrying every
-// date it runs.
-func foldServiceDates(ents []*model.StopTime) []*model.StopTime {
-	// Trip keyed by numeric id rather than GTFS trip_id, which one query can
-	// see on two feed versions of the same feed.
-	type foldKey struct {
-		feedVersionID int
-		tripID        int
-		stopID        int
-		stopSequence  int
-		arrivalTime   int
-		departureTime int
-	}
-	folded := make([]*model.StopTime, 0, len(ents))
-	byKey := map[foldKey]*model.StopTime{}
-	for _, ent := range ents {
-		k := foldKey{
-			feedVersionID: ent.FeedVersionID,
-			tripID:        ent.TripID.Int(),
-			stopID:        ent.StopID.Int(),
-			stopSequence:  ent.StopSequence.Int(),
-			arrivalTime:   ent.ArrivalTime.Int(),
-			departureTime: ent.DepartureTime.Int(),
-		}
-		prev, ok := byKey[k]
-		if !ok {
-			// The first row keeps its ServiceDate/Date, so a folded row still
-			// reports its earliest instance.
-			ent.ServiceDates = append(ent.ServiceDates, ent.ServiceDate)
-			byKey[k] = ent
-			folded = append(folded, ent)
-			continue
-		}
-		prev.ServiceDates = append(prev.ServiceDates, ent.ServiceDate)
-	}
-	return folded
 }
 
 // stopTimeEntityType specifies which entity type to filter stop_times by
@@ -405,28 +364,6 @@ func stopDeparturesSelect(fvid int, entityIDs []int, entityType stopTimeEntityTy
 		}
 	}
 	return q
-}
-
-// Run the single-date expansion once per requested date, so a date set and a
-// sequence of single-date queries produce identical rows before folding.
-func stopTimeFilterExpandDates(where *model.StopTimeFilter, fvsw *model.ServiceWindow) []*model.StopTimeFilter {
-	if where == nil || len(where.ServiceDates) == 0 {
-		return stopTimeFilterExpand(where, fvsw)
-	}
-	var out []*model.StopTimeFilter
-	for _, sd := range where.ServiceDates {
-		if sd == nil {
-			continue
-		}
-		w := *where
-		w.ServiceDates = nil
-		w.Date = nil
-		w.RelativeDate = nil
-		// Copied: stopTimeFilterExpand rewrites ServiceDate in place.
-		w.ServiceDate = ptr(*sd)
-		out = append(out, stopTimeFilterExpand(&w, fvsw)...)
-	}
-	return out
 }
 
 func stopTimeFilterExpand(where *model.StopTimeFilter, fvsw *model.ServiceWindow) []*model.StopTimeFilter {

--- a/server/finders/dbfinder/stop_time.go
+++ b/server/finders/dbfinder/stop_time.go
@@ -215,6 +215,11 @@ func stopTimeSelect(pairs []model.FVPair, entityType stopTimeEntityType, where *
 		if where.End != nil {
 			q = q.Where(sq.LtOrEq{"sts.arrival_time + gtfs_trips.journey_pattern_offset": where.End.Int()})
 		}
+		// Keeps a trip-oriented query selective: without it a route crossing a
+		// small query area returns every stop on the route.
+		if len(where.StopIds) > 0 {
+			q = q.Where(In("sts.stop_id", where.StopIds))
+		}
 	}
 	if len(pairs) > 0 {
 		eids, fvids := pairKeys(pairs)

--- a/server/finders/dbfinder/stop_time.go
+++ b/server/finders/dbfinder/stop_time.go
@@ -82,7 +82,7 @@ func (f *Finder) stopTimesByEntityIDs(ctx context.Context, entityType stopTimeEn
 			return nil, err
 		}
 		// Run separate queries for each possible service day
-		for _, w := range stopTimeFilterExpand(where, fvsw) {
+		for _, w := range stopTimeFilterExpandDates(where, fvsw) {
 			var serviceDate *tt.Date
 			if w != nil && w.ServiceDate != nil {
 				serviceDate = w.ServiceDate
@@ -118,7 +118,52 @@ func (f *Finder) stopTimesByEntityIDs(ctx context.Context, entityType stopTimeEn
 			ents = append(ents, sts...)
 		}
 	}
+	if where != nil && len(where.ServiceDates) > 0 {
+		ents = foldServiceDates(ents)
+	}
 	return ents, nil
+}
+
+// Collapse rows that differ only by service date into one row carrying every
+// date it runs. A departure is identified by its trip, stop and times — none of
+// which vary by date — so the per-date copies the queries return are redundant
+// once the caller asked for a set of dates rather than one.
+//
+// Trips are keyed by the feed-version-scoped numeric id, not the GTFS trip_id
+// string: a query spanning two feed versions of the same feed can carry the
+// same string with different times.
+func foldServiceDates(ents []*model.StopTime) []*model.StopTime {
+	type foldKey struct {
+		feedVersionID int
+		tripID        int
+		stopID        int
+		stopSequence  int
+		arrivalTime   int
+		departureTime int
+	}
+	folded := make([]*model.StopTime, 0, len(ents))
+	byKey := map[foldKey]*model.StopTime{}
+	for _, ent := range ents {
+		k := foldKey{
+			feedVersionID: ent.FeedVersionID,
+			tripID:        ent.TripID.Int(),
+			stopID:        ent.StopID.Int(),
+			stopSequence:  ent.StopSequence.Int(),
+			arrivalTime:   ent.ArrivalTime.Int(),
+			departureTime: ent.DepartureTime.Int(),
+		}
+		prev, ok := byKey[k]
+		if !ok {
+			// Keep the first row's ServiceDate/Date so single-date callers and
+			// the folded shape agree on what the earliest instance was.
+			ent.ServiceDates = append(ent.ServiceDates, ent.ServiceDate)
+			byKey[k] = ent
+			folded = append(folded, ent)
+			continue
+		}
+		prev.ServiceDates = append(prev.ServiceDates, ent.ServiceDate)
+	}
+	return folded
 }
 
 // stopTimeEntityType specifies which entity type to filter stop_times by
@@ -352,6 +397,30 @@ func stopDeparturesSelect(fvid int, entityIDs []int, entityType stopTimeEntityTy
 		}
 	}
 	return q
+}
+
+// A `service_dates` request is the single-date expansion run once per requested
+// date. Each still splits around midnight on its own, so a date set and a
+// sequence of single-date queries produce identical rows before folding.
+func stopTimeFilterExpandDates(where *model.StopTimeFilter, fvsw *model.ServiceWindow) []*model.StopTimeFilter {
+	if where == nil || len(where.ServiceDates) == 0 {
+		return stopTimeFilterExpand(where, fvsw)
+	}
+	var out []*model.StopTimeFilter
+	for _, sd := range where.ServiceDates {
+		if sd == nil {
+			continue
+		}
+		w := *where
+		w.ServiceDates = nil
+		w.Date = nil
+		w.RelativeDate = nil
+		// Copied, because stopTimeFilterExpand rewrites ServiceDate in place
+		// when it maps a date into the feed version's service window.
+		w.ServiceDate = ptr(*sd)
+		out = append(out, stopTimeFilterExpand(&w, fvsw)...)
+	}
+	return out
 }
 
 func stopTimeFilterExpand(where *model.StopTimeFilter, fvsw *model.ServiceWindow) []*model.StopTimeFilter {

--- a/server/finders/dbfinder/trip.go
+++ b/server/finders/dbfinder/trip.go
@@ -3,6 +3,8 @@ package dbfinder
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/interline-io/transitland-lib/server/dbutil"
 	"github.com/interline-io/transitland-lib/server/model"
@@ -51,6 +53,35 @@ func (f *Finder) FrequenciesByTripIDs(ctx context.Context, limit *int, keys []in
 	return arrangeGroup(keys, ents, func(ent *model.Frequency) int { return ent.FeedVersionID }), err
 }
 
+// A date outside the feed version's service window is replaced by the same
+// weekday in its fallback week; a date inside is returned unchanged.
+func mapIntoServiceWindow(s time.Time, fvsw *model.ServiceWindow) *tt.Date {
+	if !s.Before(fvsw.StartDate) && !s.After(fvsw.EndDate) {
+		return tzTruncate(s, fvsw.NowLocal.Location())
+	}
+	dow := int(s.Weekday()) - 1
+	if dow < 0 {
+		dow = 6
+	}
+	return tzTruncate(fvsw.FallbackWeek.AddDate(0, 0, dow), fvsw.NowLocal.Location())
+}
+
+// Split the aggregated service_dates column into the per-trip list the API
+// returns. A no-op unless the query filtered on service_dates.
+func expandTripServiceDates(ents []*model.Trip) {
+	for _, ent := range ents {
+		if !ent.ServiceDatesAgg.Valid || ent.ServiceDatesAgg.Val == "" {
+			continue
+		}
+		for _, s := range strings.Split(ent.ServiceDatesAgg.Val, ",") {
+			d := tt.Date{}
+			if err := d.Scan(s); err == nil {
+				ent.ServiceDates = append(ent.ServiceDates, &d)
+			}
+		}
+	}
+}
+
 func (f *Finder) TripsByRouteIDs(ctx context.Context, limit *int, where *model.TripFilter, keys []model.FVPair) ([][]*model.Trip, error) {
 	var ents []*model.Trip
 	// Group by fvid
@@ -82,6 +113,7 @@ func (f *Finder) TripsByRouteIDs(ctx context.Context, limit *int, where *model.T
 			return nil, err
 		}
 	}
+	expandTripServiceDates(ents)
 	return arrangeGroup(keys, ents, func(ent *model.Trip) model.FVPair {
 		return model.FVPair{FeedVersionID: ent.FeedVersionID, EntityID: ent.RouteID.Int()}
 	}), nil
@@ -118,6 +150,7 @@ func (f *Finder) TripsByShapeIDs(ctx context.Context, limit *int, where *model.T
 			return nil, err
 		}
 	}
+	expandTripServiceDates(ents)
 	return arrangeGroup(keys, ents, func(ent *model.Trip) model.FVPair {
 		return model.FVPair{FeedVersionID: ent.FeedVersionID, EntityID: ent.ShapeID.Int()}
 	}), nil
@@ -152,6 +185,7 @@ func (f *Finder) TripsByFeedVersionIDs(ctx context.Context, limit *int, where *m
 		}
 		ents = append(ents, q...)
 	}
+	expandTripServiceDates(ents)
 	return arrangeGroup(keys, ents, func(ent *model.Trip) int { return ent.FeedVersionID }), nil
 }
 
@@ -195,13 +229,14 @@ func tripSelect(limit *int, after *model.Cursor, ids []int, active bool, permFil
 			where.ServiceDate = tzTruncate(s, fvsw.NowLocal.Location())
 		}
 		if where.UseServiceWindow != nil && *where.UseServiceWindow {
-			s := where.ServiceDate.Val
-			if s.Before(fvsw.StartDate) || s.After(fvsw.EndDate) {
-				dow := int(s.Weekday()) - 1
-				if dow < 0 {
-					dow = 6
+			// Guarded: use_service_window with no date at all is a valid filter.
+			if where.ServiceDate != nil {
+				where.ServiceDate = mapIntoServiceWindow(where.ServiceDate.Val, fvsw)
+			}
+			for i, d := range where.ServiceDates {
+				if d != nil {
+					where.ServiceDates[i] = mapIntoServiceWindow(d.Val, fvsw)
 				}
-				where.ServiceDate = tzTruncate(fvsw.FallbackWeek.AddDate(0, 0, dow), fvsw.NowLocal.Location())
 			}
 		}
 	}
@@ -229,7 +264,39 @@ func tripSelect(limit *int, after *model.Cursor, ids []int, active bool, permFil
 		if len(where.RouteIds) > 0 {
 			q = q.Where(In("gtfs_trips.route_id", where.RouteIds))
 		}
-		if where.ServiceDate != nil {
+		if len(where.ServiceDates) > 0 {
+			// One row per trip carrying the requested dates it runs, instead of
+			// one query per date. Aggregated as text because the dates ride back
+			// on a single column; the finder splits them into ServiceDates.
+			var dates []string
+			for _, d := range where.ServiceDates {
+				if d != nil {
+					dates = append(dates, d.Val.Format("2006-01-02"))
+				}
+			}
+			q = q.Column("svc.service_dates_agg").JoinClause(`
+			join lateral (
+				select string_agg(to_char(d.day, 'YYYY-MM-DD'), ',' order by d.day) as service_dates_agg
+				from unnest(string_to_array(?, ',')::date[]) as d(day)
+				join gtfs_calendars gc on gc.id = gtfs_trips.service_id
+				left join gtfs_calendar_dates gcda on gcda.service_id = gc.id and gcda.exception_type = 1 and gcda.date = d.day
+				left join gtfs_calendar_dates gcdb on gcdb.service_id = gc.id and gcdb.exception_type = 2 and gcdb.date = d.day
+				where ((
+						gc.start_date <= d.day AND gc.end_date >= d.day
+						AND (CASE EXTRACT(isodow FROM d.day)
+						WHEN 1 THEN monday = 1
+						WHEN 2 THEN tuesday = 1
+						WHEN 3 THEN wednesday = 1
+						WHEN 4 THEN thursday = 1
+						WHEN 5 THEN friday = 1
+						WHEN 6 THEN saturday = 1
+						WHEN 7 THEN sunday = 1
+						END)
+					) OR gcda.date IS NOT NULL)
+					AND gcdb.date is null
+			) svc on true
+			`, strings.Join(dates, ",")).Where("svc.service_dates_agg is not null")
+		} else if where.ServiceDate != nil {
 			serviceDate := where.ServiceDate.Val
 			q = q.JoinClause(`
 			join lateral (

--- a/server/finders/dbfinder/trip.go
+++ b/server/finders/dbfinder/trip.go
@@ -3,6 +3,7 @@ package dbfinder
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -18,13 +19,14 @@ func (f *Finder) FindTrips(ctx context.Context, limit *int, after *model.Cursor,
 	if len(ids) > 0 || (where != nil && where.FeedVersionSha1 != nil) || (where != nil && len(where.RouteIds) > 0) {
 		active = false
 	}
-	q, err := tripSelect(limit, after, ids, active, f.PermFilter(ctx), where, nil)
+	q, tripDates, err := tripSelect(limit, after, ids, active, f.PermFilter(ctx), where, nil)
 	if err != nil {
 		return nil, err
 	}
 	if err := dbutil.Select(ctx, f.db, q, &ents); err != nil {
 		return nil, logErr(ctx, err)
 	}
+	expandTripServiceDates(ents, tripDates)
 	return ents, nil
 }
 
@@ -53,8 +55,8 @@ func (f *Finder) FrequenciesByTripIDs(ctx context.Context, limit *int, keys []in
 	return arrangeGroup(keys, ents, func(ent *model.Frequency) int { return ent.FeedVersionID }), err
 }
 
-// A date outside the feed version's service window is replaced by the same
-// weekday in its fallback week; a date inside is returned unchanged.
+// Replaces a date outside the feed version's service window with the same
+// weekday in its fallback week.
 func mapIntoServiceWindow(s time.Time, fvsw *model.ServiceWindow) *tt.Date {
 	if !s.Before(fvsw.StartDate) && !s.After(fvsw.EndDate) {
 		return tzTruncate(s, fvsw.NowLocal.Location())
@@ -66,18 +68,71 @@ func mapIntoServiceWindow(s time.Time, fvsw *model.ServiceWindow) *tt.Date {
 	return tzTruncate(fvsw.FallbackWeek.AddDate(0, 0, dow), fvsw.NowLocal.Location())
 }
 
+// tripDate is a service date to match in the database and the dates it is
+// reported as. They differ under use_service_window, which relocates a date
+// into the fallback week; several requested dates can land on the same day.
+type tripDate struct {
+	query  time.Time
+	report []time.Time
+}
+
+// Resolve a trip filter's dates into the service dates to match. Wall calendar
+// `dates` also reach back DepartureLookbackDays.
+func resolveTripDates(where *model.TripFilter, fvsw *model.ServiceWindow) []tripDate {
+	if where == nil {
+		return nil
+	}
+	src, lookback := where.ServiceDates, 0
+	if len(where.Dates) > 0 {
+		src, lookback = where.Dates, DepartureLookbackDays
+	}
+	var requested []time.Time
+	for _, d := range src {
+		if d != nil {
+			requested = append(requested, d.Val)
+		}
+	}
+	var out []tripDate
+	at := map[string]int{}
+	for _, report := range calendarServiceDates(requested, lookback) {
+		query := report
+		if nilOr(where.UseServiceWindow, false) && fvsw != nil {
+			query = mapIntoServiceWindow(report, fvsw).Val
+		}
+		key := query.Format("2006-01-02")
+		i, ok := at[key]
+		if !ok {
+			i = len(out)
+			at[key] = i
+			out = append(out, tripDate{query: query})
+		}
+		out[i].report = append(out[i].report, report)
+	}
+	return out
+}
+
 // Split the aggregated service_dates column into the per-trip list the API
-// returns. A no-op unless the query filtered on service_dates.
-func expandTripServiceDates(ents []*model.Trip) {
+// returns, relabelled as the dates the caller asked about.
+func expandTripServiceDates(ents []*model.Trip, dates []tripDate) {
+	if len(dates) == 0 {
+		return
+	}
+	report := map[string][]time.Time{}
+	for _, d := range dates {
+		report[d.query.Format("2006-01-02")] = d.report
+	}
 	for _, ent := range ents {
 		if !ent.ServiceDatesAgg.Valid || ent.ServiceDatesAgg.Val == "" {
 			continue
 		}
+		var matched []time.Time
 		for _, s := range strings.Split(ent.ServiceDatesAgg.Val, ",") {
-			d := tt.Date{}
-			if err := d.Scan(s); err == nil {
-				ent.ServiceDates = append(ent.ServiceDates, &d)
-			}
+			matched = append(matched, report[s]...)
+		}
+		sort.Slice(matched, func(i, j int) bool { return matched[i].Before(matched[j]) })
+		for _, m := range matched {
+			d := tt.NewDate(m)
+			ent.ServiceDates = append(ent.ServiceDates, &d)
 		}
 	}
 }
@@ -94,10 +149,11 @@ func (f *Finder) TripsByRouteIDs(ctx context.Context, limit *int, where *model.T
 		if err != nil {
 			return nil, err
 		}
-		inner, err := tripSelect(limit, nil, nil, false, f.PermFilter(ctx), where, fvsw)
+		inner, tripDates, err := tripSelect(limit, nil, nil, false, f.PermFilter(ctx), where, fvsw)
 		if err != nil {
 			return nil, err
 		}
+		var q []*model.Trip
 		if err := dbutil.Select(ctx,
 			f.db,
 			lateralWrap(
@@ -108,12 +164,15 @@ func (f *Finder) TripsByRouteIDs(ctx context.Context, limit *int, where *model.T
 				"route_id",
 				entityIds,
 			),
-			&ents,
+			&q,
 		); err != nil {
 			return nil, err
 		}
+		// Per feed version: each resolves the requested dates against its own
+		// service window.
+		expandTripServiceDates(q, tripDates)
+		ents = append(ents, q...)
 	}
-	expandTripServiceDates(ents)
 	return arrangeGroup(keys, ents, func(ent *model.Trip) model.FVPair {
 		return model.FVPair{FeedVersionID: ent.FeedVersionID, EntityID: ent.RouteID.Int()}
 	}), nil
@@ -131,10 +190,11 @@ func (f *Finder) TripsByShapeIDs(ctx context.Context, limit *int, where *model.T
 		if err != nil {
 			return nil, err
 		}
-		inner, err := tripSelect(limit, nil, nil, false, f.PermFilter(ctx), where, fvsw)
+		inner, tripDates, err := tripSelect(limit, nil, nil, false, f.PermFilter(ctx), where, fvsw)
 		if err != nil {
 			return nil, err
 		}
+		var q []*model.Trip
 		if err := dbutil.Select(ctx,
 			f.db,
 			lateralWrap(
@@ -145,12 +205,13 @@ func (f *Finder) TripsByShapeIDs(ctx context.Context, limit *int, where *model.T
 				"shape_id",
 				entityIds,
 			),
-			&ents,
+			&q,
 		); err != nil {
 			return nil, err
 		}
+		expandTripServiceDates(q, tripDates)
+		ents = append(ents, q...)
 	}
-	expandTripServiceDates(ents)
 	return arrangeGroup(keys, ents, func(ent *model.Trip) model.FVPair {
 		return model.FVPair{FeedVersionID: ent.FeedVersionID, EntityID: ent.ShapeID.Int()}
 	}), nil
@@ -163,7 +224,7 @@ func (f *Finder) TripsByFeedVersionIDs(ctx context.Context, limit *int, where *m
 		if err != nil {
 			return nil, err
 		}
-		inner, err := tripSelect(limit, nil, nil, false, f.PermFilter(ctx), where, fvsw)
+		inner, tripDates, err := tripSelect(limit, nil, nil, false, f.PermFilter(ctx), where, fvsw)
 		if err != nil {
 			return nil, err
 		}
@@ -183,13 +244,14 @@ func (f *Finder) TripsByFeedVersionIDs(ctx context.Context, limit *int, where *m
 		if err != nil {
 			return nil, err
 		}
+		expandTripServiceDates(q, tripDates)
 		ents = append(ents, q...)
 	}
-	expandTripServiceDates(ents)
 	return arrangeGroup(keys, ents, func(ent *model.Trip) int { return ent.FeedVersionID }), nil
 }
 
-func tripSelect(limit *int, after *model.Cursor, ids []int, active bool, permFilter *model.PermFilter, where *model.TripFilter, fvsw *model.ServiceWindow) (sq.SelectBuilder, error) {
+// Returns the query and how each matched service date should be reported.
+func tripSelect(limit *int, after *model.Cursor, ids []int, active bool, permFilter *model.PermFilter, where *model.TripFilter, fvsw *model.ServiceWindow) (sq.SelectBuilder, []tripDate, error) {
 	q := sq.StatementBuilder.Select(
 		"gtfs_trips.id",
 		"gtfs_trips.feed_version_id",
@@ -219,27 +281,25 @@ func tripSelect(limit *int, after *model.Cursor, ids []int, active bool, permFil
 		OrderBy("gtfs_trips.feed_version_id,gtfs_trips.id").
 		Limit(finderCheckLimit(limit))
 
-	// Process FVSW
-	if where != nil && fvsw != nil {
-		if where.RelativeDate != nil {
-			s, err := tt.RelativeDate(fvsw.NowLocal, kebabize(string(*where.RelativeDate)))
-			if err != nil {
-				return q, fmt.Errorf("invalid relative_date %q: %w", *where.RelativeDate, err)
-			}
-			where.ServiceDate = tzTruncate(s, fvsw.NowLocal.Location())
-		}
-		if where.UseServiceWindow != nil && *where.UseServiceWindow {
-			// Guarded: use_service_window with no date at all is a valid filter.
-			if where.ServiceDate != nil {
-				where.ServiceDate = mapIntoServiceWindow(where.ServiceDate.Val, fvsw)
-			}
-			for i, d := range where.ServiceDates {
-				if d != nil {
-					where.ServiceDates[i] = mapIntoServiceWindow(d.Val, fvsw)
+	// Resolved into a local: `where` is reused for every feed version.
+	var serviceDate *tt.Date
+	if where != nil {
+		serviceDate = where.ServiceDate
+		if fvsw != nil {
+			if where.RelativeDate != nil {
+				s, err := tt.RelativeDate(fvsw.NowLocal, kebabize(string(*where.RelativeDate)))
+				if err != nil {
+					return q, nil, fmt.Errorf("invalid relative_date %q: %w", *where.RelativeDate, err)
 				}
+				serviceDate = tzTruncate(s, fvsw.NowLocal.Location())
+			}
+			// Guarded: use_service_window with no date at all is a valid filter.
+			if nilOr(where.UseServiceWindow, false) && serviceDate != nil {
+				serviceDate = mapIntoServiceWindow(serviceDate.Val, fvsw)
 			}
 		}
 	}
+	tripDates := resolveTripDates(where, fvsw)
 
 	// Process other parameters
 	if where != nil {
@@ -264,15 +324,12 @@ func tripSelect(limit *int, after *model.Cursor, ids []int, active bool, permFil
 		if len(where.RouteIds) > 0 {
 			q = q.Where(In("gtfs_trips.route_id", where.RouteIds))
 		}
-		if len(where.ServiceDates) > 0 {
-			// One row per trip carrying the requested dates it runs, instead of
-			// one query per date. Aggregated as text because the dates ride back
-			// on a single column; the finder splits them into ServiceDates.
+		if len(tripDates) > 0 {
+			// One row per trip carrying the dates it runs, instead of one query
+			// per date. Aggregated as text to ride back on a single column.
 			var dates []string
-			for _, d := range where.ServiceDates {
-				if d != nil {
-					dates = append(dates, d.Val.Format("2006-01-02"))
-				}
+			for _, d := range tripDates {
+				dates = append(dates, d.query.Format("2006-01-02"))
 			}
 			q = q.Column("svc.service_dates_agg").JoinClause(`
 			join lateral (
@@ -296,8 +353,8 @@ func tripSelect(limit *int, after *model.Cursor, ids []int, active bool, permFil
 					AND gcdb.date is null
 			) svc on true
 			`, strings.Join(dates, ",")).Where("svc.service_dates_agg is not null")
-		} else if where.ServiceDate != nil {
-			serviceDate := where.ServiceDate.Val
+		} else if serviceDate != nil {
+			sd := serviceDate.Val
 			q = q.JoinClause(`
 			join lateral (
 				select gc.id
@@ -321,7 +378,7 @@ func tripSelect(limit *int, after *model.Cursor, ids []int, active bool, permFil
 					AND gcdb.date is null
 				LIMIT 1
 			) gc on true
-			`, serviceDate, serviceDate, serviceDate, serviceDate, serviceDate)
+			`, sd, sd, sd, sd, sd)
 		}
 		// Handle license filtering
 		q = licenseFilter(where.License, q)
@@ -345,5 +402,5 @@ func tripSelect(limit *int, after *model.Cursor, ids []int, active bool, permFil
 	// Handle permissions
 	q = joinImported(q)
 	q = pfJoinCheckFv(q, permFilter)
-	return q, nil
+	return q, tripDates, nil
 }

--- a/server/finders/dbfinder/trip.go
+++ b/server/finders/dbfinder/trip.go
@@ -58,14 +58,19 @@ func (f *Finder) FrequenciesByTripIDs(ctx context.Context, limit *int, keys []in
 // Replaces a date outside the feed version's service window with the same
 // weekday in its fallback week.
 func mapIntoServiceWindow(s time.Time, fvsw *model.ServiceWindow) *tt.Date {
-	if !s.Before(fvsw.StartDate) && !s.After(fvsw.EndDate) {
-		return tzTruncate(s, fvsw.NowLocal.Location())
+	loc := fvsw.NowLocal.Location()
+	// Compared in the feed version's timezone. The window's dates are local
+	// midnight and a date scalar parses as midnight UTC, so comparing the two
+	// as given puts the first or last day of the window outside it.
+	local := tzTruncate(s, loc)
+	if !local.Val.Before(fvsw.StartDate) && !local.Val.After(fvsw.EndDate) {
+		return local
 	}
-	dow := int(s.Weekday()) - 1
+	dow := int(local.Val.Weekday()) - 1
 	if dow < 0 {
 		dow = 6
 	}
-	return tzTruncate(fvsw.FallbackWeek.AddDate(0, 0, dow), fvsw.NowLocal.Location())
+	return tzTruncate(fvsw.FallbackWeek.AddDate(0, 0, dow), loc)
 }
 
 // tripDate is a service date to match in the database and the dates it is

--- a/server/finders/dbfinder/trip_test.go
+++ b/server/finders/dbfinder/trip_test.go
@@ -1,0 +1,175 @@
+package dbfinder
+
+import (
+	"testing"
+	"time"
+
+	"github.com/interline-io/transitland-lib/server/model"
+	"github.com/interline-io/transitland-lib/tt"
+	"github.com/stretchr/testify/assert"
+)
+
+func testDate(t *testing.T, s string) time.Time {
+	t.Helper()
+	v, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return v
+}
+
+func testDates(t *testing.T, dates ...string) []*tt.Date {
+	t.Helper()
+	var out []*tt.Date
+	for _, d := range dates {
+		out = append(out, ptr(tt.NewDate(testDate(t, d))))
+	}
+	return out
+}
+
+// A window covering one week, whose fallback week is the same Monday-Sunday.
+func testServiceWindow(t *testing.T) *model.ServiceWindow {
+	t.Helper()
+	return &model.ServiceWindow{
+		NowLocal:     testDate(t, "2026-05-13"),
+		StartDate:    testDate(t, "2026-05-11"),
+		EndDate:      testDate(t, "2026-05-17"),
+		FallbackWeek: testDate(t, "2026-05-11"),
+	}
+}
+
+func TestResolveTripDates(t *testing.T) {
+	fmtPairs := func(dates []tripDate) []string {
+		var out []string
+		for _, d := range dates {
+			s := d.query.Format("2006-01-02") + " ->"
+			for _, r := range d.report {
+				s += " " + r.Format("2006-01-02")
+			}
+			out = append(out, s)
+		}
+		return out
+	}
+	tcs := []struct {
+		name   string
+		where  *model.TripFilter
+		fvsw   *model.ServiceWindow
+		expect []string
+	}{
+		{"no filter", nil, nil, nil},
+		{"no dates", &model.TripFilter{}, nil, nil},
+		{
+			// service_dates are matched as given: no lookback, so nothing
+			// outside the requested set comes back.
+			"service_dates are exact",
+			&model.TripFilter{ServiceDates: testDates(t, "2026-05-13", "2026-05-12")}, nil,
+			[]string{"2026-05-12 -> 2026-05-12", "2026-05-13 -> 2026-05-13"},
+		},
+		{
+			"dates reach back for after-midnight departures",
+			&model.TripFilter{Dates: testDates(t, "2026-05-13")}, nil,
+			[]string{"2026-05-12 -> 2026-05-12", "2026-05-13 -> 2026-05-13"},
+		},
+		{
+			"dates take precedence over service_dates",
+			&model.TripFilter{
+				Dates:        testDates(t, "2026-05-13"),
+				ServiceDates: testDates(t, "2026-01-01"),
+			}, nil,
+			[]string{"2026-05-12 -> 2026-05-12", "2026-05-13 -> 2026-05-13"},
+		},
+		{
+			"use_service_window without a window is inert",
+			&model.TripFilter{ServiceDates: testDates(t, "2030-01-01"), UseServiceWindow: ptr(true)}, nil,
+			[]string{"2030-01-01 -> 2030-01-01"},
+		},
+		{
+			"dates inside the window are not relocated",
+			&model.TripFilter{ServiceDates: testDates(t, "2026-05-13"), UseServiceWindow: ptr(true)}, testServiceWindow(t),
+			[]string{"2026-05-13 -> 2026-05-13"},
+		},
+		{
+			// 2030-01-02 is a Wednesday, relocating to the fallback week's
+			// Wednesday; the caller still gets back the date it asked about.
+			"dates outside the window relocate but report as requested",
+			&model.TripFilter{ServiceDates: testDates(t, "2030-01-02"), UseServiceWindow: ptr(true)}, testServiceWindow(t),
+			[]string{"2026-05-13 -> 2030-01-02"},
+		},
+		{
+			// Two Wednesdays collapse onto one fallback day, which must expand
+			// back to both rather than being queried or reported twice.
+			"same weekday collapses to one query date",
+			&model.TripFilter{ServiceDates: testDates(t, "2030-01-02", "2030-01-09"), UseServiceWindow: ptr(true)}, testServiceWindow(t),
+			[]string{"2026-05-13 -> 2030-01-02 2030-01-09"},
+		},
+		{
+			// The lookback runs before relocation, so the preceding day maps by
+			// its own weekday: Tuesday 2030-01-01 to the fallback Tuesday.
+			"lookback relocates independently of the requested date",
+			&model.TripFilter{Dates: testDates(t, "2030-01-02"), UseServiceWindow: ptr(true)}, testServiceWindow(t),
+			[]string{"2026-05-12 -> 2030-01-01", "2026-05-13 -> 2030-01-02"},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expect, fmtPairs(resolveTripDates(tc.where, tc.fvsw)))
+		})
+	}
+}
+
+func TestExpandTripServiceDates(t *testing.T) {
+	trip := func(agg string) *model.Trip {
+		ent := &model.Trip{}
+		if agg != "" {
+			ent.ServiceDatesAgg.Set(agg)
+		}
+		return ent
+	}
+	got := func(ent *model.Trip) []string {
+		var out []string
+		for _, d := range ent.ServiceDates {
+			out = append(out, d.Val.Format("2006-01-02"))
+		}
+		return out
+	}
+
+	t.Run("relabels database dates as requested dates", func(t *testing.T) {
+		dates := resolveTripDates(
+			&model.TripFilter{ServiceDates: testDates(t, "2030-01-02"), UseServiceWindow: ptr(true)},
+			testServiceWindow(t),
+		)
+		ent := trip("2026-05-13")
+		expandTripServiceDates([]*model.Trip{ent}, dates)
+		assert.Equal(t, []string{"2030-01-02"}, got(ent))
+	})
+
+	t.Run("expands one database date into every date it stands for", func(t *testing.T) {
+		dates := resolveTripDates(
+			&model.TripFilter{ServiceDates: testDates(t, "2030-01-09", "2030-01-02"), UseServiceWindow: ptr(true)},
+			testServiceWindow(t),
+		)
+		ent := trip("2026-05-13")
+		expandTripServiceDates([]*model.Trip{ent}, dates)
+		assert.Equal(t, []string{"2030-01-02", "2030-01-09"}, got(ent))
+	})
+
+	t.Run("sorts across database dates", func(t *testing.T) {
+		dates := resolveTripDates(&model.TripFilter{ServiceDates: testDates(t, "2026-05-13", "2026-05-11")}, nil)
+		ent := trip("2026-05-13,2026-05-11")
+		expandTripServiceDates([]*model.Trip{ent}, dates)
+		assert.Equal(t, []string{"2026-05-11", "2026-05-13"}, got(ent))
+	})
+
+	t.Run("no dates requested", func(t *testing.T) {
+		ent := trip("2026-05-13")
+		expandTripServiceDates([]*model.Trip{ent}, nil)
+		assert.Nil(t, got(ent))
+	})
+
+	t.Run("trip matched no dates", func(t *testing.T) {
+		dates := resolveTripDates(&model.TripFilter{ServiceDates: testDates(t, "2026-05-13")}, nil)
+		ent := trip("")
+		expandTripServiceDates([]*model.Trip{ent}, dates)
+		assert.Nil(t, got(ent))
+	})
+}

--- a/server/finders/dbfinder/trip_test.go
+++ b/server/finders/dbfinder/trip_test.go
@@ -38,6 +38,28 @@ func testServiceWindow(t *testing.T) *model.ServiceWindow {
 	}
 }
 
+// The callers build one filter and hand it to tripSelect once per feed version,
+// so resolving a date must not write back into it: the next feed version would
+// then resolve an already-relocated date against its own window. End to end this
+// is nearly invisible, because relocation preserves the weekday and a route on a
+// weekday calendar returns the same trips either way, so assert it directly.
+func TestTripSelectDoesNotModifyFilter(t *testing.T) {
+	requested := testDates(t, "2030-01-02")[0]
+	where := &model.TripFilter{
+		ServiceDate:      ptr(*requested),
+		UseServiceWindow: ptr(true),
+	}
+	// A window that excludes the requested date, so it is certain to relocate.
+	fvsw := testServiceWindow(t)
+	for i := 0; i < 2; i++ {
+		if _, _, err := tripSelect(nil, nil, nil, false, nil, where, fvsw); err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, requested.Val.Format("2006-01-02"), where.ServiceDate.Val.Format("2006-01-02"),
+			"filter was rewritten on pass %d", i)
+	}
+}
+
 func TestMapIntoServiceWindow(t *testing.T) {
 	// A feed version's window carries local midnight, while a date scalar
 	// parses as midnight UTC. West of UTC the requested day then sorts before

--- a/server/finders/dbfinder/trip_test.go
+++ b/server/finders/dbfinder/trip_test.go
@@ -38,6 +38,40 @@ func testServiceWindow(t *testing.T) *model.ServiceWindow {
 	}
 }
 
+func TestMapIntoServiceWindow(t *testing.T) {
+	// A feed version's window carries local midnight, while a date scalar
+	// parses as midnight UTC. West of UTC the requested day then sorts before
+	// the window's first day; east of it, after the window's last day. Either
+	// way an in-window boundary day would be relocated.
+	for _, tz := range []string{"America/Los_Angeles", "Asia/Kolkata", "UTC"} {
+		loc, err := time.LoadLocation(tz)
+		if err != nil {
+			t.Fatal(err)
+		}
+		day := func(y int, m time.Month, d int) time.Time { return time.Date(y, m, d, 0, 0, 0, 0, loc) }
+		fvsw := &model.ServiceWindow{
+			NowLocal:     time.Date(2026, 5, 13, 9, 30, 0, 0, loc),
+			StartDate:    day(2026, 5, 11), // Monday
+			EndDate:      day(2026, 5, 17), // Sunday
+			FallbackWeek: day(2026, 3, 2),  // Monday
+		}
+		tcs := []struct{ name, in, expect string }{
+			{"first day of the window is inside it", "2026-05-11", "2026-05-11"},
+			{"last day of the window is inside it", "2026-05-17", "2026-05-17"},
+			{"mid-window is unchanged", "2026-05-13", "2026-05-13"},
+			// 2026-01-05 is a Monday, 2027-01-09 a Saturday.
+			{"before the window takes the fallback weekday", "2026-01-05", "2026-03-02"},
+			{"after the window takes the fallback weekday", "2027-01-09", "2026-03-07"},
+		}
+		for _, tc := range tcs {
+			t.Run(tz+"/"+tc.name, func(t *testing.T) {
+				got := mapIntoServiceWindow(testDate(t, tc.in), fvsw)
+				assert.Equal(t, tc.expect, got.Val.Format("2006-01-02"))
+			})
+		}
+	}
+}
+
 func TestResolveTripDates(t *testing.T) {
 	fmtPairs := func(dates []tripDate) []string {
 		var out []string

--- a/server/gql/resolver.go
+++ b/server/gql/resolver.go
@@ -20,9 +20,8 @@ const (
 	RESOLVER_LOCATION_MAXLIMIT         = 100_000
 	RESOLVER_SEGMENT_MAXLIMIT          = 100_000
 	RESOLVER_SHAPE_MAXLIMIT            = 100_000
-	// Bulk timetable extraction reads a route's trips over a date range. A busy
-	// route runs close to 1,000 trips in a single week, so the default limit
-	// truncates without an error as soon as the range is longer than that.
+	// A busy route runs close to 1,000 trips in a week, so the default limit
+	// truncates a multi-week range without an error.
 	RESOLVER_TRIP_MAXLIMIT = 100_000
 )
 

--- a/server/gql/resolver.go
+++ b/server/gql/resolver.go
@@ -20,6 +20,10 @@ const (
 	RESOLVER_LOCATION_MAXLIMIT         = 100_000
 	RESOLVER_SEGMENT_MAXLIMIT          = 100_000
 	RESOLVER_SHAPE_MAXLIMIT            = 100_000
+	// Bulk timetable extraction reads a route's trips over a date range. A busy
+	// route runs close to 1,000 trips in a single week, so the default limit
+	// truncates without an error as soon as the range is longer than that.
+	RESOLVER_TRIP_MAXLIMIT = 100_000
 )
 
 // RESOLVER_MAXLIMIT is the API limit maximum

--- a/server/gql/route_resolver.go
+++ b/server/gql/route_resolver.go
@@ -36,7 +36,7 @@ func (r *routeResolver) Geometries(ctx context.Context, obj *model.Route, limit 
 }
 
 func (r *routeResolver) Trips(ctx context.Context, obj *model.Route, limit *int, where *model.TripFilter) ([]*model.Trip, error) {
-	return LoaderFor(ctx).TripsByRouteIDs.Load(ctx, tripLoaderParam{RouteID: obj.ID, FeedVersionID: obj.FeedVersionID, Limit: resolverCheckLimit(limit), Where: where})()
+	return LoaderFor(ctx).TripsByRouteIDs.Load(ctx, tripLoaderParam{RouteID: obj.ID, FeedVersionID: obj.FeedVersionID, Limit: resolverCheckLimitMax(limit, RESOLVER_TRIP_MAXLIMIT), Where: where})()
 }
 
 func (r *routeResolver) Agency(ctx context.Context, obj *model.Route) (*model.Agency, error) {

--- a/server/gql/route_resolver_service_window_test.go
+++ b/server/gql/route_resolver_service_window_test.go
@@ -1,0 +1,74 @@
+package gql
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+)
+
+// The trip counterpart of TestStopResolver_ServiceWindowIsPerFeedVersion, and
+// the same shape of defect: Route.trips groups its routes by feed version and
+// loops, and each pass both resolves the requested date against that feed
+// version's own service window and accumulates its rows. Sharing either the
+// filter or the destination slice across passes loses results, and which
+// results depends on map iteration order — so the same request answers
+// differently from one call to the next.
+//
+// 2018-05-29 falls inside BA's service window; CT has none covering it and
+// relocates the date into its fallback week.
+func TestRouteResolver_TripsAcrossFeedVersions(t *testing.T) {
+	c, _ := newTestClient(t)
+
+	query := func(q string) string {
+		var resp map[string]interface{}
+		if err := c.Post(q, &resp); err != nil {
+			t.Fatal(err)
+		}
+		return toJson(resp)
+	}
+	// Resolved rather than hardcoded: these are unstable database ids.
+	routeID := func(feed string, gtfsRouteID string) string {
+		j := query(`query{routes(where:{feed_onestop_id:"` + feed + `", route_id:"` + gtfsRouteID + `"}){id}}`)
+		id := gjson.Get(j, "routes.0.id")
+		if !id.Exists() {
+			t.Fatalf("fixture route %s:%s not found", feed, gtfsRouteID)
+		}
+		return id.String()
+	}
+	inWindow := routeID("BA", "01")
+	relocates := routeID("CT", "Bu-130")
+
+	// The trips of one route out of a request covering all the given routes.
+	trips := func(want string, ids ...string) string {
+		j := query(`query{routes(ids:[` + strings.Join(ids, ",") + `]){
+			id trips(limit:5, where:{service_date:"` + serviceWindowDate + `", use_service_window:true}){ trip_id }
+		}}`)
+		for _, r := range gjson.Get(j, "routes").Array() {
+			if r.Get("id").String() == want {
+				return r.Get("trips.#.trip_id").Raw
+			}
+		}
+		t.Fatalf("route %s missing from response %s", want, j)
+		return ""
+	}
+
+	// The answer when nothing else shares the request.
+	alone := trips(inWindow, inWindow)
+	assert.NotEqual(t, "[]", alone, "fixture route should run on the requested date")
+
+	// The premise: the other route's feed version really does resolve the date
+	// differently. Without this the test can keep passing while asserting
+	// nothing, if the fixtures' service windows ever drift.
+	assert.NotEqual(t, "[]", trips(relocates, relocates),
+		"fixture should include a second feed version that returns trips for this date")
+
+	// Asking for both must not change either one's answer, and must not change
+	// it differently from one call to the next.
+	for i := 0; i < 10; i++ {
+		if !assert.JSONEq(t, alone, trips(inWindow, inWindow, relocates), "run %d differs from the single-route query", i) {
+			t.FailNow()
+		}
+	}
+}

--- a/server/gql/stop_resolver.go
+++ b/server/gql/stop_resolver.go
@@ -2,7 +2,6 @@ package gql
 
 import (
 	"context"
-	"errors"
 	"sort"
 	"strconv"
 	"time"
@@ -101,10 +100,6 @@ func (r *stopResolver) StopTimes(ctx context.Context, obj *model.Stop, limit *in
 }
 
 func (r *stopResolver) getStopTimes(ctx context.Context, obj *model.Stop, limit *int, where *model.StopTimeFilter) ([]*model.StopTime, error) {
-	// A folded row covers several dates; a real-time estimate belongs to one.
-	if where != nil && len(where.ServiceDates) > 1 && (containsField(ctx, "arrival") || containsField(ctx, "departure")) {
-		return nil, errors.New("arrival and departure are per-instance and cannot be selected with more than one service_dates entry")
-	}
 	sts, err := (LoaderFor(ctx).StopTimesByStopIDs.Load(ctx, stopTimeLoaderParam{
 		StopID:        obj.ID,
 		FeedVersionID: obj.FeedVersionID,

--- a/server/gql/stop_resolver.go
+++ b/server/gql/stop_resolver.go
@@ -101,8 +101,7 @@ func (r *stopResolver) StopTimes(ctx context.Context, obj *model.Stop, limit *in
 }
 
 func (r *stopResolver) getStopTimes(ctx context.Context, obj *model.Stop, limit *int, where *model.StopTimeFilter) ([]*model.StopTime, error) {
-	// A folded row covers several dates, but an estimate belongs to one trip on
-	// one date. Refuse rather than return a prediction for an unstated date.
+	// A folded row covers several dates; a real-time estimate belongs to one.
 	if where != nil && len(where.ServiceDates) > 1 && (containsField(ctx, "arrival") || containsField(ctx, "departure")) {
 		return nil, errors.New("arrival and departure are per-instance and cannot be selected with more than one service_dates entry")
 	}

--- a/server/gql/stop_resolver.go
+++ b/server/gql/stop_resolver.go
@@ -2,6 +2,7 @@ package gql
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"strconv"
 	"time"
@@ -100,6 +101,11 @@ func (r *stopResolver) StopTimes(ctx context.Context, obj *model.Stop, limit *in
 }
 
 func (r *stopResolver) getStopTimes(ctx context.Context, obj *model.Stop, limit *int, where *model.StopTimeFilter) ([]*model.StopTime, error) {
+	// A folded row covers several dates, but an estimate belongs to one trip on
+	// one date. Refuse rather than return a prediction for an unstated date.
+	if where != nil && len(where.ServiceDates) > 1 && (containsField(ctx, "arrival") || containsField(ctx, "departure")) {
+		return nil, errors.New("arrival and departure are per-instance and cannot be selected with more than one service_dates entry")
+	}
 	sts, err := (LoaderFor(ctx).StopTimesByStopIDs.Load(ctx, stopTimeLoaderParam{
 		StopID:        obj.ID,
 		FeedVersionID: obj.FeedVersionID,

--- a/server/gql/trip_resolver_test.go
+++ b/server/gql/trip_resolver_test.go
@@ -95,6 +95,44 @@ func TestTripResolver(t *testing.T) {
 			selector:     "trips.#.trip_id",
 			selectExpect: []string{"101", "103", "305", "207", "309", "211", "313", "215", "217", "319", "221", "323", "225", "227", "329", "231", "233", "135", "237", "139", "143", "147", "151", "155", "257", "159", "261", "263", "365", "267", "269", "371", "273", "375", "277", "279", "381", "283", "385", "287", "289", "191", "193", "195", "197", "199", "102", "104", "206", "208", "310", "212", "314", "216", "218", "320", "222", "324", "226", "228", "330", "232", "134", "236", "138", "142", "146", "150", "152", "254", "156", "258", "360", "262", "264", "366", "268", "370", "272", "274", "376", "278", "380", "282", "284", "386", "288", "190", "192", "194", "196", "198"},
 		},
+		// service_dates and dates. Trip 101 runs Monday-Friday, trip 422
+		// Saturday and Sunday; 2018-05-28 is a Monday.
+		{
+			name:   "where service_dates",
+			query:  `query{trips(where:{trip_id:"101",service_dates:["2018-05-29","2018-05-30"]}){trip_id service_dates}}`,
+			expect: `{"trips":[{"service_dates":["2018-05-29","2018-05-30"],"trip_id":"101"}]}`,
+		},
+		{
+			// service_dates match exactly: the preceding day is not brought in,
+			// whether or not the trip runs on it.
+			name:   "where service_dates does not reach back",
+			query:  `query{trips(where:{trip_id:"101",service_dates:["2018-05-29"]}){service_dates}}`,
+			expect: `{"trips":[{"service_dates":["2018-05-29"]}]}`,
+		},
+		{
+			// dates also match the preceding service date, whose after-midnight
+			// departures fall on the requested calendar day.
+			name:   "where dates reaches back one service date",
+			query:  `query{trips(where:{trip_id:"101",dates:["2018-05-29"]}){service_dates}}`,
+			expect: `{"trips":[{"service_dates":["2018-05-28","2018-05-29"]}]}`,
+		},
+		{
+			// A weekend trip is selected for Monday purely by that reach-back,
+			// and reports only the Sunday it actually runs.
+			name:   "where dates selects a trip through the reach-back alone",
+			query:  `query{trips(where:{trip_id:"422",dates:["2018-05-28"]}){service_dates}}`,
+			expect: `{"trips":[{"service_dates":["2018-05-27"]}]}`,
+		},
+		{
+			name:   "where service_dates does not select that trip",
+			query:  `query{trips(where:{trip_id:"422",service_dates:["2018-05-28"]}){service_dates}}`,
+			expect: `{"trips":[]}`,
+		},
+		{
+			name:   "where dates takes precedence over service_dates",
+			query:  `query{trips(where:{trip_id:"101",dates:["2018-05-29"],service_dates:["2018-05-31"]}){service_dates}}`,
+			expect: `{"trips":[{"service_dates":["2018-05-28","2018-05-29"]}]}`,
+		},
 		// license
 		{
 			name:         "license filter: share_alike_optional = yes",

--- a/server/model/models.go
+++ b/server/model/models.go
@@ -111,10 +111,8 @@ type RTStopTimeUpdate struct {
 }
 
 type StopTime struct {
-	ServiceDate tt.Date
-	Date        tt.Date
-	// Every requested date this departure runs.
-	ServiceDates     []tt.Date
+	ServiceDate      tt.Date
+	Date             tt.Date
 	RTTripID         string            // internal: for ADDED trips
 	RTStopTimeUpdate *RTStopTimeUpdate // internal
 	gtfs.StopTime

--- a/server/model/models.go
+++ b/server/model/models.go
@@ -97,6 +97,11 @@ type Route struct {
 
 type Trip struct {
 	RTTripID string // internal: for ADDED trips
+	// Set only for `service_dates` queries: every requested date this trip runs.
+	ServiceDates []*tt.Date
+	// Wire format for the above — the query aggregates the dates into one
+	// comma-separated column, which the finder splits into ServiceDates.
+	ServiceDatesAgg tt.String `db:"service_dates_agg"`
 	gtfs.Trip
 }
 

--- a/server/model/models.go
+++ b/server/model/models.go
@@ -97,10 +97,9 @@ type Route struct {
 
 type Trip struct {
 	RTTripID string // internal: for ADDED trips
-	// Set only for `service_dates` queries: every requested date this trip runs.
+	// Every requested date this trip runs.
 	ServiceDates []*tt.Date
-	// Wire format for the above — the query aggregates the dates into one
-	// comma-separated column, which the finder splits into ServiceDates.
+	// Wire format for ServiceDates: one comma-separated column.
 	ServiceDatesAgg tt.String `db:"service_dates_agg"`
 	gtfs.Trip
 }
@@ -114,8 +113,7 @@ type RTStopTimeUpdate struct {
 type StopTime struct {
 	ServiceDate tt.Date
 	Date        tt.Date
-	// Set only for `service_dates` queries: every requested date this departure
-	// runs, folded into one row instead of one row per date.
+	// Every requested date this departure runs.
 	ServiceDates     []tt.Date
 	RTTripID         string            // internal: for ADDED trips
 	RTStopTimeUpdate *RTStopTimeUpdate // internal

--- a/server/model/models.go
+++ b/server/model/models.go
@@ -107,8 +107,11 @@ type RTStopTimeUpdate struct {
 }
 
 type StopTime struct {
-	ServiceDate      tt.Date
-	Date             tt.Date
+	ServiceDate tt.Date
+	Date        tt.Date
+	// Set only for `service_dates` queries: every requested date this departure
+	// runs, folded into one row instead of one row per date.
+	ServiceDates     []tt.Date
 	RTTripID         string            // internal: for ADDED trips
 	RTStopTimeUpdate *RTStopTimeUpdate // internal
 	gtfs.StopTime

--- a/server/model/models.go
+++ b/server/model/models.go
@@ -97,7 +97,8 @@ type Route struct {
 
 type Trip struct {
 	RTTripID string // internal: for ADDED trips
-	// Every requested date this trip runs.
+	// Every service date matched by a dates or service_dates query. Under
+	// `dates` this reaches one day before the earliest requested date.
 	ServiceDates []*tt.Date
 	// Wire format for ServiceDates: one comma-separated column.
 	ServiceDatesAgg tt.String `db:"service_dates_agg"`

--- a/server/model/models_gen.go
+++ b/server/model/models_gen.go
@@ -1476,6 +1476,8 @@ type StopTimeFilter struct {
 	RelativeDate *RelativeDate `json:"relative_date,omitempty"`
 	// GTFS service date (which may differ from the calendar date for trips that cross midnight)
 	ServiceDate *tt.Date `json:"service_date,omitempty"`
+	// Several GTFS service dates, which need not be contiguous. Returns one row per departure with every matching date in `service_dates`, rather than repeating the row once per date. Intended for bulk timetable extraction; real-time fields cannot be selected alongside more than one date.
+	ServiceDates []*tt.Date `json:"service_dates,omitempty"`
 	// If true and the requested date falls outside the feed version's normal service window, use the feed version's `fallback_week` instead
 	UseServiceWindow *bool `json:"use_service_window,omitempty"`
 	// Lower bound for departure time, in seconds since midnight

--- a/server/model/models_gen.go
+++ b/server/model/models_gen.go
@@ -1516,6 +1516,8 @@ type Tenant struct {
 type TripFilter struct {
 	// GTFS service date on which trips run
 	ServiceDate *tt.Date `json:"service_date,omitempty"`
+	// Several GTFS service dates, which need not be contiguous. Returns each trip once, with the matching dates in `Trip.service_dates`, rather than requiring one query per date.
+	ServiceDates []*tt.Date `json:"service_dates,omitempty"`
 	// Calendar date relative to today; see `RelativeDate`
 	RelativeDate *RelativeDate `json:"relative_date,omitempty"`
 	// If true and the requested date falls outside the feed version's normal service window, use the feed version's `fallback_week` instead
@@ -1542,6 +1544,8 @@ type TripStopTimeFilter struct {
 	Start *tt.Seconds `json:"start,omitempty"`
 	// Upper bound for arrival time, in local `HH:MM:SS`
 	End *tt.Seconds `json:"end,omitempty"`
+	// Restrict to stop times at these stops (database integer IDs)
+	StopIds []int `json:"stop_ids,omitempty"`
 }
 
 // A user in the authorization system

--- a/server/model/models_gen.go
+++ b/server/model/models_gen.go
@@ -1476,8 +1476,6 @@ type StopTimeFilter struct {
 	RelativeDate *RelativeDate `json:"relative_date,omitempty"`
 	// GTFS service date (which may differ from the calendar date for trips that cross midnight)
 	ServiceDate *tt.Date `json:"service_date,omitempty"`
-	// Several GTFS service dates, which need not be contiguous. Returns one row per departure with every matching date in `service_dates`, rather than repeating the row once per date. Intended for bulk timetable extraction; real-time fields cannot be selected alongside more than one date.
-	ServiceDates []*tt.Date `json:"service_dates,omitempty"`
 	// If true and the requested date falls outside the feed version's normal service window, use the feed version's `fallback_week` instead
 	UseServiceWindow *bool `json:"use_service_window,omitempty"`
 	// Lower bound for departure time, in seconds since midnight
@@ -1518,7 +1516,7 @@ type TripFilter struct {
 	ServiceDate *tt.Date `json:"service_date,omitempty"`
 	// Several GTFS service dates, which need not be contiguous. Returns each trip once, with the matching dates in `Trip.service_dates`, rather than requiring one query per date.
 	ServiceDates []*tt.Date `json:"service_dates,omitempty"`
-	// Several wall calendar dates, which need not be contiguous. Unlike `service_dates` these are calendar days rather than GTFS service days, so a trip departing after midnight is selected for the calendar date it actually departs on: each requested date also matches the service date before it, whose late-night departures roll over. `Trip.service_dates` reports the service dates matched, from which each departure's calendar date is `service_date + floor(departure_time / 86400)`. Departures more than 48 hours into their service date are not reached.
+	// Several wall calendar dates, which need not be contiguous. Unlike `service_dates`, a trip departing after midnight is matched for the calendar date it departs on, so each requested date also matches the service date before it. Departures more than 48 hours into their service date are not reached.
 	Dates []*tt.Date `json:"dates,omitempty"`
 	// Calendar date relative to today; see `RelativeDate`
 	RelativeDate *RelativeDate `json:"relative_date,omitempty"`

--- a/server/model/models_gen.go
+++ b/server/model/models_gen.go
@@ -1518,6 +1518,8 @@ type TripFilter struct {
 	ServiceDate *tt.Date `json:"service_date,omitempty"`
 	// Several GTFS service dates, which need not be contiguous. Returns each trip once, with the matching dates in `Trip.service_dates`, rather than requiring one query per date.
 	ServiceDates []*tt.Date `json:"service_dates,omitempty"`
+	// Several wall calendar dates, which need not be contiguous. Unlike `service_dates` these are calendar days rather than GTFS service days, so a trip departing after midnight is selected for the calendar date it actually departs on: each requested date also matches the service date before it, whose late-night departures roll over. `Trip.service_dates` reports the service dates matched, from which each departure's calendar date is `service_date + floor(departure_time / 86400)`. Departures more than 48 hours into their service date are not reached.
+	Dates []*tt.Date `json:"dates,omitempty"`
 	// Calendar date relative to today; see `RelativeDate`
 	RelativeDate *RelativeDate `json:"relative_date,omitempty"`
 	// If true and the requested date falls outside the feed version's normal service window, use the feed version's `fallback_week` instead

--- a/server/model/models_gen.go
+++ b/server/model/models_gen.go
@@ -1512,13 +1512,13 @@ type Tenant struct {
 
 // Search options for trips
 type TripFilter struct {
-	// GTFS service date on which trips run
+	// GTFS service date on which trips run. Lowest precedence: ignored if `dates`, `service_dates` or `relative_date` is set
 	ServiceDate *tt.Date `json:"service_date,omitempty"`
-	// Several GTFS service dates, which need not be contiguous. Returns each trip once, with the matching dates in `Trip.service_dates`, rather than requiring one query per date.
+	// Several GTFS service dates, which need not be contiguous. Returns each trip once, with the matching dates in `Trip.service_dates`, rather than requiring one query per date. Dates are matched exactly as given: unlike `dates`, no neighbouring service date is brought in for after-midnight departures. Ignored if `dates` is set.
 	ServiceDates []*tt.Date `json:"service_dates,omitempty"`
-	// Several wall calendar dates, which need not be contiguous. Unlike `service_dates`, a trip departing after midnight is matched for the calendar date it departs on, so each requested date also matches the service date before it. Departures more than 48 hours into their service date are not reached.
+	// Several wall calendar dates, which need not be contiguous. Unlike `service_dates`, a trip departing after midnight is matched for the calendar date it departs on, so each requested date also matches the service date before it — and `Trip.service_dates` can therefore name a day earlier than any requested here. Departures more than 48 hours into their service date are not reached. Takes precedence over `service_date`, `service_dates` and `relative_date`.
 	Dates []*tt.Date `json:"dates,omitempty"`
-	// Calendar date relative to today; see `RelativeDate`
+	// Calendar date relative to today; see `RelativeDate`. Ignored if `dates` or `service_dates` is set
 	RelativeDate *RelativeDate `json:"relative_date,omitempty"`
 	// If true and the requested date falls outside the feed version's normal service window, use the feed version's `fallback_week` instead
 	UseServiceWindow *bool `json:"use_service_window,omitempty"`


### PR DESCRIPTION
## Summary

Adds a way to fetch schedule data in bulk without repeating a row per date, entered through routes rather than stops and selected by wall calendar day. `TripFilter.service_dates` selects trips active on any of a set of dates and reports which ones in a new `Trip.service_dates`, so a trip's identity and calendar are stated once rather than repeated on every stop time; `TripStopTimeFilter.stop_ids` keeps that selective when a route only clips a corner of the query area. `TripFilter.dates` selects the same shape by calendar day, so a trip departing after midnight is matched for the day it actually departs on.

The new API surface is opt-in and the existing single-date behavior is unchanged. Several correctness fixes in the same files are not opt-in, and are listed under Fixes and Impact below.

An equivalent stop-oriented form — `service_dates` on `StopTimeFilter`, folding the per-date rows in the finder — was built and measured first, and dropped from this PR. It works (2,810 departures over 100 stops and one week arrive as 558 rows, a 5.04x fold, for 73.1% fewer bytes) but it is dominated by the trip-oriented form on the same workload, and it folds after the per-date queries have already run, so it saves response size rather than database work. It also forces a request-time guard against selecting real-time fields alongside several dates, since a folded row covers dates that an estimate cannot. It is preserved on `exp-stop-time-service-dates` if a stop-entrypoint bulk form is ever wanted.

### Trip-oriented departures

- `TripFilter.service_dates: [Date!]` accepts several dates, which need not be contiguous. The date filter becomes a lateral that aggregates matching dates per trip in place of the previous existence check, and `Trip.service_dates` reports them.
- `TripStopTimeFilter.stop_ids: [Int!]` restricts a trip's stop times to a given set of stops. Without it a route crossing a small query area returns every stop on the route, so this is what keeps the trip-oriented shape selective.
- `Trip.stop_times` resolves through `stopTimeSelect`, which has no `active_services` CTE and none of the per-date machinery in `stopDeparturesSelect`. Selecting trips by date once and then fetching their stop times undated moves that work off the per-stop-per-date path.
- Measured over 6,412 stops, 91 routes and one week: this returns the same 2,135,106 departures in 54.75 MiB and 3.4s, against 309.65 MiB and 58.9s for seven aliased single-date stop queries.

### Wall calendar dates

`service_dates` selects GTFS service days, which is the wrong unit for a caller working in calendar days: a departure at 25:00 on service date S happens on calendar date S+1, and the day it departs on is the one a user means. `TripFilter.dates: [Date!]` selects by calendar day instead. `TripFilter` had no calendar-date field at all before this, so it is new surface rather than a rename, and `service_date` / `service_dates` are unchanged for callers that do want service days. The schema now states the resolution order between them: `dates` over `service_dates` over `relative_date` over `service_date`.

- A departure at time t on service date S falls on calendar date `S + floor(t / 86400)`. Inverting that, calendar date D is served by service dates `D-k` for k in `0..DepartureLookbackDays`. The constant is 1, covering departures up to 48:00; raising it covers services that run longer, at one more service date per query.
- Deduplicating the expansion collapses overlapping runs, so a week costs 8 service dates rather than 14, and `{2026-05-10, 2026-05-11, 2026-05-15}` costs 5.
- A trip cannot carry calendar dates directly — a trip departing 23:50 and arriving 24:10 contributes to two of them, and which one a given stop time belongs to depends on that stop time's `departure_time`. So `Trip.service_dates` carries service dates and the caller applies the same arithmetic per stop time, which is what keeps the compression: the translation is transmitted as a rule rather than as a date on every row. Under `dates` that list therefore reaches one day before the earliest requested date, which both the schema and the Go field now say.
- `Trip.service_dates` reports dates in the frame the query was expressed in. A date relocated into the feed version's fallback week by `use_service_window` comes back as the date that was asked for, not where it landed, since the fallback mapping is not invertible by the caller. Requested dates on the same weekday relocate to the same fallback day, and expand back to all of them.
- Verified against the stop-oriented path over a full week on a route with midnight-crossing trips: 44,732 departures, identical `(stop, calendar date, departure time, trip)` sets, no difference in either direction. Separately verified that a departure 80 hours into its service date is omitted rather than misfiled at `DepartureLookbackDays = 1`, and is attributed correctly at 3.

### Fixes

These are in the same files but independent of the new fields, and they change existing queries.

- **`TripsByRouteIDs` and `TripsByShapeIDs` discarded all but one feed version.** Each pass of the per-feed-version loop passed the same slice to `dbutil.Select`, which replaces its destination rather than appending, so only the feed version visited last survived and map iteration order picked it. Asking one request for a route in each of two feed versions returned one route's trips and dropped the other's on six of eight identical calls. This is very likely the same defect as the batched `Route.trips` truncation previously listed here as undiagnosed — the observed shortfall grew with batch size and vanished at one route per request, which is exactly the point at which a batch stops spanning feed versions — though that workload has not been re-measured to confirm it.
- **`tripSelect` rewrote `where.ServiceDate` in place**, so the second feed version in a loop resolved an already-relocated date against its own window. Now resolved into a local.
- **`mapIntoServiceWindow` compared dates across timezones.** A service window carries local midnight while a date scalar parses as midnight UTC, so the first day of a window sorted before it (west of UTC) or the last day sorted after it (east of UTC), and an in-window boundary day was relocated into the fallback week. The date is now truncated into the feed version's timezone before comparison, which is what the stop path already did.
- **`FindTrips` never called `expandTripServiceDates`**, so a top-level `trips(where: {service_dates: [...]})` returned the dates empty.
- **`tripSelect` panicked** when `use_service_window` was set without a date, dereferencing `where.ServiceDate` unconditionally.
- **`RESOLVER_TRIP_MAXLIMIT` (100,000) is applied to `Route.trips`**, which previously used the 1,000 default. TriMet's busiest route runs 994 trips in a single week and 3,725 across a service window, so any range longer than a week silently lost trips. Verified: that route over 21 dates now returns 1,970 trips where it previously stopped at exactly 1,000.

### Impact on existing consumers

REST is unaffected: its trip endpoint uses the top-level `trips(...)` query rather than `Route.trips`, no embedded query selects the new fields, and it renders through GraphQL field selection rather than marshalling `model.Trip`, so the two new struct fields cannot appear in its output. The top-level `trips` resolver keeps the 1,000 default.

Of the changes above, the three loop fixes only make results more complete or more stable — a caller either sees no difference or sees rows that were previously being dropped. The timezone fix is the only one that changes *which* trips come back rather than how many, and only on the first or last day of a feed version's service window. The limit raise is the only change that is a policy decision rather than a bug fix, and combined with the loop fixes it is the realistic path to a response becoming substantially larger than before.

## Limitations

- At `DepartureLookbackDays = 1`, departures more than 48 hours into their service date are omitted from a `dates` query. The existing stop-oriented path instead files everything in its `[24h, 100h]` look-behind one day later, so a departure at 80:35 lands two days early there. Omitting is the safer failure and is fixed by raising the constant, but it is a difference against current behavior for exactly those departures.
- A departure at exactly `24:00:00` is returned by the stop-oriented path on two calendar days: the requested day's window ends inclusively at 86400 and the next day's look-behind begins inclusively at 86400, so a query for one date comes back with rows the resolver itself labels as the previous date. Unchanged here, but it is the largest remaining difference between the two paths.
- Under `use_service_window`, the two paths disagree on what stands in for the day before the fallback week's Monday. The stop-oriented path takes the fallback Monday and subtracts a day, landing on a Sunday outside the service window; `dates` maps the requested Sunday by weekday, landing on the fallback week's own Sunday.
- `StopTimeFilter` has no `dates` counterpart. The stop-oriented path still expresses calendar dates through its hardcoded `date` expansion rather than the general form.
- `Trip.stop_times` does not expand frequencies, while `Stop.departures` does. A frequency-based trip therefore yields one departure through the trip-oriented shape where the stop-oriented shape yields the whole generated series.
- `Trip.stop_times` ignores its `limit`, and `Stop.stop_times` still uses the 1,000 default. Seven stops in the test fixture return exactly 1,000 for a one-week query. Neither is addressed here, but the first now sits under a `Route.trips` limit 100 times higher than before.

## Tests

Unit coverage for the date arithmetic: `calendarServiceDates` across lookbacks, gaps and month boundaries; `resolveTripDates` including the fallback-week collapse where two requested dates land on one day; `expandTripServiceDates` relabelling and many-to-one expansion; and `mapIntoServiceWindow` across three timezones, which fails on the boundary days if the comparison is not normalized.

Resolver coverage: `dates` versus `service_dates` semantics and their precedence, including a weekend trip selected for a Monday purely by the reach-back and the same query under `service_dates` selecting nothing. `TestRouteResolver_TripsAcrossFeedVersions` asks one request for routes in two feed versions and asserts neither answer changes across repeated calls.

`TestTripSelectDoesNotModifyFilter` covers the in-place rewrite directly rather than end to end, because relocation preserves the weekday and a route on a weekday calendar returns the same trips either way — the resolver test cannot see that defect, only the slice one.

Still manual: comparing a week of `dates` output against seven single-date `stop_times` queries for departure-level equality, and confirming a departure more than 48 hours into its service date is absent rather than misdated.
