### PR TITLE
Only attach realtime updates when the query selects them

### DIFF
--- a/server/gql/resolver.go
+++ b/server/gql/resolver.go
@@ -111,6 +111,21 @@ func containsField(ctx context.Context, fieldName string) bool {
 	return false
 }
 
+// wantsRTStopTimeUpdate reports whether the selection needs a realtime update
+// attached to each stop time.
+//
+// These are the only fields that read StopTime.RTStopTimeUpdate, so when none
+// is selected the lookup is unobservable rather than merely wasted.
+func wantsRTStopTimeUpdate(ctx context.Context) bool {
+	for _, field := range graphql.CollectFieldsCtx(ctx, nil) {
+		switch field.Name {
+		case "arrival", "departure", "schedule_relationship":
+			return true
+		}
+	}
+	return false
+}
+
 func convertScheduleRelationship(sr string) *model.ScheduleRelationship {
 	var msr model.ScheduleRelationship
 	switch sr {

--- a/server/gql/stop_resolver.go
+++ b/server/gql/stop_resolver.go
@@ -113,7 +113,7 @@ func (r *stopResolver) getStopTimes(ctx context.Context, obj *model.Stop, limit 
 	// Merge scheduled stop times with rt stop times
 	// TODO: handle StopTimeFilter in RT
 	// Handle scheduled trips; these can be matched on trip_id or (route_id,direction_id,...)
-	if containsField(ctx, "arrival") || containsField(ctx, "departure") {
+	if wantsRTStopTimeUpdate(ctx) {
 		for _, st := range sts {
 			ft := model.Trip{}
 			ft.FeedVersionID = obj.FeedVersionID

--- a/server/gql/stop_resolver_rt_test.go
+++ b/server/gql/stop_resolver_rt_test.go
@@ -519,3 +519,37 @@ func TestStopRT_Alerts(t *testing.T) {
 		testRt(t, tc)
 	}
 }
+
+// schedule_relationship must answer the same whether or not arrival and
+// departure are also selected. It once did not — population was gated on those
+// two, so asking for it alone reported STATIC for rescheduled stop times.
+func TestStopRT_ScheduleRelationshipWithoutArrivalDeparture(t *testing.T) {
+	const query = `query($stop_id: String!, $stf: StopTimeFilter) {
+		stops(where: {stop_id: $stop_id}) {
+			stop_times(where: $stf) {
+				schedule_relationship
+				trip { trip_id }
+			}
+		}
+	}`
+	testRt(t, rtTestCase{
+		name:    "schedule_relationship alone",
+		query:   query,
+		vars:    rtTestStopQueryVars(),
+		rtfiles: []testconfig.RTJsonFile{{Feed: "BA", Ftype: "realtime_trip_updates", Fname: "BA-added.json"}},
+		cb: func(t *testing.T, jj string) {
+			checkTrip := "1131530WKDY"
+			found := false
+			for _, st := range gjson.Get(jj, "stops.0.stop_times").Array() {
+				if st.Get("trip.trip_id").String() != checkTrip {
+					continue
+				}
+				found = true
+				assert.Equal(t, "SCHEDULED", st.Get("schedule_relationship").String(), "schedule_relationship")
+			}
+			if !found {
+				t.Errorf("expected to find trip '%s'", checkTrip)
+			}
+		},
+	})
+}

--- a/server/gql/trip_resolver.go
+++ b/server/gql/trip_resolver.go
@@ -42,9 +42,11 @@ func (r *tripResolver) StopTimes(ctx context.Context, obj *model.Trip, limit *in
 		Limit:         resolverCheckLimit(limit),
 		Where:         where,
 	})()
-	for _, st := range sts {
-		if ste, ok := model.ForContext(ctx).RTFinder.FindStopTimeUpdate(ctx, obj, st); ok {
-			st.RTStopTimeUpdate = ste
+	if wantsRTStopTimeUpdate(ctx) {
+		for _, st := range sts {
+			if ste, ok := model.ForContext(ctx).RTFinder.FindStopTimeUpdate(ctx, obj, st); ok {
+				st.RTStopTimeUpdate = ste
+			}
 		}
 	}
 	return sts, err

--- a/server/gql/trip_resolver_rt_test.go
+++ b/server/gql/trip_resolver_rt_test.go
@@ -133,3 +133,28 @@ func TestTripRT_StopTimes(t *testing.T) {
 		testRt(t, tc)
 	}
 }
+
+// Realtime population on a trip's stop times is conditional on the selection,
+// so schedule_relationship has to be one of the fields that turns it on.
+func TestTripRT_ScheduleRelationshipWithoutArrivalDeparture(t *testing.T) {
+	const query = `query($trip_id: String!) {
+		trips(where: {trip_id: $trip_id}) {
+			stop_times { schedule_relationship stop_sequence }
+		}
+	}`
+	testRt(t, rtTestCase{
+		name:    "schedule_relationship alone",
+		query:   query,
+		vars:    hw{"trip_id": "1131530WKDY"},
+		rtfiles: []testconfig.RTJsonFile{{Feed: "BA", Ftype: "realtime_trip_updates", Fname: "BA-added.json"}},
+		cb: func(t *testing.T, jj string) {
+			var scheduled int
+			for _, st := range gjson.Get(jj, "trips.0.stop_times").Array() {
+				if st.Get("schedule_relationship").String() == "SCHEDULED" {
+					scheduled++
+				}
+			}
+			assert.NotZero(t, scheduled, "expected realtime-matched stop times to report SCHEDULED")
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Realtime updates were attached to every stop time a resolver returned, whether or not the query asked for anything that reads them. Matching runs per stop time against every RT feed associated with the feed version, so a schedule-only query — trip patterns, most-common-stop, anything reading `arrival_time`/`departure_time` — paid for realtime it never looked at. This adds a selection check so that work is skipped when nothing can observe it.

Only three fields read `StopTime.RTStopTimeUpdate`: `arrival`, `departure`, and `schedule_relationship`. When none of them is selected, skipping the lookup is not a tradeoff — no resolver can tell the difference. `arrival_time` and `departure_time` are plain scalars marshalled from the row with no resolver, so a static query names none of the three and the loop disappears entirely.

For scale: on a Bay Area feed version, whose operator association reaches 36 RT feeds, resolving one 64-stop trip triggers roughly 4,600 realtime topic lookups. A query selecting only static fields now does none of them.

### The guard

`wantsRTStopTimeUpdate` collects the current field's selection set once and reports whether any of the three is present. `graphql.CollectFieldsCtx` resolves names relative to the field being resolved, so these are bare `StopTime` field names rather than paths, and it expands inline fragments and named fragment spreads, matches on the schema name rather than the alias, and honours `@skip`/`@include`. It sees one level, so `arrival { scheduled }` — which needs no realtime — still populates. That errs toward doing unnecessary work rather than returning a wrong answer.

### A bug this exposed

`Stop.stop_times` already had a guard, checking only `arrival` and `departure`. But `schedule_relationship` reads the same update: it returns `STATIC` when none is attached and `SCHEDULED`/`CANCELED`/etc. when one is. So a query asking for `schedule_relationship` *without* also asking for `arrival` or `departure` reported `STATIC` for stop times realtime had rescheduled — the answer depended on which other fields you happened to select.

`Trip.stop_times` had no guard at all, so it was unaffected by that bug but did the work unconditionally. Both now call the same helper, which is the point: the reason the stop path was wrong is that the field list was written inline and `schedule_relationship` was added to the model later.

### Behavior notes

Queries selecting `schedule_relationship` without `arrival` or `departure` now do realtime work they previously skipped, so they get slower. That is the fix — they were previously fast because they were wrong.

Added trips stay outside the guard on the stop path. `Stop.stop_times` appends realtime-derived rows for added trips regardless of selection, because a static-only feed still needs them discovered. So on that path the guard suppresses realtime *fields*, not realtime-derived *rows*.

Ordering is unaffected: `getStopTimes` sorts by scheduled departure time, not by realtime.

### Tests

Two, one per resolver, each requesting `schedule_relationship` alone and asserting it still reflects realtime. Both were verified by mutation — reverting the guard to `arrival || departure` makes them fail, so they hold the behavior rather than restating it.

They cover the bug fix, not the skip. Nothing yet asserts that a static-only query performs no realtime lookups, because the skip is deliberately invisible in the response — a regression that made the guard always return true would pass the suite. Pinning it means counting calls through a wrapped `RTFinder` in the test config.

## Test plan

- Against a feed version with live realtime, query a trip's `stop_times` selecting only `stop_sequence`, `arrival_time`, `departure_time`, and confirm the `found stop time update on trip_id/...` trace lines are absent for that request id. Adding `arrival { time_utc }` to the same query brings them back.
- Query a stop's `stop_times` selecting `schedule_relationship` without `arrival` or `departure`, against a feed with realtime, and confirm rescheduled stop times report `SCHEDULED` rather than `STATIC`. On main this returns `STATIC`.
- Confirm a query selecting `arrival` or `departure` returns unchanged results against main.
