### PR TITLE
ReadRowsHeader

### DIFF
--- a/cmds/feed_version_args.go
+++ b/cmds/feed_version_args.go
@@ -184,16 +184,14 @@ func readFVIDFile(fn string) ([]string, error) {
 	defer f.Close()
 	var ids []string
 	col := -1
-	if err := tlcsv.ReadRows(f, func(row tlcsv.Row) {
+	header, err := tlcsv.ReadRowsHeader(f, func(row tlcsv.Row) {
 		if col < 0 {
 			if i, ok := row.Hindex["feed_version_id"]; ok {
 				col = i
 			} else if len(row.Header) > 0 {
-				if h := strings.TrimSpace(row.Header[0]); h != "" {
-					if _, err := strconv.Atoi(h); err == nil {
-						col = 0
-						ids = append(ids, h)
-					}
+				if h, ok := fvidValue(row.Header[0]); ok {
+					col = 0
+					ids = append(ids, h)
 				}
 			}
 		}
@@ -202,8 +200,28 @@ func readFVIDFile(fn string) ([]string, error) {
 				ids = append(ids, v)
 			}
 		}
-	}); err != nil && err != io.EOF { // io.EOF: empty file, no rows
+	})
+	if err != nil && err != io.EOF { // io.EOF: empty file, no rows
 		return nil, err
 	}
+	// A file holding a single id has no rows after the header, so the callback never
+	// ran and the id is in the header itself.
+	if col < 0 && len(header) > 0 {
+		if h, ok := fvidValue(header[0]); ok {
+			ids = append(ids, h)
+		}
+	}
 	return ids, nil
+}
+
+// fvidValue returns v trimmed, if it is a bare integer feed version id.
+func fvidValue(v string) (string, bool) {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return "", false
+	}
+	if _, err := strconv.Atoi(v); err != nil {
+		return "", false
+	}
+	return v, true
 }

--- a/cmds/feed_version_args_test.go
+++ b/cmds/feed_version_args_test.go
@@ -40,8 +40,38 @@ func TestReadFVIDFile(t *testing.T) {
 			want:    []string{"100", "200"},
 		},
 		{
+			name:    "no header, single id",
+			content: "100\n",
+			want:    []string{"100"},
+		},
+		{
+			name:    "no header, single id, no trailing newline",
+			content: "100",
+			want:    []string{"100"},
+		},
+		{
+			name:    "no header, single id with extra columns",
+			content: "100,f-a\n",
+			want:    []string{"100"},
+		},
+		{
+			name:    "feed_version_id header, single id",
+			content: "feed_version_id\n100\n",
+			want:    []string{"100"},
+		},
+		{
+			name:    "feed_version_id header, no rows",
+			content: "feed_version_id\n",
+			want:    nil,
+		},
+		{
 			name:    "non-numeric header without feed_version_id yields nothing",
 			content: "onestop_id,id\nf-a,1\nf-b,2\n",
+			want:    nil,
+		},
+		{
+			name:    "non-numeric single row yields nothing",
+			content: "onestop_id\n",
 			want:    nil,
 		},
 		{

--- a/tlcsv/row.go
+++ b/tlcsv/row.go
@@ -32,6 +32,14 @@ type csvOptFn func(*csv.Reader)
 
 // ReadRows iterates through csv rows with callback.
 func ReadRows(in io.Reader, cb func(Row)) error {
+	_, err := ReadRowsHeader(in, cb)
+	return err
+}
+
+// ReadRowsHeader iterates through csv rows with callback and returns the header row.
+// The callback is only invoked for rows after the header, so this is the only way to
+// see a file that has no data rows.
+func ReadRowsHeader(in io.Reader, cb func(Row)) ([]string, error) {
 	// Handle byte-order-marks.
 	r := csv.NewReader(utfbom.SkipOnly(in))
 	// Allow variable columns - very common in GTFS
@@ -46,11 +54,11 @@ func ReadRows(in io.Reader, cb func(Row)) error {
 	return readRows(r, cb)
 }
 
-func readRows(r *csv.Reader, cb func(Row)) error {
+func readRows(r *csv.Reader, cb func(Row)) ([]string, error) {
 	// Go for it.
 	firstRow, err := r.Read()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	// Copy header, since we will reuse the backing array
 	header := []string{}
@@ -73,7 +81,7 @@ func readRows(r *csv.Reader, cb func(Row)) error {
 			row = []string{}
 		} else {
 			// Serious error: break and return with error
-			return err
+			return header, err
 		}
 		// Remove whitespace
 		for i := 0; i < len(row); i++ {
@@ -87,7 +95,7 @@ func readRows(r *csv.Reader, cb func(Row)) error {
 		line, _ := r.FieldPos(0)
 		cb(Row{Row: row, Line: line, Header: header, Hindex: hindex, Err: err})
 	}
-	return nil
+	return header, nil
 }
 
 func ReadRowsIter(in io.Reader, optFns ...csvOptFn) iter.Seq2[Row, error] {

--- a/tlcsv/row_test.go
+++ b/tlcsv/row_test.go
@@ -1,0 +1,69 @@
+package tlcsv
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadRowsHeader(t *testing.T) {
+	tcs := []struct {
+		name       string
+		data       string
+		wantHeader []string
+		wantRows   [][]string
+		wantErr    error
+	}{
+		{
+			name:       "header and rows",
+			data:       "a,b\n1,2\n3,4\n",
+			wantHeader: []string{"a", "b"},
+			wantRows:   [][]string{{"1", "2"}, {"3", "4"}},
+		},
+		{
+			// The callback must not fire, or every header-only GTFS file would yield
+			// a blank entity.
+			name:       "header only, no data rows",
+			data:       "a,b\n",
+			wantHeader: []string{"a", "b"},
+		},
+		{
+			name:       "single row is the header",
+			data:       "1\n",
+			wantHeader: []string{"1"},
+		},
+		{
+			name:       "ragged rows",
+			data:       "a,b,c\n1\n2,3\n",
+			wantHeader: []string{"a", "b", "c"},
+			wantRows:   [][]string{{"1"}, {"2", "3"}},
+		},
+		{
+			name:    "empty file",
+			data:    "",
+			wantErr: io.EOF,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			var rows [][]string
+			header, err := ReadRowsHeader(strings.NewReader(tc.data), func(row Row) {
+				// Records are reused between reads, so copy before keeping.
+				rows = append(rows, append([]string(nil), row.Row...))
+			})
+			assert.Equal(t, tc.wantErr, err)
+			assert.Equal(t, tc.wantHeader, header)
+			assert.Equal(t, tc.wantRows, rows)
+
+			// ReadRows wraps ReadRowsHeader and must keep reporting the same rows.
+			rows = nil
+			err = ReadRows(strings.NewReader(tc.data), func(row Row) {
+				rows = append(rows, append([]string(nil), row.Row...))
+			})
+			assert.Equal(t, tc.wantErr, err)
+			assert.Equal(t, tc.wantRows, rows)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
`--fvid-file` silently read zero feed version ids from a header-less file containing exactly one id, which made `unimport --fvid-file` fail with "must provide at least one feed version id as an argument or with --fvid-file" whenever the generating query returned a single row. The root cause was in `tlcsv.ReadRows`: it consumes the first record as the header and only invokes the callback for records after it, so a single-record file produces no callbacks at all and the header is discarded. `readFVIDFile` recovers a header-less list by checking whether the header parses as an integer, but that check lived inside the callback and therefore never ran. This adds `tlcsv.ReadRowsHeader`, which returns the header alongside the error, and has `readFVIDFile` consult it after the read. `ReadRows` keeps its exact signature and behavior.

### tlcsv: ReadRowsHeader
- New `ReadRowsHeader(in io.Reader, cb func(Row)) ([]string, error)` returns the header row. Since the callback only fires for rows after the header, this is the only way for a caller to see a file that has no data rows.
- `ReadRows` is unchanged as public API and is now a thin wrapper that discards the header. No call sites needed updating.
- Callback semantics are deliberately unchanged: `Reader.ReadEntities` constructs and sends an entity for every callback with no empty-row guard, so emitting a callback for header-only files would inject a blank entity into every GTFS file that has only a header, such as an empty `frequencies.txt` or `transfers.txt`.
- `ReadRowsIter` has the same header-loss property and is left alone. Reading its header eagerly would leave the empty-file error with nowhere clean to go. This is also the cause of the documented limitation in `ValidateStructure`, where the column check cannot run on a file with no data rows.

### cmds: single-id --fvid-file
- `readFVIDFile` switches to `ReadRowsHeader` and, when the callback never established a column, checks the returned header for a bare integer id. The callback body is otherwise unchanged.
- The post-read check is guarded on `col < 0`, which covers both "no data rows fired" and "a real header with no feed_version_id column"; the latter still yields nothing because a header like `onestop_id` is not an integer.
- Extracted `fvidValue` so the trim-and-Atoi test is not duplicated between the callback and the post-read check.
- This affects every command taking `--fvid-file`: `unimport` and `import` failed outright on a single-id file, and `stats-rebuild` silently rebuilt nothing because it has no empty-selection check.

### Tests
- New `tlcsv/row_test.go` covering header plus rows, header-only, single-row, ragged rows, and empty input, asserting both the returned header and the rows delivered to the callback. Each case is also run through `ReadRows` to pin the wrapper. The header-only case asserts the callback does not fire, which is the guard against blank GTFS entities.
- `TestReadFVIDFile` gains single-id cases with and without a trailing newline, with extra columns, with a `feed_version_id` header, a header with no rows, and a non-numeric single row. Every pre-existing header-less case had two or more rows, which is why this shipped.

## Test plan
- With a single-id file, `printf '100\n' > fvids.txt`, confirm `transitland unimport --dry-run --fvid-file fvids.txt` now resolves feed version 100 instead of exiting on the "must provide at least one feed version id" parse error.
- Confirm multi-id files are unaffected: `printf '100\n200\n' > fvids.txt` reports both ids.
- Confirm the CSV form still works with a single row: `printf 'feed_version_id,sha1\n100,abc\n' > fvids.csv` resolves only feed version 100.
- Confirm a file with a real header and no `feed_version_id` column still selects nothing rather than misreading the first column.
- Validate a feed containing a header-only optional file, for example a `frequencies.txt` with just its header row, and confirm it is still reported as empty with no phantom entity and no new validation errors.
