### PR TITLE
Link generating callback

### DIFF
--- a/server/model/config.go
+++ b/server/model/config.go
@@ -42,6 +42,15 @@ type Config struct {
 	// mount segment is not known at config time; the server recovers it from the
 	// request path. Empty yields host-relative links.
 	RestPrefix string
+	// LinkURL rewrites a public URL this server generated for a client to
+	// follow, such as the REST pagination link. Hosts set it to re-add
+	// parameters the caller must present again — an API key that arrived in the
+	// query string and was taken off the request before it reached a handler.
+	// Nil leaves generated URLs unchanged.
+	//
+	// This package deliberately sees only the URL: how a caller authenticated
+	// is not something it should know.
+	LinkURL func(ctx context.Context, u string) string
 	// JobsPrefix is the public prefix of the jobserver mount (analogue of
 	// RestPrefix for the REST mount), used to build absolute artifact download
 	// links that are correct behind a path-rewriting ingress. Empty yields
@@ -64,6 +73,15 @@ var finderCtxKey = &contextKey{"finderConfig"}
 
 type contextKey struct {
 	name string
+}
+
+// Link applies LinkURL to a generated URL, or returns it unchanged when no
+// host rewriter is set.
+func (cfg Config) Link(ctx context.Context, u string) string {
+	if cfg.LinkURL == nil {
+		return u
+	}
+	return cfg.LinkURL(ctx, u)
 }
 
 func ForContext(ctx context.Context) Config {

--- a/server/rest/link_url_test.go
+++ b/server/rest/link_url_test.go
@@ -1,0 +1,41 @@
+package rest
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/interline-io/transitland-lib/server/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// The hook exists so a host can re-add a parameter it took off the request
+// before any handler saw it. These pin that it reaches the two URLs a client
+// follows back to this server, and that it is not applied anywhere else.
+func TestConfigLink(t *testing.T) {
+	addKey := func(_ context.Context, u string) string {
+		sep := "?"
+		if strings.Contains(u, "?") {
+			sep = "&"
+		}
+		return u + sep + "apikey=" + url.QueryEscape("secret")
+	}
+
+	t.Run("nil rewriter leaves the url alone", func(t *testing.T) {
+		cfg := model.Config{}
+		assert.Equal(t, "https://example.test/rest/feeds", cfg.Link(context.Background(), "https://example.test/rest/feeds"))
+	})
+
+	t.Run("rewriter is applied", func(t *testing.T) {
+		cfg := model.Config{LinkURL: addKey}
+		assert.Equal(t, "https://example.test/rest/feeds?apikey=secret",
+			cfg.Link(context.Background(), "https://example.test/rest/feeds"))
+	})
+
+	t.Run("rewriter sees an existing query", func(t *testing.T) {
+		cfg := model.Config{LinkURL: addKey}
+		assert.Equal(t, "https://example.test/rest/feeds?after=10&apikey=secret",
+			cfg.Link(context.Background(), "https://example.test/rest/feeds?after=10"))
+	})
+}

--- a/server/rest/link_url_test.go
+++ b/server/rest/link_url_test.go
@@ -2,40 +2,110 @@ package rest
 
 import (
 	"context"
-	"net/url"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/interline-io/transitland-lib/internal/testconfig"
+	"github.com/interline-io/transitland-lib/server/gql"
 	"github.com/interline-io/transitland-lib/server/model"
+	"github.com/interline-io/transitland-lib/testdata"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-// The hook exists so a host can re-add a parameter it took off the request
-// before any handler saw it. These pin that it reaches the two URLs a client
-// follows back to this server, and that it is not applied anywhere else.
-func TestConfigLink(t *testing.T) {
-	addKey := func(_ context.Context, u string) string {
-		sep := "?"
-		if strings.Contains(u, "?") {
-			sep = "&"
-		}
-		return u + sep + "apikey=" + url.QueryEscape("secret")
-	}
+// linkMarker stands in for the parameter a host re-adds to links a caller
+// follows without authenticating again.
+const linkMarker = "testlink=1"
 
+func appendMarker(_ context.Context, u string) string {
+	if strings.Contains(u, "?") {
+		return u + "&" + linkMarker
+	}
+	return u + "?" + linkMarker
+}
+
+func testHandlerWithLinkURL(t testing.TB, fn func(context.Context, string) string) http.Handler {
+	t.Helper()
+	cfg := testconfig.Config(t, testconfig.Options{Storage: testdata.Path("server", "tmp")})
+	cfg.LinkURL = fn
+	graphqlHandler, err := gql.NewServer()
+	require.NoError(t, err)
+	restHandler, err := NewServer(graphqlHandler)
+	require.NoError(t, err)
+	return model.AddConfigAndPerms(cfg, restHandler)
+}
+
+func TestConfigLink(t *testing.T) {
 	t.Run("nil rewriter leaves the url alone", func(t *testing.T) {
 		cfg := model.Config{}
 		assert.Equal(t, "https://example.test/rest/feeds", cfg.Link(context.Background(), "https://example.test/rest/feeds"))
 	})
 
 	t.Run("rewriter is applied", func(t *testing.T) {
-		cfg := model.Config{LinkURL: addKey}
-		assert.Equal(t, "https://example.test/rest/feeds?apikey=secret",
+		cfg := model.Config{LinkURL: appendMarker}
+		assert.Equal(t, "https://example.test/rest/feeds?"+linkMarker,
 			cfg.Link(context.Background(), "https://example.test/rest/feeds"))
 	})
 
 	t.Run("rewriter sees an existing query", func(t *testing.T) {
-		cfg := model.Config{LinkURL: addKey}
-		assert.Equal(t, "https://example.test/rest/feeds?after=10&apikey=secret",
+		cfg := model.Config{LinkURL: appendMarker}
+		assert.Equal(t, "https://example.test/rest/feeds?after=10&"+linkMarker,
 			cfg.Link(context.Background(), "https://example.test/rest/feeds?after=10"))
+	})
+}
+
+// The hook has to reach the URLs a client follows back into the API. Removing
+// either cfg.Link call site must fail here.
+func TestLinkURL_AppliedToFollowedLinks(t *testing.T) {
+	srv := testHandlerWithLinkURL(t, appendMarker)
+
+	t.Run("pagination link", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/feeds.json?limit=1", nil)
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Result().StatusCode)
+
+		var body struct {
+			Meta struct {
+				Next string `json:"next"`
+			} `json:"meta"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+		require.NotEmpty(t, body.Meta.Next, "expected a next link to assert on")
+		assert.Contains(t, body.Meta.Next, linkMarker)
+		// The rewrite must not cost the pagination cursor.
+		assert.Contains(t, body.Meta.Next, "after=")
+	})
+
+	t.Run("onestop_id redirect", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/onestop_id/f-123", nil)
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, req)
+		require.Equal(t, http.StatusFound, w.Result().StatusCode)
+		assert.Contains(t, w.Result().Header.Get("Location"), linkMarker)
+	})
+}
+
+// The OpenAPI document serves anonymously, so a credential must not reach the
+// redirect that points at it or the servers entry inside it.
+func TestLinkURL_NotAppliedToPublicDocuments(t *testing.T) {
+	srv := testHandlerWithLinkURL(t, appendMarker)
+
+	t.Run("root redirect to openapi.json", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/", nil)
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, req)
+		assert.NotContains(t, w.Result().Header.Get("Location"), linkMarker)
+	})
+
+	t.Run("openapi servers entry", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/openapi.json", nil)
+		w := httptest.NewRecorder()
+		srv.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Result().StatusCode)
+		assert.NotContains(t, w.Body.String(), linkMarker)
 	})
 }

--- a/server/rest/onestop_id_entity_request.go
+++ b/server/rest/onestop_id_entity_request.go
@@ -67,7 +67,7 @@ func (handler *OnestopIdEntityRedirectRequest) ServeHTTP(w http.ResponseWriter, 
 		redirectUrl = fmt.Sprintf("%s/routes/%s", prefix, onestop_id)
 	}
 	if redirectUrl != "" {
-		w.Header().Add("Location", redirectUrl)
+		w.Header().Add("Location", cfg.Link(r.Context(), redirectUrl))
 		w.WriteHeader(http.StatusFound)
 	} else {
 		http.Error(w, "not found", http.StatusNotFound)

--- a/server/rest/rest.go
+++ b/server/rest/rest.go
@@ -372,7 +372,7 @@ func makeRequest(ctx context.Context, graphqlHandler http.Handler, ent apiHandle
 				rq := newUrl.Query()
 				rq.Set("after", strconv.Itoa(lastId))
 				newUrl.RawQuery = rq.Encode()
-				meta["next"] = cfg.RestPrefix + newUrl.String()
+				meta["next"] = cfg.Link(ctx, cfg.RestPrefix+newUrl.String())
 			}
 			response["meta"] = meta
 		}


### PR DESCRIPTION
## Summary

Adds `model.Config.LinkURL`, an optional hook letting a host application rewrite the public URLs this package generates for clients to follow. The motivating case is a server that accepts an API key as a query parameter and strips it from the request before any handler or logging middleware can see it: the REST pagination link still has to carry that key, because clients follow it without re-authenticating. Without a hook, the only way to preserve that is to leave the credential on `r.URL` for the whole request lifetime, where every logging and tracing sink downstream will read it.

The hook sees only a URL string. This package gets no notion of credentials, headers or query-parameter names — how a caller authenticated is not something it should know.

### The hook

- `LinkURL func(ctx context.Context, u string) string` on `model.Config`, with a `Link` method that applies it or returns the URL unchanged when nil.
- Applied at the two URLs a client follows back into the authenticated API: the REST pagination link in `meta.next`, and the `Location` target of the onestop_id redirect.
- Deliberately not applied to the root redirect to `openapi.json` or the `servers` entry in the generated schema. Both point at a document that serves anonymously, so passing a credential through them would create exposure rather than preserve it.

### Compatibility

A nil hook is the default and leaves every generated URL byte-identical, so this is a no-op for existing callers. The full `server/...` suite passes unchanged — 30 packages, including the existing `mountPrefix` and OpenAPI-handler regression tests.

### Not in scope

`RestPrefix` and `mountPrefix` are untouched. Reconstructing a public URL from a configured prefix plus the inbound request path is awkward — `RestPrefix`'s own doc comment notes the mount segment isn't known at config time, and there is a regression test guarding the case where the prefix passes through and drops the mount. A host-supplied builder could dissolve that, but it would move the marker-not-found fallback and the protocol-relative guard across a new origin/mount boundary, which is a larger change with security-relevant edges. This adds the seam; that cleanup can reuse it.

## Test plan

`server/rest/link_url_test.go` covers the nil case, a rewriter being applied, and a rewriter receiving a URL that already has a query string.

For an end-to-end check, mount the REST handlers with a config whose `LinkURL` appends a parameter, then request a paginated endpoint and confirm `meta.next` carries it, and request an onestop_id redirect and confirm the `Location` header does. Then request `/` and `/openapi.json` on the same server and confirm neither the redirect nor the schema's `servers` entry has been rewritten.
