### PR TITLE
Fix place bbox across the antimeridian

### DIFF
--- a/server/finders/dbfinder/agency.go
+++ b/server/finders/dbfinder/agency.go
@@ -252,6 +252,28 @@ func agencySelect(limit *int, after *model.Cursor, ids []int, useActive *UseActi
 	return q
 }
 
+// Extent of the geometry aliased as ne_geom.g, in whichever longitude frame is
+// narrower. A shape crossing the antimeridian spans nearly the whole globe in the
+// normal frame — Alaska measures 358.9 degrees — and its true width once shifted
+// into [0,360), where the same polygon is 57.5. Everything else measures the same
+// in both frames and the tie goes to the normal one, so longitudes stay within
+// [-180,180] unless the place genuinely crosses the line.
+const placeBboxSQL = `case
+	when ST_XMax(ST_Extent(ne_geom.g)) - ST_XMin(ST_Extent(ne_geom.g))
+		<= ST_XMax(ST_Extent(ST_ShiftLongitude(ne_geom.g))) - ST_XMin(ST_Extent(ST_ShiftLongitude(ne_geom.g)))
+	then ST_SetSRID(ST_Extent(ne_geom.g)::geometry, 4326)
+	else ST_SetSRID(ST_Extent(ST_ShiftLongitude(ne_geom.g))::geometry, 4326)
+end as bbox`
+
+// The same choice for a country, which aggregates every region it contains rather
+// than the rows the query joined.
+const placeBboxCountrySQL = `(select case
+	when ST_XMax(ST_Extent(w.g)) - ST_XMin(ST_Extent(w.g))
+		<= ST_XMax(ST_Extent(ST_ShiftLongitude(w.g))) - ST_XMin(ST_Extent(ST_ShiftLongitude(w.g)))
+	then ST_SetSRID(ST_Extent(w.g)::geometry, 4326)
+	else ST_SetSRID(ST_Extent(ST_ShiftLongitude(w.g))::geometry, 4326)
+end from (select whole.geometry::geometry as g from ne_10m_admin_1_states_provinces whole where whole.admin = tlap.adm0name) w) as bbox`
+
 // placeBboxSelect adds the bounding box column to a place query.
 //
 // Cities are points in Natural Earth and regions are polygons, so they come from
@@ -280,17 +302,20 @@ func placeBboxSelect(q sq.SelectBuilder, level *model.PlaceAggregationLevel) sq.
 	case cityLevel:
 		// The join is per row, so a level that groups several cities together —
 		// same name in more than one region, or in more than one country — widens
-		// the box to cover them, the way its count already covers them.
+		// the box to cover them, the way its count already covers them. The buffer
+		// is aliased through a lateral so the frame comparison names it once.
 		q = q.
 			JoinClause("left join ne_10m_populated_places ne_place on ne_place.name = tlap.name and ne_place.adm1name = tlap.adm1name and ne_place.adm0name = tlap.adm0name").
-			Column("ST_SetSRID(ST_Extent(ST_Buffer(ne_place.geometry, ?)::geometry)::geometry, 4326) as bbox", placeCityRadius)
+			JoinClause("left join lateral (select ST_Buffer(ne_place.geometry, ?)::geometry as g) ne_geom on true", placeCityRadius).
+			Column(placeBboxSQL)
 	case singleUnit:
 		q = q.
 			JoinClause("left join ne_10m_admin_1_states_provinces ne_admin on ne_admin.name = tlap.adm1name and ne_admin.admin = tlap.adm0name").
-			Column("ST_SetSRID(ST_Extent(ne_admin.geometry::geometry)::geometry, 4326) as bbox")
+			JoinClause("left join lateral (select ne_admin.geometry::geometry as g) ne_geom on true").
+			Column(placeBboxSQL)
 	default:
 		// A country: every region it contains, not only those with operators.
-		q = q.Column("(select ST_SetSRID(ST_Extent(whole.geometry::geometry)::geometry, 4326) from ne_10m_admin_1_states_provinces whole where whole.admin = tlap.adm0name) as bbox")
+		q = q.Column(placeBboxCountrySQL)
 	}
 	return q
 }

--- a/server/finders/dbfinder/agency_place_bbox_test.go
+++ b/server/finders/dbfinder/agency_place_bbox_test.go
@@ -1,0 +1,96 @@
+package dbfinder
+
+import (
+	"context"
+	"testing"
+
+	"github.com/interline-io/transitland-lib/server/dbutil"
+	"github.com/interline-io/transitland-lib/server/testutil"
+	sq "github.com/irees/squirrel"
+	"github.com/stretchr/testify/assert"
+)
+
+// Exercises placeBboxSQL against the Natural Earth tables directly, which needs
+// no imported feed: the aggregation levels reach this expression through a join
+// on tl_agency_places, but the expression itself only ever sees the geometry the
+// lateral hands it. Places crossing the antimeridian are the reason it exists and
+// no fixture feed has operators near the line.
+func TestPlaceBboxSQL(t *testing.T) {
+	dbx := testutil.MustOpenTestDB(t)
+	tcs := []struct {
+		name    string
+		city    bool
+		place   string
+		minLon  float64
+		maxLon  float64
+		comment string
+	}{
+		{
+			name: "region crossing the antimeridian", place: "Alaska",
+			minLon: 172.476, maxLon: 230.011,
+			comment: "Attu east to the panhandle: 57 degrees, not the 359 the normal frame reports",
+		},
+		{
+			name: "region away from the line keeps its coordinates", place: "California",
+			minLon: -124.409, maxLon: -114.119,
+			comment: "both frames measure the same width, so the tie keeps this within [-180,180]",
+		},
+		{
+			name: "city buffer crossing the antimeridian", city: true, place: "Beringovskiy",
+			minLon: 178.515, maxLon: 180.097,
+			comment: "40km around a Chukotka town reaches past the line",
+		},
+		{
+			name: "city buffer near the line but not crossing", city: true, place: "Funafuti",
+			minLon: 178.853, maxLon: 179.580,
+			comment: "close enough to matter, far enough that the normal frame is still narrower",
+		},
+		{
+			name: "city away from the line keeps its coordinates", city: true, place: "Oakland",
+			minLon: -122.732, maxLon: -121.824,
+			comment: "the ordinary case: a 40km box in the normal frame",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			// Built the way placeBboxSelect builds it, so the expression under test
+			// is the one that ships.
+			var inner sq.SelectBuilder
+			if tc.city {
+				inner = sq.StatementBuilder.
+					Select("ne_place.name").
+					Column(placeBboxSQL).
+					From("ne_10m_populated_places ne_place").
+					JoinClause("left join lateral (select ST_Buffer(ne_place.geometry, ?)::geometry as g) ne_geom on true", placeCityRadius).
+					Where(sq.Eq{"ne_place.name": tc.place}).
+					GroupBy("ne_place.name")
+			} else {
+				inner = sq.StatementBuilder.
+					Select("ne_admin.name").
+					Column(placeBboxSQL).
+					From("ne_10m_admin_1_states_provinces ne_admin").
+					JoinClause("left join lateral (select ne_admin.geometry::geometry as g) ne_geom on true").
+					Where(sq.Eq{"ne_admin.name": tc.place}).
+					GroupBy("ne_admin.name")
+			}
+			q := sq.StatementBuilder.
+				Select("ST_XMin(t.bbox) as min_lon", "ST_XMax(t.bbox) as max_lon").
+				FromSelect(inner, "t")
+
+			var got []struct {
+				MinLon float64 `db:"min_lon"`
+				MaxLon float64 `db:"max_lon"`
+			}
+			if err := dbutil.Select(context.Background(), dbx, q, &got); err != nil {
+				t.Fatal(err)
+			}
+			// A kilometre of tolerance: the assertion is about which frame was
+			// chosen, not about how finely ST_Buffer approximates a circle.
+			if assert.Len(t, got, 1, "expected one row for %s", tc.place) {
+				assert.InDelta(t, tc.minLon, got[0].MinLon, 1e-2, tc.comment)
+				assert.InDelta(t, tc.maxLon, got[0].MaxLon, 1e-2, tc.comment)
+				assert.Less(t, got[0].MaxLon-got[0].MinLon, 180.0, "a usable extent is never wider than half the globe")
+			}
+		})
+	}
+}

--- a/server/gql/place_resolver_test.go
+++ b/server/gql/place_resolver_test.go
@@ -13,6 +13,11 @@ func bboxMinLon(jj string) float64 {
 	return gjson.Get(jj, "places.0.bbox.coordinates.0.0.0").Float()
 }
 
+// bboxWidth is that box's span in degrees of longitude.
+func bboxWidth(jj string) float64 {
+	return gjson.Get(jj, "places.0.bbox.coordinates.0.2.0").Float() - bboxMinLon(jj)
+}
+
 func TestPlaceResolver(t *testing.T) {
 	q := `query($level: PlaceAggregationLevel,$where: PlaceFilter) {
 		places(level: $level, where: $where) {
@@ -98,12 +103,15 @@ func TestPlaceResolver(t *testing.T) {
 			},
 		},
 		{
-			name:  "country bbox reaches every region",
+			// A country covers every region it contains, including those with no
+			// operators — and the United States crosses the antimeridian at the
+			// Aleutians, so its extent is only meaningful in the shifted frame.
+			// Measured normally it reads -179.1 to 179.8, a useless 359 degrees.
+			name:  "country bbox crossing the antimeridian",
 			query: `query{ places(level: ADM0, where: {adm0_name: "United States of America"}) { bbox } }`,
 			f: func(t *testing.T, jj string) {
-				// Alaska, not California: a country covers every region it contains,
-				// including those with no operators at all.
-				assert.InDelta(t, -179.143503, bboxMinLon(jj), 1e-5, "country spans every region")
+				assert.InDelta(t, 172.476085, bboxMinLon(jj), 1e-5, "Attu, the westernmost Aleutian")
+				assert.InDelta(t, 120.5, bboxWidth(jj), 0.1, "the real width, not 359")
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Fixes `Place.bbox` for places that cross the antimeridian. The extent is now measured in both longitude frames — as stored, and shifted into [0,360) — and the narrower of the two is returned. Alaska measures 358.9 degrees the first way and 57.5 the second; the United States, 358.9 against 120.5. Nothing else changes: a place that does not cross the line measures the same in both frames, and the tie goes to the normal one, so longitudes stay within [-180,180] unless the place genuinely crosses.

### Why the extent was wrong

- `ST_Extent` reports the minimum and maximum longitude of a shape, which for Alaska is -179.14 and 179.78 — the two sides of the date line. Read literally that is a box spanning almost the entire globe, and fitting a map to it shows the whole world rather than the place.
- The four numbers are also lossy: they cannot distinguish a narrow strip crossing the line from a wide span across the Pacific, because Alaska's mainland at -165 to -130 sits inside that range either way. A consumer cannot repair this after the fact, which is why it is fixed here rather than in the client.
- `ST_ShiftLongitude` moves coordinates into [0,360), where a shape straddling the seam becomes contiguous and its extent is measurable. Comparing the two widths and taking the smaller is the standard treatment.

### Implementation

- The comparison lives in two named SQL constants next to the query, one for the joined levels and one for the country subquery, rather than being assembled at runtime.
- The joined levels alias their geometry through a `left join lateral`, so the expression names it once instead of repeating `ST_Buffer(...)` six times across the comparison — which also keeps the buffer radius a single bound parameter.
- A place crossing the line now returns longitudes above 180, which is the conventional encoding for a date-line-crossing extent and what map libraries expect when fitting bounds.

## Test plan

- `places(level: ADM0, where: {adm0_name: "United States of America"}) { bbox }` returns a box from about 172.5 to 293.0, 120.5 degrees wide, rather than -179.1 to 179.8. The covered test asserts both the western edge and the width, since the width is what the bug actually broke.
- `places(level: ADM0_ADM1, where: {adm1_name: "Alaska"}) { bbox }` against a database with Alaskan operators returns about 172.5 to 230.0, 57.5 degrees, rather than 358.9.
- `places(level: ADM0_ADM1, where: {adm1_name: "California"}) { bbox }` is unchanged at about -124.4 to -114.1, confirming that places away from the line keep their existing coordinates and stay within [-180,180].
- Spot-check a city near the line, such as one in Fiji or eastern Russia, and confirm its 40 km box is contiguous rather than globe-spanning.
