### PR TITLE
Return place geometries and extents

### DIFF
--- a/internal/generated/gqlout/generated.go
+++ b/internal/generated/gqlout/generated.go
@@ -919,8 +919,10 @@ type ComplexityRoot struct {
 	Place struct {
 		Adm0Name  func(childComplexity int) int
 		Adm1Name  func(childComplexity int) int
+		Bbox      func(childComplexity int) int
 		CityName  func(childComplexity int) int
 		Count     func(childComplexity int) int
+		Geometry  func(childComplexity int) int
 		Operators func(childComplexity int) int
 	}
 
@@ -5595,6 +5597,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Place.Adm1Name(childComplexity), true
+	case "Place.bbox":
+		if e.ComplexityRoot.Place.Bbox == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Place.Bbox(childComplexity), true
 	case "Place.city_name":
 		if e.ComplexityRoot.Place.CityName == nil {
 			break
@@ -5607,6 +5615,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Place.Count(childComplexity), true
+	case "Place.geometry":
+		if e.ComplexityRoot.Place.Geometry == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Place.Geometry(childComplexity), true
 	case "Place.operators":
 		if e.ComplexityRoot.Place.Operators == nil {
 			break
@@ -10512,6 +10526,19 @@ type Place {
   
   "Operators associated with this place"
   operators: [Operator!]
+  
+  """
+  Boundary of this place from Natural Earth: the region polygons, or the point of
+  a city. Null where the place has no match there. A country collects every
+  region below it and can be very large.
+  """
+  geometry: Geometry
+
+  """
+  Bounding box of this place, from Natural Earth. A country covers every region
+  it contains, so the United States reaches Alaska and Hawaii.
+  """
+  bbox: Geometry
 }
 
 """
@@ -13723,6 +13750,10 @@ func (ec *executionContext) childFields_Place(ctx context.Context, field graphql
 		return ec.fieldContext_Place_count(ctx, field)
 	case "operators":
 		return ec.fieldContext_Place_operators(ctx, field)
+	case "geometry":
+		return ec.fieldContext_Place_geometry(ctx, field)
+	case "bbox":
+		return ec.fieldContext_Place_bbox(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type Place", field.Name)
 }
@@ -32803,6 +32834,52 @@ func (ec *executionContext) fieldContext_Place_operators(_ context.Context, fiel
 		},
 	}
 	return fc, nil
+}
+
+func (ec *executionContext) _Place_geometry(ctx context.Context, field graphql.CollectedField, obj *model.Place) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Place_geometry(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Geometry, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *tt.Geometry) graphql.Marshaler {
+			return ec.marshalOGeometry2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐGeometry(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_Place_geometry(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Place", field, false, false, errors.New("field of type Geometry does not have child fields"))
+}
+
+func (ec *executionContext) _Place_bbox(ctx context.Context, field graphql.CollectedField, obj *model.Place) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Place_bbox(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Bbox, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *tt.Geometry) graphql.Marshaler {
+			return ec.marshalOGeometry2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐGeometry(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_Place_bbox(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Place", field, false, false, errors.New("field of type Geometry does not have child fields"))
 }
 
 func (ec *executionContext) _Query_feeds(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -53111,6 +53188,10 @@ func (ec *executionContext) _Place(ctx context.Context, sel ast.SelectionSet, ob
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "geometry":
+			out.Values[i] = ec._Place_geometry(ctx, field, obj)
+		case "bbox":
+			out.Values[i] = ec._Place_bbox(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/internal/generated/gqlout/generated.go
+++ b/internal/generated/gqlout/generated.go
@@ -922,7 +922,6 @@ type ComplexityRoot struct {
 		Bbox      func(childComplexity int) int
 		CityName  func(childComplexity int) int
 		Count     func(childComplexity int) int
-		Geometry  func(childComplexity int) int
 		Operators func(childComplexity int) int
 	}
 
@@ -5615,12 +5614,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Place.Count(childComplexity), true
-	case "Place.geometry":
-		if e.ComplexityRoot.Place.Geometry == nil {
-			break
-		}
-
-		return e.ComplexityRoot.Place.Geometry(childComplexity), true
 	case "Place.operators":
 		if e.ComplexityRoot.Place.Operators == nil {
 			break
@@ -10528,15 +10521,9 @@ type Place {
   operators: [Operator!]
   
   """
-  Boundary of this place from Natural Earth: the region polygons, or the point of
-  a city. Null where the place has no match there. A country collects every
-  region below it and can be very large.
-  """
-  geometry: Geometry
-
-  """
-  Bounding box of this place, from Natural Earth. A country covers every region
-  it contains, so the United States reaches Alaska and Hawaii.
+  Bounding box of this place, from Natural Earth; null where it has no match
+  there. A country covers every region it contains, so the United States reaches
+  Alaska and Hawaii.
   """
   bbox: Geometry
 }
@@ -13750,8 +13737,6 @@ func (ec *executionContext) childFields_Place(ctx context.Context, field graphql
 		return ec.fieldContext_Place_count(ctx, field)
 	case "operators":
 		return ec.fieldContext_Place_operators(ctx, field)
-	case "geometry":
-		return ec.fieldContext_Place_geometry(ctx, field)
 	case "bbox":
 		return ec.fieldContext_Place_bbox(ctx, field)
 	}
@@ -32834,29 +32819,6 @@ func (ec *executionContext) fieldContext_Place_operators(_ context.Context, fiel
 		},
 	}
 	return fc, nil
-}
-
-func (ec *executionContext) _Place_geometry(ctx context.Context, field graphql.CollectedField, obj *model.Place) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_Place_geometry(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return obj.Geometry, nil
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *tt.Geometry) graphql.Marshaler {
-			return ec.marshalOGeometry2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐGeometry(ctx, selections, v)
-		},
-		true,
-		false,
-	)
-}
-func (ec *executionContext) fieldContext_Place_geometry(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	return graphql.NewScalarFieldContext("Place", field, false, false, errors.New("field of type Geometry does not have child fields"))
 }
 
 func (ec *executionContext) _Place_bbox(ctx context.Context, field graphql.CollectedField, obj *model.Place) (ret graphql.Marshaler) {
@@ -53188,8 +53150,6 @@ func (ec *executionContext) _Place(ctx context.Context, sel ast.SelectionSet, ob
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "geometry":
-			out.Values[i] = ec._Place_geometry(ctx, field, obj)
 		case "bbox":
 			out.Values[i] = ec._Place_bbox(ctx, field, obj)
 		default:

--- a/schema/graphql/schema.graphqls
+++ b/schema/graphql/schema.graphqls
@@ -1649,6 +1649,19 @@ type Place {
   
   "Operators associated with this place"
   operators: [Operator!]
+  
+  """
+  Boundary of this place from Natural Earth: the region polygons, or the point of
+  a city. Null where the place has no match there. A country collects every
+  region below it and can be very large.
+  """
+  geometry: Geometry
+
+  """
+  Bounding box of this place, from Natural Earth. A country covers every region
+  it contains, so the United States reaches Alaska and Hawaii.
+  """
+  bbox: Geometry
 }
 
 """

--- a/schema/graphql/schema.graphqls
+++ b/schema/graphql/schema.graphqls
@@ -1651,15 +1651,9 @@ type Place {
   operators: [Operator!]
   
   """
-  Boundary of this place from Natural Earth: the region polygons, or the point of
-  a city. Null where the place has no match there. A country collects every
-  region below it and can be very large.
-  """
-  geometry: Geometry
-
-  """
-  Bounding box of this place, from Natural Earth. A country covers every region
-  it contains, so the United States reaches Alaska and Hawaii.
+  Bounding box of this place, from Natural Earth; null where it has no match
+  there. A country covers every region it contains, so the United States reaches
+  Alaska and Hawaii.
   """
   bbox: Geometry
 }

--- a/server/finders/dbfinder/agency.go
+++ b/server/finders/dbfinder/agency.go
@@ -252,15 +252,16 @@ func agencySelect(limit *int, after *model.Cursor, ids []int, useActive *UseActi
 	return q
 }
 
-// placeGeometrySelect adds the requested geometry columns to a place query.
+// placeBboxSelect adds the bounding box column to a place query.
 //
 // Cities are points in Natural Earth and regions are polygons, so they come from
 // different tables. Where a group is a single Natural Earth unit — any level that
-// groups down to its own region or city — the join covers exactly that unit and
-// the extent is the aggregate over it. A country groups over the regions beneath
-// it, where the join would reach only the regions that have operators, so its
-// extent comes from a subquery over every region instead.
-func placeGeometrySelect(q sq.SelectBuilder, geom model.PlaceGeometrySelect, level *model.PlaceAggregationLevel) sq.SelectBuilder {
+// groups down to its own region or city — a left join covers exactly that unit
+// and the extent is the aggregate over it; a place with no match there keeps its
+// row with a null box. A country groups over the regions beneath it, where that
+// join would reach only the regions that have operators, so its box comes from a
+// subquery over every region instead.
+func placeBboxSelect(q sq.SelectBuilder, level *model.PlaceAggregationLevel) sq.SelectBuilder {
 	cityLevel := false
 	singleUnit := false
 	switch {
@@ -269,51 +270,27 @@ func placeGeometrySelect(q sq.SelectBuilder, geom model.PlaceGeometrySelect, lev
 		singleUnit = true
 	case *level == model.PlaceAggregationLevelAdm0Adm1City:
 		cityLevel = true
-		singleUnit = true
 	case *level == model.PlaceAggregationLevelAdm0City,
 		*level == model.PlaceAggregationLevelAdm1City,
 		*level == model.PlaceAggregationLevelCity:
 		cityLevel = true
 	}
 
-	// Left joined: a place whose name came from a feed's own admin data has no
-	// Natural Earth match, and still belongs in the result without a geometry. The
-	// join multiplies rows where a place is several polygons, which the distinct
-	// aggregate on agency ids is already written to tolerate.
-	joined := false
-	joinNaturalEarth := func(q sq.SelectBuilder) sq.SelectBuilder {
-		if joined {
-			return q
-		}
-		joined = true
-		if cityLevel {
-			return q.JoinClause("left join ne_10m_populated_places ne_place on ne_place.name = tlap.name and ne_place.adm1name = tlap.adm1name and ne_place.adm0name = tlap.adm0name")
-		}
-		return q.JoinClause("left join ne_10m_admin_1_states_provinces ne_admin on ne_admin.name = tlap.adm1name and ne_admin.admin = tlap.adm0name")
-	}
-
-	if geom.Geometry {
-		q = joinNaturalEarth(q)
-		if cityLevel {
-			q = q.Column("ST_SetSRID(ST_CollectionHomogenize(ST_Collect(ne_place.geometry::geometry)), 4326) as geometry")
-		} else {
-			q = q.Column("ST_SetSRID(ST_CollectionHomogenize(ST_Collect(ne_admin.geometry::geometry)), 4326) as geometry")
-		}
-	}
-
-	if geom.Bbox {
-		switch {
-		case singleUnit && cityLevel:
-			q = joinNaturalEarth(q)
-			q = q.Column("ST_SetSRID(ST_Extent(ST_Buffer(ne_place.geometry, ?)::geometry)::geometry, 4326) as bbox", placeCityRadius)
-		case singleUnit:
-			q = joinNaturalEarth(q)
-			q = q.Column("ST_SetSRID(ST_Extent(ne_admin.geometry::geometry)::geometry, 4326) as bbox")
-		case cityLevel:
-			// Grouped above the city, so there is no single point to widen.
-		default:
-			q = q.Column("(select ST_SetSRID(ST_Extent(whole.geometry::geometry)::geometry, 4326) from ne_10m_admin_1_states_provinces whole where whole.admin = tlap.adm0name) as bbox")
-		}
+	switch {
+	case cityLevel:
+		// The join is per row, so a level that groups several cities together —
+		// same name in more than one region, or in more than one country — widens
+		// the box to cover them, the way its count already covers them.
+		q = q.
+			JoinClause("left join ne_10m_populated_places ne_place on ne_place.name = tlap.name and ne_place.adm1name = tlap.adm1name and ne_place.adm0name = tlap.adm0name").
+			Column("ST_SetSRID(ST_Extent(ST_Buffer(ne_place.geometry, ?)::geometry)::geometry, 4326) as bbox", placeCityRadius)
+	case singleUnit:
+		q = q.
+			JoinClause("left join ne_10m_admin_1_states_provinces ne_admin on ne_admin.name = tlap.adm1name and ne_admin.admin = tlap.adm0name").
+			Column("ST_SetSRID(ST_Extent(ne_admin.geometry::geometry)::geometry, 4326) as bbox")
+	default:
+		// A country: every region it contains, not only those with operators.
+		q = q.Column("(select ST_SetSRID(ST_Extent(whole.geometry::geometry)::geometry, 4326) from ne_10m_admin_1_states_provinces whole where whole.admin = tlap.adm0name) as bbox")
 	}
 	return q
 }
@@ -355,8 +332,8 @@ func placeSelect(_ *int, _ *model.Cursor, _ []int, level *model.PlaceAggregation
 		Join("current_feeds on current_feeds.id = feed_states.feed_id").
 		GroupBy(groupKeys...)
 
-	if geom.Any() {
-		q = placeGeometrySelect(q, geom, level)
+	if geom.Bbox {
+		q = placeBboxSelect(q, level)
 	}
 
 	if where != nil {

--- a/server/finders/dbfinder/agency.go
+++ b/server/finders/dbfinder/agency.go
@@ -94,14 +94,19 @@ func (f *Finder) AgenciesByOnestopIDs(ctx context.Context, limit *int, where *mo
 	return arrangeGroup(keys, ents, func(ent *model.Agency) string { return ent.OnestopID }), err
 }
 
-func (f *Finder) FindPlaces(ctx context.Context, limit *int, after *model.Cursor, ids []int, level *model.PlaceAggregationLevel, where *model.PlaceFilter) ([]*model.Place, error) {
+func (f *Finder) FindPlaces(ctx context.Context, limit *int, after *model.Cursor, ids []int, level *model.PlaceAggregationLevel, where *model.PlaceFilter, geom model.PlaceGeometrySelect) ([]*model.Place, error) {
 	var ents []*model.Place
-	q := placeSelect(limit, after, ids, level, f.PermFilter(ctx), where)
+	q := placeSelect(limit, after, ids, level, f.PermFilter(ctx), where, geom)
 	if err := dbutil.Select(ctx, f.db, q, &ents); err != nil {
 		return nil, err
 	}
 	return ents, nil
 }
+
+// Radius in meters the agency place builder uses to associate a stop with a
+// populated place; Natural Earth carries cities as points, so a city's extent is
+// that association's own catchment.
+const placeCityRadius = 40_000.0
 
 func agencySelect(limit *int, after *model.Cursor, ids []int, useActive *UseActive, permFilter *model.PermFilter, where *model.AgencyFilter) sq.SelectBuilder {
 	distinct := false
@@ -247,7 +252,73 @@ func agencySelect(limit *int, after *model.Cursor, ids []int, useActive *UseActi
 	return q
 }
 
-func placeSelect(_ *int, _ *model.Cursor, _ []int, level *model.PlaceAggregationLevel, permFilter *model.PermFilter, where *model.PlaceFilter) sq.SelectBuilder {
+// placeGeometrySelect adds the requested geometry columns to a place query.
+//
+// Cities are points in Natural Earth and regions are polygons, so they come from
+// different tables. Where a group is a single Natural Earth unit — any level that
+// groups down to its own region or city — the join covers exactly that unit and
+// the extent is the aggregate over it. A country groups over the regions beneath
+// it, where the join would reach only the regions that have operators, so its
+// extent comes from a subquery over every region instead.
+func placeGeometrySelect(q sq.SelectBuilder, geom model.PlaceGeometrySelect, level *model.PlaceAggregationLevel) sq.SelectBuilder {
+	cityLevel := false
+	singleUnit := false
+	switch {
+	case level == nil:
+	case *level == model.PlaceAggregationLevelAdm0Adm1:
+		singleUnit = true
+	case *level == model.PlaceAggregationLevelAdm0Adm1City:
+		cityLevel = true
+		singleUnit = true
+	case *level == model.PlaceAggregationLevelAdm0City,
+		*level == model.PlaceAggregationLevelAdm1City,
+		*level == model.PlaceAggregationLevelCity:
+		cityLevel = true
+	}
+
+	// Left joined: a place whose name came from a feed's own admin data has no
+	// Natural Earth match, and still belongs in the result without a geometry. The
+	// join multiplies rows where a place is several polygons, which the distinct
+	// aggregate on agency ids is already written to tolerate.
+	joined := false
+	joinNaturalEarth := func(q sq.SelectBuilder) sq.SelectBuilder {
+		if joined {
+			return q
+		}
+		joined = true
+		if cityLevel {
+			return q.JoinClause("left join ne_10m_populated_places ne_place on ne_place.name = tlap.name and ne_place.adm1name = tlap.adm1name and ne_place.adm0name = tlap.adm0name")
+		}
+		return q.JoinClause("left join ne_10m_admin_1_states_provinces ne_admin on ne_admin.name = tlap.adm1name and ne_admin.admin = tlap.adm0name")
+	}
+
+	if geom.Geometry {
+		q = joinNaturalEarth(q)
+		if cityLevel {
+			q = q.Column("ST_SetSRID(ST_CollectionHomogenize(ST_Collect(ne_place.geometry::geometry)), 4326) as geometry")
+		} else {
+			q = q.Column("ST_SetSRID(ST_CollectionHomogenize(ST_Collect(ne_admin.geometry::geometry)), 4326) as geometry")
+		}
+	}
+
+	if geom.Bbox {
+		switch {
+		case singleUnit && cityLevel:
+			q = joinNaturalEarth(q)
+			q = q.Column("ST_SetSRID(ST_Extent(ST_Buffer(ne_place.geometry, ?)::geometry)::geometry, 4326) as bbox", placeCityRadius)
+		case singleUnit:
+			q = joinNaturalEarth(q)
+			q = q.Column("ST_SetSRID(ST_Extent(ne_admin.geometry::geometry)::geometry, 4326) as bbox")
+		case cityLevel:
+			// Grouped above the city, so there is no single point to widen.
+		default:
+			q = q.Column("(select ST_SetSRID(ST_Extent(whole.geometry::geometry)::geometry, 4326) from ne_10m_admin_1_states_provinces whole where whole.admin = tlap.adm0name) as bbox")
+		}
+	}
+	return q
+}
+
+func placeSelect(_ *int, _ *model.Cursor, _ []int, level *model.PlaceAggregationLevel, permFilter *model.PermFilter, where *model.PlaceFilter, geom model.PlaceGeometrySelect) sq.SelectBuilder {
 	// placeSelect is limited to active feed versions
 	var groupKeys []string
 	var selKeys []string
@@ -283,6 +354,10 @@ func placeSelect(_ *int, _ *model.Cursor, _ []int, level *model.PlaceAggregation
 		Join("feed_versions on feed_versions.id = feed_states.materialized_feed_version_id").
 		Join("current_feeds on current_feeds.id = feed_states.feed_id").
 		GroupBy(groupKeys...)
+
+	if geom.Any() {
+		q = placeGeometrySelect(q, geom, level)
+	}
 
 	if where != nil {
 		if where.Adm0Name != nil {

--- a/server/gql/place_resolver_test.go
+++ b/server/gql/place_resolver_test.go
@@ -80,6 +80,34 @@ func TestPlaceResolver(t *testing.T) {
 			selector:     "places.#.city_name",
 			selectExpect: []string{"Oakland"},
 		},
+		// geometry
+		{
+			name:         "region bbox comes from the admin polygon",
+			query:        `query{ places(level: ADM0_ADM1, where: {adm1_name: "California"}) { bbox } }`,
+			selector:     "places.0.bbox.coordinates.0.0.0",
+			selectExpect: []string{"-124.4092019709999"},
+		},
+		{
+			// Every region, including those with no operators at all.
+			name:         "country bbox reaches every region",
+			query:        `query{ places(level: ADM0, where: {adm0_name: "United States of America"}) { bbox } }`,
+			selector:     "places.0.bbox.coordinates.0.0.0",
+			selectExpect: []string{"-179.1435033839999"},
+		},
+		{
+			// A city is a point in Natural Earth, buffered by the radius the place
+			// association itself uses.
+			name:         "city bbox is buffered around the point",
+			query:        `query{ places(level: ADM0_ADM1_CITY, where: {city_name: "Oakland"}) { bbox } }`,
+			selector:     "places.0.bbox.coordinates.0.0.0",
+			selectExpect: []string{"-122.73241922786842"},
+		},
+		{
+			name:         "region geometry is the admin polygon",
+			query:        `query{ places(level: ADM0_ADM1, where: {adm1_name: "California"}) { geometry } }`,
+			selector:     "places.0.geometry.type",
+			selectExpect: []string{"MultiPolygon"},
+		},
 		// operators
 		{
 			name:         "ADM0 operators",

--- a/server/gql/place_resolver_test.go
+++ b/server/gql/place_resolver_test.go
@@ -2,7 +2,16 @@ package gql
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
 )
+
+// bboxMinLon is the western edge of the first returned place's bounding box.
+// ST_Extent emits the ring from its lower-left corner.
+func bboxMinLon(jj string) float64 {
+	return gjson.Get(jj, "places.0.bbox.coordinates.0.0.0").Float()
+}
 
 func TestPlaceResolver(t *testing.T) {
 	q := `query($level: PlaceAggregationLevel,$where: PlaceFilter) {
@@ -82,32 +91,37 @@ func TestPlaceResolver(t *testing.T) {
 		},
 		// bbox
 		{
-			name:         "region bbox comes from the admin polygon",
-			query:        `query{ places(level: ADM0_ADM1, where: {adm1_name: "California"}) { bbox } }`,
-			selector:     "places.0.bbox.coordinates.0.0.0",
-			selectExpect: []string{"-124.4092019709999"},
+			name:  "region bbox comes from the admin polygon",
+			query: `query{ places(level: ADM0_ADM1, where: {adm1_name: "California"}) { bbox } }`,
+			f: func(t *testing.T, jj string) {
+				assert.InDelta(t, -124.409202, bboxMinLon(jj), 1e-5, "California reaches its own coastline")
+			},
 		},
 		{
-			// Every region, including those with no operators at all.
-			name:         "country bbox reaches every region",
-			query:        `query{ places(level: ADM0, where: {adm0_name: "United States of America"}) { bbox } }`,
-			selector:     "places.0.bbox.coordinates.0.0.0",
-			selectExpect: []string{"-179.1435033839999"},
+			name:  "country bbox reaches every region",
+			query: `query{ places(level: ADM0, where: {adm0_name: "United States of America"}) { bbox } }`,
+			f: func(t *testing.T, jj string) {
+				// Alaska, not California: a country covers every region it contains,
+				// including those with no operators at all.
+				assert.InDelta(t, -179.143503, bboxMinLon(jj), 1e-5, "country spans every region")
+			},
 		},
 		{
 			// A city is a point in Natural Earth, buffered by the radius the place
-			// association itself uses.
-			name:         "city bbox is buffered around the point",
-			query:        `query{ places(level: ADM0_ADM1_CITY, where: {city_name: "Oakland"}) { bbox } }`,
-			selector:     "places.0.bbox.coordinates.0.0.0",
-			selectExpect: []string{"-122.73241922786842"},
+			// association itself uses: about 0.46 degrees of longitude at this latitude.
+			name:  "city bbox is buffered around the point",
+			query: `query{ places(level: ADM0_ADM1_CITY, where: {city_name: "Oakland"}) { bbox } }`,
+			f: func(t *testing.T, jj string) {
+				assert.InDelta(t, -122.732419, bboxMinLon(jj), 1e-5, "Oakland widened by the association radius")
+			},
 		},
 		{
 			// A level that identifies a city by fewer names still gets a box.
-			name:         "city bbox at a coarser level",
-			query:        `query{ places(level: ADM0_CITY, where: {city_name: "Oakland"}) { bbox } }`,
-			selector:     "places.0.bbox.coordinates.0.0.0",
-			selectExpect: []string{"-122.73241922786842"},
+			name:  "city bbox at a coarser level",
+			query: `query{ places(level: ADM0_CITY, where: {city_name: "Oakland"}) { bbox } }`,
+			f: func(t *testing.T, jj string) {
+				assert.InDelta(t, -122.732419, bboxMinLon(jj), 1e-5, "same box as the finer level")
+			},
 		},
 		// operators
 		{

--- a/server/gql/place_resolver_test.go
+++ b/server/gql/place_resolver_test.go
@@ -80,7 +80,7 @@ func TestPlaceResolver(t *testing.T) {
 			selector:     "places.#.city_name",
 			selectExpect: []string{"Oakland"},
 		},
-		// geometry
+		// bbox
 		{
 			name:         "region bbox comes from the admin polygon",
 			query:        `query{ places(level: ADM0_ADM1, where: {adm1_name: "California"}) { bbox } }`,
@@ -103,10 +103,11 @@ func TestPlaceResolver(t *testing.T) {
 			selectExpect: []string{"-122.73241922786842"},
 		},
 		{
-			name:         "region geometry is the admin polygon",
-			query:        `query{ places(level: ADM0_ADM1, where: {adm1_name: "California"}) { geometry } }`,
-			selector:     "places.0.geometry.type",
-			selectExpect: []string{"MultiPolygon"},
+			// A level that identifies a city by fewer names still gets a box.
+			name:         "city bbox at a coarser level",
+			query:        `query{ places(level: ADM0_CITY, where: {city_name: "Oakland"}) { bbox } }`,
+			selector:     "places.0.bbox.coordinates.0.0.0",
+			selectExpect: []string{"-122.73241922786842"},
 		},
 		// operators
 		{

--- a/server/gql/query_resolver.go
+++ b/server/gql/query_resolver.go
@@ -103,7 +103,11 @@ func (r *queryResolver) Operators(ctx context.Context, limit *int, after *int, i
 
 func (r *queryResolver) Places(ctx context.Context, limit *int, after *int, level *model.PlaceAggregationLevel, where *model.PlaceFilter) ([]*model.Place, error) {
 	cfg := model.ForContext(ctx)
-	return cfg.Finder.FindPlaces(ctx, resolverCheckLimit(limit), checkCursor(after), nil, level, where)
+	geom := model.PlaceGeometrySelect{
+		Geometry: containsField(ctx, "geometry"),
+		Bbox:     containsField(ctx, "bbox"),
+	}
+	return cfg.Finder.FindPlaces(ctx, resolverCheckLimit(limit), checkCursor(after), nil, level, where, geom)
 }
 
 func (r *queryResolver) CensusDatasets(ctx context.Context, limit *int, after *int, ids []int, where *model.CensusDatasetFilter) ([]*model.CensusDataset, error) {

--- a/server/gql/query_resolver.go
+++ b/server/gql/query_resolver.go
@@ -103,10 +103,7 @@ func (r *queryResolver) Operators(ctx context.Context, limit *int, after *int, i
 
 func (r *queryResolver) Places(ctx context.Context, limit *int, after *int, level *model.PlaceAggregationLevel, where *model.PlaceFilter) ([]*model.Place, error) {
 	cfg := model.ForContext(ctx)
-	geom := model.PlaceGeometrySelect{
-		Geometry: containsField(ctx, "geometry"),
-		Bbox:     containsField(ctx, "bbox"),
-	}
+	geom := model.PlaceGeometrySelect{Bbox: containsField(ctx, "bbox")}
 	return cfg.Finder.FindPlaces(ctx, resolverCheckLimit(limit), checkCursor(after), nil, level, where, geom)
 }
 

--- a/server/model/finders.go
+++ b/server/model/finders.go
@@ -38,7 +38,7 @@ type EntityFinder interface {
 	FindFeedVersions(context.Context, *int, *Cursor, []int, *FeedVersionFilter) ([]*FeedVersion, error)
 	FindFeeds(context.Context, *int, *Cursor, []int, *FeedFilter) ([]*Feed, error)
 	FindOperators(context.Context, *int, *Cursor, []int, *OperatorFilter) ([]*Operator, error)
-	FindPlaces(context.Context, *int, *Cursor, []int, *PlaceAggregationLevel, *PlaceFilter) ([]*Place, error)
+	FindPlaces(context.Context, *int, *Cursor, []int, *PlaceAggregationLevel, *PlaceFilter, PlaceGeometrySelect) ([]*Place, error)
 	FindCensusDatasets(context.Context, *int, *Cursor, []int, *CensusDatasetFilter) ([]*CensusDataset, error)
 	FindCensusValuesByDatasetID(context.Context, *int, CensusCursor, int, *CensusDatasetValueFilter) ([]*CensusValue, error)
 	RouteStopBuffer(context.Context, *int, *float64, int) ([]*RouteStopBuffer, error)

--- a/server/model/models.go
+++ b/server/model/models.go
@@ -25,16 +25,10 @@ type StopPlaceParam struct {
 }
 
 // PlaceGeometrySelect chooses which geometry columns a place query computes.
-// Each is a separate aggregate over the Natural Earth tables, so they are only
-// worth paying for when the caller asked for them.
+// Each is an aggregate over the Natural Earth tables, so it is only worth paying
+// for when the caller asked for it.
 type PlaceGeometrySelect struct {
-	Geometry bool
-	Bbox     bool
-}
-
-// Any reports whether any geometry column was requested.
-func (v PlaceGeometrySelect) Any() bool {
-	return v.Geometry || v.Bbox
+	Bbox bool
 }
 
 //////////

--- a/server/model/models.go
+++ b/server/model/models.go
@@ -24,6 +24,19 @@ type StopPlaceParam struct {
 	Point tlxy.Point
 }
 
+// PlaceGeometrySelect chooses which geometry columns a place query computes.
+// Each is a separate aggregate over the Natural Earth tables, so they are only
+// worth paying for when the caller asked for them.
+type PlaceGeometrySelect struct {
+	Geometry bool
+	Bbox     bool
+}
+
+// Any reports whether any geometry column was requested.
+func (v PlaceGeometrySelect) Any() bool {
+	return v.Geometry || v.Bbox
+}
+
 //////////
 
 type Feed struct {

--- a/server/model/models_gen.go
+++ b/server/model/models_gen.go
@@ -942,7 +942,14 @@ type Place struct {
 	Count int `json:"count"`
 	// Operators associated with this place
 	Operators []*Operator `json:"operators,omitempty"`
-	AgencyIDs tt.Ints     `db:"agency_ids"`
+	// Boundary of this place from Natural Earth: the region polygons, or the point of
+	// a city. Null where the place has no match there. A country collects every
+	// region below it and can be very large.
+	Geometry *tt.Geometry `json:"geometry,omitempty"`
+	// Bounding box of this place, from Natural Earth. A country covers every region
+	// it contains, so the United States reaches Alaska and Hawaii.
+	Bbox      *tt.Geometry `json:"bbox,omitempty"`
+	AgencyIDs tt.Ints      `db:"agency_ids"`
 }
 
 // Search options for associated places

--- a/server/model/models_gen.go
+++ b/server/model/models_gen.go
@@ -942,12 +942,9 @@ type Place struct {
 	Count int `json:"count"`
 	// Operators associated with this place
 	Operators []*Operator `json:"operators,omitempty"`
-	// Boundary of this place from Natural Earth: the region polygons, or the point of
-	// a city. Null where the place has no match there. A country collects every
-	// region below it and can be very large.
-	Geometry *tt.Geometry `json:"geometry,omitempty"`
-	// Bounding box of this place, from Natural Earth. A country covers every region
-	// it contains, so the United States reaches Alaska and Hawaii.
+	// Bounding box of this place, from Natural Earth; null where it has no match
+	// there. A country covers every region it contains, so the United States reaches
+	// Alaska and Hawaii.
 	Bbox      *tt.Geometry `json:"bbox,omitempty"`
 	AgencyIDs tt.Ints      `db:"agency_ids"`
 }

--- a/server/model/unimplemented_finder.go
+++ b/server/model/unimplemented_finder.go
@@ -88,7 +88,7 @@ func (UnimplementedFinder) FindFeeds(context.Context, *int, *Cursor, []int, *Fee
 func (UnimplementedFinder) FindOperators(context.Context, *int, *Cursor, []int, *OperatorFilter) ([]*Operator, error) {
 	return nil, notImplErr()
 }
-func (UnimplementedFinder) FindPlaces(context.Context, *int, *Cursor, []int, *PlaceAggregationLevel, *PlaceFilter) ([]*Place, error) {
+func (UnimplementedFinder) FindPlaces(context.Context, *int, *Cursor, []int, *PlaceAggregationLevel, *PlaceFilter, PlaceGeometrySelect) ([]*Place, error) {
 	return nil, notImplErr()
 }
 func (UnimplementedFinder) FindCensusDatasets(context.Context, *int, *Cursor, []int, *CensusDatasetFilter) ([]*CensusDataset, error) {


### PR DESCRIPTION
## Summary

Adds an optional `bbox` field to the `Place` type, resolved from the same Natural Earth tables the place associations themselves are built from. It costs nothing unless the query selects it: the resolver inspects the requested fields and the place query adds the join or subquery only when `bbox` was asked for. There are no new tables, columns or migrations, and nothing about how places are matched or counted changes.

### Place extent

- `Place.bbox` returns the bounding box of a place, and null where the place has no Natural Earth match — a place whose names came from a feed's own admin data keeps its row rather than being dropped.
- A country covers every region it contains, not only the regions that have operators, so the United States reaches Alaska and Hawaii. That comes from a subquery over all of a country's regions, because the join used at finer levels would reach only the regions present in an association.
- A region takes the extent of its admin-1 polygons. Because a level that groups down to a single region joins exactly that region's rows, the aggregate over the join is already the whole answer and no subquery is needed.
- Cities are points in Natural Earth, so a city extent is that point buffered by 40 km, mirroring the radius `AgencyPlaceBuilder` uses to associate a stop with a populated place. It is a named constant here rather than a literal in the SQL, but the builder still has its own copy in `ext/builders/agency_place_builder.go`, so the two are documented as matching rather than shared — changing one means changing the other.
- Every level that identifies a city gets a box, including the levels that name it with fewer parts. Those levels group several distinct cities together when a name repeats — 63 name collisions within a single country, 188 worldwide — and the box widens to cover them, the same way the group's count already covers them.
- `ST_Extent` returns a box2d rather than a geometry, so the result is cast and tagged with SRID 4326 to match the other geometry columns.

### Computed only when requested

- `FindPlaces` takes a `PlaceGeometrySelect` describing whether to compute the box, and the query resolver fills it in from `containsField`, the same helper the stop resolver uses to skip unrequested departure work.
- A query that does not select `bbox` produces exactly the SQL it did before: no Natural Earth join and no subquery. This matters because aggregating extents for every country at once measures around 126 ms against roughly 6 ms for the regions of a single country, and the gating is what keeps that off the common path.

## Test plan

- `places(level: ADM0_ADM1, where: {adm1_name: "California"}) { bbox }` returns a box whose western edge is about -124.409, the state's actual coastline.
- `places(level: ADM0, where: {adm0_name: "United States of America"}) { bbox }` reaches about -179.14, confirming a country spans every region rather than stopping at the ones with operators.
- `places(level: ADM0_ADM1_CITY, where: {city_name: "Oakland"}) { bbox }` returns the Natural Earth point widened by 40 km in both axes, and the same query at `ADM0_CITY`, `ADM1_CITY` and `CITY` returns the same box rather than null.
- Run a places query without `bbox` selected and with query logging on, and confirm the emitted SQL references neither `ne_10m_admin_1_states_provinces` nor `ne_10m_populated_places`.
- Query a place whose names do not exist in Natural Earth and confirm it is still returned, with `bbox` null.
