### PR TITLE
Resolve stop time date filters per feed version

### DIFF
--- a/server/finders/dbfinder/stop_time.go
+++ b/server/finders/dbfinder/stop_time.go
@@ -81,8 +81,15 @@ func (f *Finder) stopTimesByEntityIDs(ctx context.Context, entityType stopTimeEn
 		if err != nil {
 			return nil, err
 		}
+		// Copied: the expansion rewrites the filter's date in place, and each
+		// feed version resolves it against its own service window.
+		fvWhere := where
+		if where != nil {
+			w := *where
+			fvWhere = &w
+		}
 		// Run separate queries for each possible service day
-		for _, w := range stopTimeFilterExpand(where, fvsw) {
+		for _, w := range stopTimeFilterExpand(fvWhere, fvsw) {
 			var serviceDate *tt.Date
 			if w != nil && w.ServiceDate != nil {
 				serviceDate = w.ServiceDate

--- a/server/gql/stop_resolver_service_window_test.go
+++ b/server/gql/stop_resolver_service_window_test.go
@@ -8,16 +8,23 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+// Fixture stops in feed versions that resolve 2018-05-29 differently: BA's
+// service window covers it, so BA answers for the date as asked, while the
+// others have no window covering it and relocate it into their own fallback
+// week.
+const serviceWindowDate = "2018-05-29"
+
+var (
+	serviceWindowInWindow  = [2]string{"BA", "MONT"}
+	serviceWindowRelocates = [][2]string{{"CT", "70011"}, {"HA", "1014"}, {"WMATA", "ENT_A01_C01_E"}}
+)
+
 // One `stops` selection can span feed versions, and every stop in it shares a
 // single filter. Each feed version resolves the requested date against its own
-// service window, relocating a date its window excludes into its fallback week;
-// that resolution must not follow the shared filter into the next feed version.
-//
-// 2018-05-29 falls inside BA's service window, so BA answers for the date as
-// asked. The other feed versions here all relocate it. The finder visits them in
-// map order, so leaking the resolution makes BA's answer depend on whether it
-// was visited first, and the same request returns different stop times from one
-// call to the next.
+// service window, and that resolution must not follow the shared filter into
+// the next feed version. The finder visits them in map order, so a leak makes
+// BA's answer depend on whether it was visited first, and the same request
+// returns different stop times from one call to the next.
 func TestStopResolver_ServiceWindowIsPerFeedVersion(t *testing.T) {
 	c, _ := newTestClient(t)
 
@@ -29,48 +36,61 @@ func TestStopResolver_ServiceWindowIsPerFeedVersion(t *testing.T) {
 		return toJson(resp)
 	}
 	// Resolved rather than hardcoded: these are unstable database ids.
-	stopID := func(feed string, stopID string) string {
-		j := query(`query{stops(where:{feed_onestop_id:"` + feed + `", stop_id:"` + stopID + `"}){id}}`)
+	stopID := func(feed string, gtfsStopID string) string {
+		j := query(`query{stops(where:{feed_onestop_id:"` + feed + `", stop_id:"` + gtfsStopID + `"}){id}}`)
 		id := gjson.Get(j, "stops.0.id")
 		if !id.Exists() {
-			t.Fatalf("fixture stop %s:%s not found", feed, stopID)
+			t.Fatalf("fixture stop %s:%s not found", feed, gtfsStopID)
 		}
 		return id.String()
 	}
-	inWindow := stopID("BA", "MONT")
-	// Three more feed versions, none of whose windows cover the date. Only the
-	// visit order decides whether a leak shows, so one alone would leave a coin
-	// flip; with these the odds of missing it across the runs below are about
-	// one in a million.
+	inWindow := stopID(serviceWindowInWindow[0], serviceWindowInWindow[1])
+	// Three more feed versions. Only the visit order decides whether a leak
+	// shows, so one alone would leave a coin flip; with these the odds of
+	// missing it across the runs below are about one in a million.
 	var relocating []string
-	for _, s := range [][2]string{{"CT", "70011"}, {"HA", "1014"}, {"WMATA", "ENT_A01_C01_E"}} {
+	for _, s := range serviceWindowRelocates {
 		relocating = append(relocating, stopID(s[0], s[1]))
 	}
 
-	departures := func(ids ...string) string {
+	// stop_times for one stop out of a request covering all the given stops.
+	departures := func(want string, ids ...string) string {
 		j := query(`query{stops(ids:[` + strings.Join(ids, ",") + `]){
-			id stop_times(where:{date:"2018-05-29", use_service_window:true}){ service_date departure_time }
+			id stop_times(where:{date:"` + serviceWindowDate + `", use_service_window:true}){ service_date departure_time }
 		}}`)
-		// Only the in-window stop's answer is under test.
 		for _, s := range gjson.Get(j, "stops").Array() {
-			if s.Get("id").String() == inWindow {
+			if s.Get("id").String() == want {
 				return s.Get("stop_times").Raw
 			}
 		}
-		t.Fatalf("stop %s missing from response %s", inWindow, j)
+		t.Fatalf("stop %s missing from response %s", want, j)
 		return ""
 	}
 
 	// The answer when nothing else shares the request.
-	alone := departures(inWindow)
-	assert.Contains(t, alone, `"service_date":"2018-05-29"`,
+	alone := departures(inWindow, inWindow)
+	assert.Contains(t, alone, `"service_date":"`+serviceWindowDate+`"`,
 		"fixture should answer for the requested date, not a relocated one")
 
-	// Adding stops whose feed versions relocate the date must not change it, and
-	// must not change it differently from one call to the next.
+	// The premise: at least one of the others really does relocate the date.
+	// Without this the test can keep passing while asserting nothing, if the
+	// fixtures ever drift so that no feed version resolves the date differently.
+	relocated := false
+	for i, id := range relocating {
+		sd := gjson.Get(departures(id, id), "0.service_date").String()
+		if sd != "" && sd != serviceWindowDate {
+			relocated = true
+			break
+		}
+		t.Logf("%v did not relocate %s (service_date %q)", serviceWindowRelocates[i], serviceWindowDate, sd)
+	}
+	assert.True(t, relocated, "fixture should include a feed version that relocates the date")
+
+	// Adding stops whose feed versions relocate the date must not change BA's
+	// answer, and must not change it differently from one call to the next.
+	all := append([]string{inWindow}, relocating...)
 	for i := 0; i < 10; i++ {
-		got := departures(append([]string{inWindow}, relocating...)...)
-		if !assert.JSONEq(t, alone, got, "run %d differs from the single-stop query", i) {
+		if !assert.JSONEq(t, alone, departures(inWindow, all...), "run %d differs from the single-stop query", i) {
 			t.FailNow()
 		}
 	}

--- a/server/gql/stop_resolver_service_window_test.go
+++ b/server/gql/stop_resolver_service_window_test.go
@@ -1,0 +1,77 @@
+package gql
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+)
+
+// One `stops` selection can span feed versions, and every stop in it shares a
+// single filter. Each feed version resolves the requested date against its own
+// service window, relocating a date its window excludes into its fallback week;
+// that resolution must not follow the shared filter into the next feed version.
+//
+// 2018-05-29 falls inside BA's service window, so BA answers for the date as
+// asked. The other feed versions here all relocate it. The finder visits them in
+// map order, so leaking the resolution makes BA's answer depend on whether it
+// was visited first, and the same request returns different stop times from one
+// call to the next.
+func TestStopResolver_ServiceWindowIsPerFeedVersion(t *testing.T) {
+	c, _ := newTestClient(t)
+
+	query := func(q string) string {
+		var resp map[string]interface{}
+		if err := c.Post(q, &resp); err != nil {
+			t.Fatal(err)
+		}
+		return toJson(resp)
+	}
+	// Resolved rather than hardcoded: these are unstable database ids.
+	stopID := func(feed string, stopID string) string {
+		j := query(`query{stops(where:{feed_onestop_id:"` + feed + `", stop_id:"` + stopID + `"}){id}}`)
+		id := gjson.Get(j, "stops.0.id")
+		if !id.Exists() {
+			t.Fatalf("fixture stop %s:%s not found", feed, stopID)
+		}
+		return id.String()
+	}
+	inWindow := stopID("BA", "MONT")
+	// Three more feed versions, none of whose windows cover the date. Only the
+	// visit order decides whether a leak shows, so one alone would leave a coin
+	// flip; with these the odds of missing it across the runs below are about
+	// one in a million.
+	var relocating []string
+	for _, s := range [][2]string{{"CT", "70011"}, {"HA", "1014"}, {"WMATA", "ENT_A01_C01_E"}} {
+		relocating = append(relocating, stopID(s[0], s[1]))
+	}
+
+	departures := func(ids ...string) string {
+		j := query(`query{stops(ids:[` + strings.Join(ids, ",") + `]){
+			id stop_times(where:{date:"2018-05-29", use_service_window:true}){ service_date departure_time }
+		}}`)
+		// Only the in-window stop's answer is under test.
+		for _, s := range gjson.Get(j, "stops").Array() {
+			if s.Get("id").String() == inWindow {
+				return s.Get("stop_times").Raw
+			}
+		}
+		t.Fatalf("stop %s missing from response %s", inWindow, j)
+		return ""
+	}
+
+	// The answer when nothing else shares the request.
+	alone := departures(inWindow)
+	assert.Contains(t, alone, `"service_date":"2018-05-29"`,
+		"fixture should answer for the requested date, not a relocated one")
+
+	// Adding stops whose feed versions relocate the date must not change it, and
+	// must not change it differently from one call to the next.
+	for i := 0; i < 10; i++ {
+		got := departures(append([]string{inWindow}, relocating...)...)
+		if !assert.JSONEq(t, alone, got, "run %d differs from the single-stop query", i) {
+			t.FailNow()
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`stopTimesByEntityIDs` groups the requested stops by feed version and loops, calling `stopTimeFilterExpand` once per feed version — but passing the same `*model.StopTimeFilter` each time, which that function rewrites in place. Under `use_service_window` the rewrite replaces a date falling outside a feed version's service window with the same weekday in its fallback week, so once any feed version in the batch has relocated the date, every feed version processed after it queries the relocated date rather than the one that was asked for.

Which stops are affected therefore depends on the order the feed versions happen to be visited, and that order comes from ranging over a map. The same request against the same data returns different results from one call to the next. Repeating one identical query eight times, batching a stop from a feed version whose window covers the requested date with a stop from one whose window ended two years earlier, returned the correct four trips five times and a different four trips — from a service date five weeks away — the other three.

This is a plain 200 with plausible-looking data, not an error, so nothing downstream has any way to notice.

The filter is now copied per feed version. The copy is shallow, which is sufficient: every write in `stopTimeFilterExpand` replaces a pointer field rather than writing through one.

## Scope

Everything that resolves through `stopTimesByEntityIDs` is affected: `Stop.stop_times`, `Stop.departures`, `Stop.arrivals`, and the flex `Location` / `LocationGroup` stop time resolvers. A request only hits it when it batches stops across feed versions and sets `use_service_window` — but that combination is the normal case for a spatial query, since a bounding box crosses feeds and the dataloader coalesces the stops it finds into one call.

The other in-place rewrites in `stopTimeFilterExpand` — `relative_date` and `next` resolving to a date, `start` / `end` folding into `start_time` / `end_time` — recompute from scratch on each pass and were not producing wrong answers. They are covered by the same copy.

**This fixes the stop path only.** `tripSelect` rewrites `where.ServiceDate` in place from the same kind of per-feed-version loop, so `Route.trips` and `Shape.trips` have the identical defect; on this branch `routes(ids: [...]) { trips(where: {service_date, use_service_window}) }` across two feed versions returns one route's trips and drops the other's on six of eight identical requests. That path also loses results a second way, because each `dbutil.Select` replaces the destination slice rather than appending to it. Both are fixed in #721 rather than here, since disentangling them from that branch's rewrite of the same lines produces a merge conflict for no benefit.

Found while comparing two ways of fetching the same departures and finding they disagreed on 2,126 of 5,257 stops; this was most of the gap.

## Test

`TestStopResolver_ServiceWindowIsPerFeedVersion` asks one `stops` selection for stop times across four feed versions — one whose window covers the requested date, three that relocate it — and asserts the first one's answer is identical to what it returns alone, ten times over. Reverting only `stop_time.go` makes it fail on that assertion; with the fix it passes repeatedly.

Two details are deliberate. It batches four feed versions rather than two because only the visit order decides whether the leak surfaces, so a single relocating neighbour would leave a coin flip per run; four brings the odds of a broken build passing to roughly one in a million. And it separately asserts that at least one neighbour really does relocate the date, so the test cannot quietly degrade into asserting nothing if the fixtures' service windows ever drift.

Fixture stop ids are resolved by feed and `stop_id` at runtime rather than hardcoded, since the database ids are not stable.

## Risk

No measurable cost. The change is one shallow struct copy per feed version per request, it issues no new queries, and it does not change how many are issued — the one-to-three way midnight split keys off start and end times, not dates. Four batch shapes measured against the unfixed build produced byte-identical output and indistinguishable timing.

The behavior change is the point rather than a side effect: where results move, they move from nondeterministically wrong to correct. The one direction that could cost more is that a feed version which was wrongly returning nothing now returns its real rows, so a request that was accidentally cheap now does the work it was always supposed to.

The trigger needs two things to coincide — the affected stops landing in the same dataloader batch, and an unfavourable map iteration order — which is presumably why it went unnoticed, and also means how often it bites in practice is not something this change can quantify.
