### PR TITLE
Only load and decode the RT topics a process actually serves

### DIFF
--- a/server/finders/rtfinder/cache.go
+++ b/server/finders/rtfinder/cache.go
@@ -14,8 +14,7 @@ const (
 	lastTTL = 5 * time.Minute
 	// missingTTL is how long a topic the store could not answer for is
 	// remembered as absent. Roughly a feed's publish cadence: checking more
-	// often cannot find anything new, and a cold read is the only way a topic
-	// that starts publishing is noticed once drain is filtered to held topics.
+	// often cannot find anything new.
 	missingTTL = 1 * time.Minute
 	// reconnectDelay paces re-subscription attempts.
 	reconnectDelay = 1 * time.Second
@@ -41,10 +40,8 @@ type storeCache struct {
 	wg      sync.WaitGroup
 	lock    sync.Mutex
 	sources map[string]*Source
-	// missing records topics the store had nothing for. Callers loop over
-	// every RT feed associated with a feed version, most of which carry
-	// nothing for a given trip, and without this each one is a fresh round
-	// trip on every call.
+	// missing records topics the store had nothing for, so a caller looping
+	// over dozens of associated feeds does not re-read each one every time.
 	missing map[string]time.Time
 }
 
@@ -108,10 +105,9 @@ func (c *storeCache) GetSource(ctx context.Context, topic string) (*Source, bool
 		c.lock.Lock()
 		c.missing[topic] = time.Now()
 		c.lock.Unlock()
-		// Both outcomes are remembered, so a caller looping over every
-		// associated feed does not re-read each one. They are logged apart
-		// because they mean different things: absent is a quiet feed, failed
-		// is the store not answering.
+		// Both outcomes are remembered so a caller looping over every
+		// associated feed does not re-read each one, but they are logged
+		// apart: absent is a quiet feed, failed is the store not answering.
 		if err != nil {
 			log.For(ctx).Trace().Str("topic", topic).Dur("retry_after", missingTTL).Msg("rtcache: topic read failed, not retried until this expires")
 		} else {
@@ -185,13 +181,10 @@ func (c *storeCache) drain(sub kvcache.Subscription) {
 	}
 }
 
-// loadFromStore reads a topic's last payload and decodes it into a fresh
-// Source. The read honors the caller's context, so a canceled GetSource aborts
-// promptly.
+// loadFromStore reads and decodes a topic's last payload.
 //
 // A nil Source with a nil error means the store definitely held nothing; a
-// non-nil error means it could not say. Callers treat both as a miss, but only
-// the caller knows what to do about the difference.
+// non-nil error means it could not say. Callers treat both as a miss.
 func (c *storeCache) loadFromStore(ctx context.Context, topic string) (*Source, error) {
 	rctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
@@ -212,8 +205,7 @@ func (c *storeCache) loadFromStore(ctx context.Context, topic string) (*Source, 
 }
 
 // watching reports whether this process holds a snapshot for topic, which is
-// true only of topics a caller has asked for. It is the subscription filter:
-// announcements for anything else are dropped before the store is read.
+// true only of topics a caller has asked for.
 func (c *storeCache) watching(topic string) bool {
 	c.lock.Lock()
 	defer c.lock.Unlock()

--- a/server/finders/rtfinder/cache.go
+++ b/server/finders/rtfinder/cache.go
@@ -12,6 +12,10 @@ import (
 const (
 	// lastTTL bounds how long a topic's last-seen payload survives in the store.
 	lastTTL = 5 * time.Minute
+	// missingTTL is how long a topic the store had nothing for is remembered
+	// as absent. Short, because a cold read is the only way a newly published
+	// topic is noticed once drain is filtered to held topics.
+	missingTTL = 5 * time.Second
 	// reconnectDelay paces re-subscription attempts.
 	reconnectDelay = 1 * time.Second
 	// updatesChannel carries topic pointers to the notify-then-read listeners.
@@ -36,6 +40,11 @@ type storeCache struct {
 	wg      sync.WaitGroup
 	lock    sync.Mutex
 	sources map[string]*Source
+	// missing records topics the store had nothing for. Callers loop over
+	// every RT feed associated with a feed version, most of which carry
+	// nothing for a given trip, and without this each one is a fresh round
+	// trip on every call.
+	missing map[string]time.Time
 }
 
 func newStoreCache(store kvcache.Store) *storeCache {
@@ -45,6 +54,7 @@ func newStoreCache(store kvcache.Store) *storeCache {
 		ctx:     ctx,
 		cancel:  cancel,
 		sources: map[string]*Source{},
+		missing: map[string]time.Time{},
 	}
 	if ps, ok := store.(kvcache.PubSubStore); ok {
 		c.pubsub = ps
@@ -86,10 +96,21 @@ func (c *storeCache) GetSource(ctx context.Context, topic string) (*Source, bool
 		c.lock.Unlock()
 		return s, true
 	}
+	if at, ok := c.missing[topic]; ok && time.Since(at) < missingTTL {
+		c.lock.Unlock()
+		return nil, false
+	}
 	c.lock.Unlock()
 	// Cold read from the shared store without holding the lock.
 	s := c.loadFromStore(ctx, topic)
+	// Only store reads are logged. The local and remembered-absent paths are
+	// map hits, and a caller looping over every associated RT feed for every
+	// stop time makes logging them thousands of lines a request.
+	log.For(ctx).Trace().Str("topic", topic).Bool("found", s != nil).Msg("rtcache: topic read")
 	if s == nil {
+		c.lock.Lock()
+		c.missing[topic] = time.Now()
+		c.lock.Unlock()
 		return nil, false
 	}
 	c.lock.Lock()
@@ -140,6 +161,12 @@ func (c *storeCache) drain(sub kvcache.Subscription) {
 				return
 			}
 			topic := string(msg)
+			// Every RT fetch in the fleet announces on this one channel, so a
+			// process must take only what it serves. Without this each process
+			// reads and decodes every feed in the system on every fetch.
+			if !c.watching(topic) {
+				continue
+			}
 			if s := c.loadFromStore(c.ctx, topic); s != nil {
 				c.putSource(topic, s)
 				log.For(c.ctx).Trace().Str("topic", topic).Msg("rtcache: processed update")
@@ -168,6 +195,16 @@ func (c *storeCache) loadFromStore(ctx context.Context, topic string) *Source {
 		return nil
 	}
 	return s
+}
+
+// watching reports whether this process holds a snapshot for topic, which is
+// true only of topics a caller has asked for. It is the subscription filter:
+// announcements for anything else are dropped before the store is read.
+func (c *storeCache) watching(topic string) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	_, ok := c.sources[topic]
+	return ok
 }
 
 // putSource installs s as the local snapshot for topic, replacing any prior one.

--- a/server/finders/rtfinder/cache.go
+++ b/server/finders/rtfinder/cache.go
@@ -12,10 +12,11 @@ import (
 const (
 	// lastTTL bounds how long a topic's last-seen payload survives in the store.
 	lastTTL = 5 * time.Minute
-	// missingTTL is how long a topic the store had nothing for is remembered
-	// as absent. Short, because a cold read is the only way a newly published
-	// topic is noticed once drain is filtered to held topics.
-	missingTTL = 5 * time.Second
+	// missingTTL is how long a topic the store could not answer for is
+	// remembered as absent. Roughly a feed's publish cadence: checking more
+	// often cannot find anything new, and a cold read is the only way a topic
+	// that starts publishing is noticed once drain is filtered to held topics.
+	missingTTL = 1 * time.Minute
 	// reconnectDelay paces re-subscription attempts.
 	reconnectDelay = 1 * time.Second
 	// updatesChannel carries topic pointers to the notify-then-read listeners.
@@ -102,17 +103,26 @@ func (c *storeCache) GetSource(ctx context.Context, topic string) (*Source, bool
 	}
 	c.lock.Unlock()
 	// Cold read from the shared store without holding the lock.
-	s := c.loadFromStore(ctx, topic)
-	// Only store reads are logged. The local and remembered-absent paths are
-	// map hits, and a caller looping over every associated RT feed for every
-	// stop time makes logging them thousands of lines a request.
-	log.For(ctx).Trace().Str("topic", topic).Bool("found", s != nil).Msg("rtcache: topic read")
+	s, err := c.loadFromStore(ctx, topic)
 	if s == nil {
 		c.lock.Lock()
 		c.missing[topic] = time.Now()
 		c.lock.Unlock()
+		// Both outcomes are remembered, so a caller looping over every
+		// associated feed does not re-read each one. They are logged apart
+		// because they mean different things: absent is a quiet feed, failed
+		// is the store not answering.
+		if err != nil {
+			log.For(ctx).Trace().Str("topic", topic).Dur("retry_after", missingTTL).Msg("rtcache: topic read failed, not retried until this expires")
+		} else {
+			log.For(ctx).Trace().Str("topic", topic).Dur("retry_after", missingTTL).Msg("rtcache: topic absent from store, not retried until this expires")
+		}
 		return nil, false
 	}
+	// Only store reads are logged. The local and remembered paths are map
+	// hits, and a caller looping over every associated feed for every stop
+	// time makes logging them thousands of lines a request.
+	log.For(ctx).Trace().Str("topic", topic).Msg("rtcache: topic read")
 	c.lock.Lock()
 	// Double-check: a concurrent update may have inserted it meanwhile.
 	if existing, ok := c.sources[topic]; ok {
@@ -167,7 +177,7 @@ func (c *storeCache) drain(sub kvcache.Subscription) {
 			if !c.watching(topic) {
 				continue
 			}
-			if s := c.loadFromStore(c.ctx, topic); s != nil {
+			if s, _ := c.loadFromStore(c.ctx, topic); s != nil {
 				c.putSource(topic, s)
 				log.For(c.ctx).Trace().Str("topic", topic).Msg("rtcache: processed update")
 			}
@@ -176,25 +186,29 @@ func (c *storeCache) drain(sub kvcache.Subscription) {
 }
 
 // loadFromStore reads a topic's last payload and decodes it into a fresh
-// Source. It returns nil on a miss or any error (treated as a miss). The
-// read honors the caller's context, so a canceled GetSource aborts promptly.
-func (c *storeCache) loadFromStore(ctx context.Context, topic string) *Source {
+// Source. The read honors the caller's context, so a canceled GetSource aborts
+// promptly.
+//
+// A nil Source with a nil error means the store definitely held nothing; a
+// non-nil error means it could not say. Callers treat both as a miss, but only
+// the caller knows what to do about the difference.
+func (c *storeCache) loadFromStore(ctx context.Context, topic string) (*Source, error) {
 	rctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 	data, ok, err := c.store.Get(rctx, lastKey(topic))
 	if err != nil {
 		log.For(ctx).Error().Err(err).Str("topic", topic).Msg("rtcache: error reading last data")
-		return nil
+		return nil, err
 	}
 	if !ok || len(data) == 0 {
-		return nil
+		return nil, nil
 	}
 	s, err := c.decode(ctx, topic, data)
 	if err != nil {
 		log.For(ctx).Error().Err(err).Str("topic", topic).Msg("rtcache: error decoding last data")
-		return nil
+		return nil, err
 	}
-	return s
+	return s, nil
 }
 
 // watching reports whether this process holds a snapshot for topic, which is

--- a/server/finders/rtfinder/cache.go
+++ b/server/finders/rtfinder/cache.go
@@ -102,6 +102,12 @@ func (c *storeCache) GetSource(ctx context.Context, topic string) (*Source, bool
 	// Cold read from the shared store without holding the lock.
 	s, err := c.loadFromStore(ctx, topic)
 	if s == nil {
+		// A caller that has gone away taught us nothing about the topic, so
+		// its cancellation must not be remembered as an absence.
+		if ctx.Err() != nil {
+			log.For(ctx).Trace().Str("topic", topic).Msg("rtcache: topic read abandoned by caller")
+			return nil, false
+		}
 		c.lock.Lock()
 		c.missing[topic] = time.Now()
 		c.lock.Unlock()
@@ -184,13 +190,19 @@ func (c *storeCache) drain(sub kvcache.Subscription) {
 // loadFromStore reads and decodes a topic's last payload.
 //
 // A nil Source with a nil error means the store definitely held nothing; a
-// non-nil error means it could not say. Callers treat both as a miss.
+// non-nil error means it could not say. Callers treat both as a miss, but must
+// check their own context before concluding anything: a read cut short by the
+// caller says nothing about the topic.
 func (c *storeCache) loadFromStore(ctx context.Context, topic string) (*Source, error) {
 	rctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 	data, ok, err := c.store.Get(rctx, lastKey(topic))
 	if err != nil {
-		log.For(ctx).Error().Err(err).Str("topic", topic).Msg("rtcache: error reading last data")
+		// A read that failed because the caller went away is not a store
+		// problem, and logging it as one floods on every client disconnect.
+		if ctx.Err() == nil {
+			log.For(ctx).Error().Err(err).Str("topic", topic).Msg("rtcache: error reading last data")
+		}
 		return nil, err
 	}
 	if !ok || len(data) == 0 {

--- a/server/finders/rtfinder/cache_test.go
+++ b/server/finders/rtfinder/cache_test.go
@@ -188,9 +188,8 @@ func TestStoreCache_RemembersMissingTopics(t *testing.T) {
 }
 
 // A store that cannot answer is remembered the same way an empty one is.
-// Callers make thousands of lookups per request, so retrying each of them
-// against a failing store would turn one slow dependency into a request that
-// never finishes.
+// Retrying every lookup against a failing store would turn one slow dependency
+// into a request that never finishes.
 func TestStoreCache_RemembersFailedReads(t *testing.T) {
 	store := &countingStore{MemoryStore: kvcache.NewMemoryStore()}
 	store.fail.Store(true)

--- a/server/finders/rtfinder/cache_test.go
+++ b/server/finders/rtfinder/cache_test.go
@@ -204,3 +204,25 @@ func TestStoreCache_RemembersFailedReads(t *testing.T) {
 	}
 	assert.EqualValues(t, 1, store.gets.Load(), "a failing store should be read once, not once per lookup")
 }
+
+// A read cut short because the caller went away says nothing about the topic,
+// so it must not be remembered as an absence — otherwise one canceled request
+// blinds every later one for a minute.
+func TestStoreCache_DoesNotRememberAbandonedReads(t *testing.T) {
+	store := &countingStore{MemoryStore: kvcache.NewMemoryStore()}
+	c := newStoreCache(store)
+	defer c.Close()
+
+	const topic = "rtabandoned"
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, ok := c.GetSource(canceled, topic); ok {
+		t.Fatal("an abandoned read must not resolve")
+	}
+
+	// A later live lookup still has to reach the store.
+	if _, ok := c.GetSource(context.Background(), topic); ok {
+		t.Fatal("the topic is genuinely absent")
+	}
+	assert.EqualValues(t, 2, store.gets.Load(), "an abandoned read must not be remembered as absence")
+}

--- a/server/finders/rtfinder/cache_test.go
+++ b/server/finders/rtfinder/cache_test.go
@@ -2,6 +2,7 @@ package rtfinder
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -150,10 +151,14 @@ func TestStoreCache_IgnoresUnwatchedTopics(t *testing.T) {
 type countingStore struct {
 	*kvcache.MemoryStore
 	gets atomic.Int64
+	fail atomic.Bool
 }
 
 func (s *countingStore) Get(ctx context.Context, key string) ([]byte, bool, error) {
 	s.gets.Add(1)
+	if s.fail.Load() {
+		return nil, false, errors.New("store unavailable")
+	}
 	return s.MemoryStore.Get(ctx, key)
 }
 
@@ -180,4 +185,23 @@ func TestStoreCache_RemembersMissingTopics(t *testing.T) {
 	s, ok := c.GetSource(ctx, topic)
 	require.True(t, ok)
 	assert.EqualValues(t, uint64(1234), s.GetTimestamp())
+}
+
+// A store that cannot answer is remembered the same way an empty one is.
+// Callers make thousands of lookups per request, so retrying each of them
+// against a failing store would turn one slow dependency into a request that
+// never finishes.
+func TestStoreCache_RemembersFailedReads(t *testing.T) {
+	store := &countingStore{MemoryStore: kvcache.NewMemoryStore()}
+	store.fail.Store(true)
+	c := newStoreCache(store)
+	defer c.Close()
+
+	ctx := context.Background()
+	for i := 0; i < 50; i++ {
+		if _, ok := c.GetSource(ctx, "rtfailing"); ok {
+			t.Fatal("a failed read must not resolve")
+		}
+	}
+	assert.EqualValues(t, 1, store.gets.Load(), "a failing store should be read once, not once per lookup")
 }

--- a/server/finders/rtfinder/cache_test.go
+++ b/server/finders/rtfinder/cache_test.go
@@ -3,6 +3,7 @@ package rtfinder
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/interline-io/transitland-lib/server/caches/kvcache"
 	"github.com/interline-io/transitland-lib/server/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -96,4 +98,86 @@ func testCache(t *testing.T, rtCache Cache) {
 	if len(found) != len(feeds) {
 		t.Errorf("got %d items, expected %d", len(found), len(feeds))
 	}
+}
+
+// The updates channel carries every RT fetch in the fleet — 10 to 100 a second
+// in production. A process must ignore announcements for topics it has not been
+// asked for, or it reads and decodes every feed in the system.
+func TestStoreCache_IgnoresUnwatchedTopics(t *testing.T) {
+	if a, ok := testutil.CheckTestRedisClient(); !ok {
+		t.Skip(a)
+		return
+	}
+	ctx := context.Background()
+	store := kvcache.NewRedisStore(testutil.MustOpenTestRedisClient(t))
+	c := newStoreCache(store)
+	defer c.Close()
+
+	now := time.Now().UnixNano()
+	watched := fmt.Sprintf("rtwatched-%d", now)
+	unwatched := fmt.Sprintf("rtunwatched-%d", now)
+	const v1, v2 = uint64(1000), uint64(2000)
+
+	// Demand one topic so it is watched, and leave the other only in the store.
+	if err := store.Set(ctx, lastKey(watched), mkRTData(v1), lastTTL); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := c.GetSource(ctx, watched); !ok {
+		t.Fatal("cold read failed")
+	}
+	if err := store.Set(ctx, lastKey(watched), mkRTData(v2), lastTTL); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Set(ctx, lastKey(unwatched), mkRTData(v1), lastTTL); err != nil {
+		t.Fatal(err)
+	}
+
+	// The watched topic refreshing proves the subscription delivered in this
+	// window, which is what makes the unwatched assertion below meaningful
+	// rather than a race that simply never fired.
+	assert.Eventually(t, func() bool {
+		_ = store.Publish(ctx, updatesChannel, []byte(unwatched))
+		_ = store.Publish(ctx, updatesChannel, []byte(watched))
+		s, ok := c.GetSource(ctx, watched)
+		return ok && s.GetTimestamp() == v2
+	}, 5*time.Second, 100*time.Millisecond, "watched topic should refresh")
+
+	assert.False(t, c.watching(unwatched), "an undemanded topic must never be read from the store")
+}
+
+// countingStore counts reads so a test can assert what a sequence of lookups
+// costs in round trips.
+type countingStore struct {
+	*kvcache.MemoryStore
+	gets atomic.Int64
+}
+
+func (s *countingStore) Get(ctx context.Context, key string) ([]byte, bool, error) {
+	s.gets.Add(1)
+	return s.MemoryStore.Get(ctx, key)
+}
+
+// Callers loop over every RT feed associated with a feed version, and most of
+// them carry nothing for a given trip. Re-reading each absent topic on every
+// lookup is what turned one query into thousands of round trips.
+func TestStoreCache_RemembersMissingTopics(t *testing.T) {
+	store := &countingStore{MemoryStore: kvcache.NewMemoryStore()}
+	c := newStoreCache(store)
+	defer c.Close()
+
+	ctx := context.Background()
+	const topic = "rtabsent"
+	for i := 0; i < 50; i++ {
+		if _, ok := c.GetSource(ctx, topic); ok {
+			t.Fatal("an absent topic must not resolve")
+		}
+	}
+	assert.EqualValues(t, 1, store.gets.Load(), "an absent topic should be read once, not once per lookup")
+
+	// A topic that arrives is served straight away rather than waiting out the
+	// TTL: the local snapshot is consulted before the record of absence.
+	require.NoError(t, c.AddData(ctx, topic, mkRTData(1234)))
+	s, ok := c.GetSource(ctx, topic)
+	require.True(t, ok)
+	assert.EqualValues(t, uint64(1234), s.GetTimestamp())
 }

--- a/server/finders/rtfinder/finder.go
+++ b/server/finders/rtfinder/finder.go
@@ -3,7 +3,6 @@ package rtfinder
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strconv"
 	"time"
 
@@ -220,17 +219,19 @@ func (f *Finder) FindAlertsForStop(ctx context.Context, t *model.Stop, limit *in
 }
 
 func (f *Finder) FindStopTimeUpdate(ctx context.Context, t *model.Trip, st *model.StopTime) (*model.RTStopTimeUpdate, bool) {
-	tid := t.TripID
 	seq := st.StopSequence.Int()
+	// Resolve the trip in each RT feed once. Both passes below ask every topic
+	// the same question, and a feed version can be associated with dozens of RT
+	// feeds, so answering twice is most of the work.
 	topics, _ := f.lc.GetFeedVersionRTFeeds(t.FeedVersionID)
-	// Attempt to match on stop sequence
+	var rtTrips []*pb.TripUpdate
 	for _, topic := range topics {
-		// Match on trip
-		rtTrip, rtok := f.getTrip(ctx, topic, tid.Val)
-		if !rtok {
-			continue
+		if rtTrip, ok := f.getTrip(ctx, topic, t.TripID.Val); ok {
+			rtTrips = append(rtTrips, rtTrip)
 		}
-		// Match on stop sequence
+	}
+	// Attempt to match on stop sequence
+	for _, rtTrip := range rtTrips {
 		for _, ste := range rtTrip.StopTimeUpdate {
 			if int(ste.GetStopSequence()) == seq {
 				log.For(ctx).Trace().Str("trip_id", t.TripID.Val).Int("seq", seq).Msgf("found stop time update on trip_id/stop_sequence")
@@ -239,12 +240,7 @@ func (f *Finder) FindStopTimeUpdate(ctx context.Context, t *model.Trip, st *mode
 		}
 	}
 	// Attempt to match on stop id
-	for _, topic := range topics {
-		// Match on trip
-		rtTrip, rtok := f.getTrip(ctx, topic, tid.Val)
-		if !rtok {
-			continue
-		}
+	for _, rtTrip := range rtTrips {
 		// If no match on stop sequence, match on stop_id if stop is not visited twice
 		check := map[string]int{}
 		for _, ste := range rtTrip.StopTimeUpdate {
@@ -432,8 +428,10 @@ func newTranslation(v *pb.TranslatedString) []*model.RTTranslation {
 	return ret
 }
 
+// getTopicKey is called once per associated RT feed per stop time, so it
+// concatenates rather than formatting.
 func getTopicKey(topic string, t string) string {
-	return fmt.Sprintf("rtdata:%s:%s", topic, t)
+	return "rtdata:" + topic + ":" + t
 }
 
 func copyPtr[T any, PT *T](v PT) PT {


### PR DESCRIPTION
## Summary

Every RT fetch anywhere in the fleet publishes its topic name to a single `rtfetch:updates` channel, and every process subscribes to it. On receiving a notification, `drain` unconditionally read the payload back from Redis and decoded it into the local map — regardless of whether that process had ever been asked about the feed, or ever would be. At 10 to 100 fetches per second across the fleet, that is 10 to 100 Redis reads and protobuf decodes per second, per process, for feeds it does not serve. A single request's trace was full of alerts being unmarshalled for agencies on the other side of the country.

This adds a check between the notification and the read, so a process takes only what it serves.

The "decode everything" behavior predates the kvcache migration — the old `RedisCache` did `PSubscribe("rtfetch:sub:*")` and decoded every message too. What the migration added was the Redis read, since notify-then-read replaced payload-in-message, multiplying the cost by the number of processes.

### The read filter

`watching(topic)` is true only for topics already in the local map, and a topic only lands there when a `GetSource` cold read found data — which only happens when something asked for it. The notifications still all arrive; the read and the decode are what stop. Filtering the subscription itself would need per-topic channels and dynamic subscribe management, for a saving that is already noise next to the read and the decode.

### Remembered absences

`GetSource` did not cache a miss, so a topic with no data was re-read from Redis on every call. That matters because callers loop over every RT feed associated with a feed version, once per stop time: a Bay Area feed version reaches 36 associated feeds, so resolving one 64-stop trip produced roughly 4,600 sequential Redis round trips, nearly all of them for feeds that carry no realtime at all.

A topic the store cannot answer for is now remembered for one minute — roughly a feed's publish cadence, since checking more often cannot find anything new. That collapses a request to one read per topic and takes the steady-state floor for a permanently quiet topic from twelve reads a minute to one.

Two outcomes are remembered — the store held nothing, or it failed to answer — and they are logged apart so the difference is visible: `topic absent from store` is a quiet feed, `topic read failed` is the store not answering. Caching failures is deliberate. Not caching them would mean a struggling Redis turns a single request's thousands of lookups into thousands of one-second timeouts, which is a far worse failure than a minute without realtime. The cost is that recovery from a store outage also takes up to a minute.

A third outcome is deliberately *not* remembered. `loadFromStore` derives its one-second budget from the caller, so a failure can mean the store was too slow or simply that the caller went away — and a read cut short by a client hanging up says nothing about the topic. `GetSource` therefore checks its own context before concluding anything: if the caller is already done it logs `topic read abandoned by caller` and records nothing, so one canceled request cannot blind every later one for a minute. For the same reason a read that fails while the context is already done is not logged at error level, which would otherwise emit one spurious error per associated feed on every disconnect.

### Two incidental fixes found while profiling

`getTopicKey` was `fmt.Sprintf`, called once per associated feed per stop time. It accounted for 88% of allocations on that path; plain concatenation removes them.

`FindStopTimeUpdate` makes two passes over the topic list — stop sequence, then stop id — and each pass independently resolved the trip in every topic. It now resolves once and runs both passes over the result. This also makes the two passes see a consistent snapshot, where before a concurrent update could change what the second pass saw.

Together, on the measured shape (36 associated feeds, 64 stops, negative cache warm): 233 to 127 microseconds and 4,672 to 2,374 allocations per trip.

### Tracing

`GetSource` now logs only actual store reads, as `rtcache: topic read`. The local-hit and remembered-absent paths are map hits, and logging them produced thousands of lines per request — enough to obscure the problem this PR fixes.

### Behavior notes

A process that fetches a feed but never queries it no longer holds that feed's data locally. That is intended: the fetcher writes to Redis and publishes, and only processes serving queries need the decoded copy.

A topic that starts publishing after being marked absent is noticed within a minute rather than immediately, which is the cost of not loading every feed in the fleet. It only applies to feeds that had gone quiet for longer than the five-minute `lastTTL`.

Nothing is evicted. `sources` and `missing` both only grow, bounded by the topics a process has asked about. That is a much better bound than before, where every process accumulated every topic anyone in the fleet had fetched, but it is not a ceiling. Dropping topics untouched for some interval is the natural follow-up and is deliberately not in this change.

## Test plan

- Run a server against production Redis with trace logging on and confirm `rtcache: processed update` lines appear only for topics that queries have asked about, rather than for every feed in the fleet.
- Resolve a trip's stop times with `arrival` selected, against a feed version associated with many RT feeds, and confirm `rtcache: topic read` appears roughly once per associated topic rather than once per topic per stop time.
- Confirm realtime still resolves: query a stop or trip with live realtime and check arrival and departure estimates are present.
- Stop an RT feed from publishing, wait past the five-minute `lastTTL`, and confirm lookups fall back to remembered-absent rather than re-reading Redis on every call, and that `topic absent from store` appears at most once a minute per topic.
- Point a server at an unreachable Redis and confirm `topic read failed` appears at most once a minute per topic rather than once per lookup.
- Cancel a request mid-flight (client disconnect) and confirm `topic read abandoned by caller` appears rather than error-level read failures, and that a following request still reaches the store for those topics.
