### PR TITLE
Add a service date filter and representative trip to Route.patterns

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -177,8 +177,14 @@ models:
     fields:
       trips:
         resolver: true
+      representative_trip:
+        resolver: true
     extraFields:
       RouteID:
+        type: int
+      FeedVersionID:
+        type: int
+      RepresentativeTripID:
         type: int
   RouteGeometry:
     extraFields:

--- a/internal/generated/gqlout/generated.go
+++ b/internal/generated/gqlout/generated.go
@@ -984,7 +984,7 @@ type ComplexityRoot struct {
 		Headways          func(childComplexity int, limit *int) int
 		ID                func(childComplexity int) int
 		OnestopID         func(childComplexity int) int
-		Patterns          func(childComplexity int) int
+		Patterns          func(childComplexity int, where *model.RouteStopPatternFilter) int
 		RouteAttribute    func(childComplexity int) int
 		RouteColor        func(childComplexity int) int
 		RouteDesc         func(childComplexity int) int
@@ -1046,10 +1046,11 @@ type ComplexityRoot struct {
 	}
 
 	RouteStopPattern struct {
-		Count         func(childComplexity int) int
-		DirectionID   func(childComplexity int) int
-		StopPatternID func(childComplexity int) int
-		Trips         func(childComplexity int, limit *int) int
+		Count              func(childComplexity int) int
+		DirectionID        func(childComplexity int) int
+		RepresentativeTrip func(childComplexity int) int
+		StopPatternID      func(childComplexity int) int
+		Trips              func(childComplexity int, limit *int) int
 	}
 
 	Segment struct {
@@ -1526,7 +1527,7 @@ type RouteResolver interface {
 	Geometries(ctx context.Context, obj *model.Route, limit *int) ([]*model.RouteGeometry, error)
 	CensusGeographies(ctx context.Context, obj *model.Route, limit *int, where *model.CensusGeographyFilter) ([]*model.CensusGeography, error)
 	RouteStopBuffer(ctx context.Context, obj *model.Route, radius *float64) (*model.RouteStopBuffer, error)
-	Patterns(ctx context.Context, obj *model.Route) ([]*model.RouteStopPattern, error)
+	Patterns(ctx context.Context, obj *model.Route, where *model.RouteStopPatternFilter) ([]*model.RouteStopPattern, error)
 	Alerts(ctx context.Context, obj *model.Route, active *bool, limit *int) ([]*model.Alert, error)
 	Segments(ctx context.Context, obj *model.Route, limit *int, where *model.SegmentFilter) ([]*model.Segment, error)
 	SegmentPatterns(ctx context.Context, obj *model.Route, limit *int, where *model.SegmentPatternFilter) ([]*model.SegmentPattern, error)
@@ -1542,6 +1543,7 @@ type RouteStopResolver interface {
 	Agency(ctx context.Context, obj *model.RouteStop) (*model.Agency, error)
 }
 type RouteStopPatternResolver interface {
+	RepresentativeTrip(ctx context.Context, obj *model.RouteStopPattern) (*model.Trip, error)
 	Trips(ctx context.Context, obj *model.RouteStopPattern, limit *int) ([]*model.Trip, error)
 }
 type SegmentResolver interface {
@@ -5985,7 +5987,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			break
 		}
 
-		return e.ComplexityRoot.Route.Patterns(childComplexity), true
+		args, err := ec.field_Route_patterns_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Route.Patterns(childComplexity, args["where"].(*model.RouteStopPatternFilter)), true
 	case "Route.route_attribute":
 		if e.ComplexityRoot.Route.RouteAttribute == nil {
 			break
@@ -6292,6 +6299,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.RouteStopPattern.DirectionID(childComplexity), true
+	case "RouteStopPattern.representative_trip":
+		if e.ComplexityRoot.RouteStopPattern.RepresentativeTrip == nil {
+			break
+		}
+
+		return e.ComplexityRoot.RouteStopPattern.RepresentativeTrip(childComplexity), true
 	case "RouteStopPattern.stop_pattern_id":
 		if e.ComplexityRoot.RouteStopPattern.StopPatternID == nil {
 			break
@@ -7867,6 +7880,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputPointRadius,
 		ec.unmarshalInputRouteFilter,
 		ec.unmarshalInputRouteLocationFilter,
+		ec.unmarshalInputRouteStopPatternFilter,
 		ec.unmarshalInputSegmentFilter,
 		ec.unmarshalInputSegmentPatternFilter,
 		ec.unmarshalInputServiceCoversFilter,
@@ -9673,7 +9687,7 @@ type Route {
   route_stop_buffer(radius: Float): RouteStopBuffer!
 
   "Unique stop sequences operated on this route"
-  patterns: [RouteStopPattern!]
+  patterns(where: RouteStopPatternFilter): [RouteStopPattern!]
   
   "GTFS-RT service alerts for this route; pass ` + "`" + `active: true` + "`" + ` to return only currently active alerts"
   alerts(active: Boolean, limit: Int): [Alert!]
@@ -10621,6 +10635,13 @@ type RouteStopPattern {
 
   "Number of trips that operate this stop pattern"
   count: Int!
+
+  """
+  One trip that follows this stop pattern, for reading the stop sequence without fetching every trip. Every trip sharing a stop pattern visits the same stops in the same order, so any of them describes the pattern; this is the lowest-numbered, scoped to the queried service date when ` + "`" + `Route.patterns` + "`" + ` was given one.
+
+  Times, headsigns and ` + "`" + `timepoint` + "`" + ` flags are properties of the trip and can differ between trips of the same pattern — only the stop sequence is guaranteed common.
+  """
+  representative_trip: Trip
 
   "Representative trips that follow this stop pattern; useful for fetching full stop_times"
   trips(limit: Int): [Trip!]
@@ -11747,6 +11768,16 @@ input TripFilter {
   feed_version_sha1: String
   "Search for trips with this feed Onestop ID"
   feed_onestop_id: String
+}
+
+"""Search options for a route's stop patterns"""
+input RouteStopPatternFilter {
+  "GTFS service date. Restricts the patterns returned to those a trip operates on that date, counts them over that date alone, and picks ` + "`" + `representative_trip` + "`" + ` from it. Ignored if ` + "`" + `relative_date` + "`" + ` is set"
+  service_date: Date
+  "Calendar date relative to today; see ` + "`" + `RelativeDate` + "`" + `. Takes precedence over ` + "`" + `service_date` + "`" + `"
+  relative_date: RelativeDate
+  "If true and the requested date falls outside the feed version's normal service window, use the feed version's ` + "`" + `fallback_week` + "`" + ` instead"
+  use_service_window: Boolean
 }
 
 """Search options for census datasets"""
@@ -13935,6 +13966,8 @@ func (ec *executionContext) childFields_RouteStopPattern(ctx context.Context, fi
 		return ec.fieldContext_RouteStopPattern_direction_id(ctx, field)
 	case "count":
 		return ec.fieldContext_RouteStopPattern_count(ctx, field)
+	case "representative_trip":
+		return ec.fieldContext_RouteStopPattern_representative_trip(ctx, field)
 	case "trips":
 		return ec.fieldContext_RouteStopPattern_trips(ctx, field)
 	}
@@ -16140,6 +16173,20 @@ func (ec *executionContext) field_Route_headways_args(ctx context.Context, rawAr
 		return nil, err
 	}
 	args["limit"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Route_patterns_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "where",
+		func(ctx context.Context, v any) (*model.RouteStopPatternFilter, error) {
+			return ec.unmarshalORouteStopPatternFilter2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐRouteStopPatternFilter(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["where"] = arg0
 	return args, nil
 }
 
@@ -34738,7 +34785,8 @@ func (ec *executionContext) _Route_patterns(ctx context.Context, field graphql.C
 			return ec.fieldContext_Route_patterns(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
-			return ec.Resolvers.Route().Patterns(ctx, obj)
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Route().Patterns(ctx, obj, fc.Args["where"].(*model.RouteStopPatternFilter))
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v []*model.RouteStopPattern) graphql.Marshaler {
@@ -34748,7 +34796,7 @@ func (ec *executionContext) _Route_patterns(ctx context.Context, field graphql.C
 		false,
 	)
 }
-func (ec *executionContext) fieldContext_Route_patterns(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Route_patterns(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Route",
 		Field:      field,
@@ -34757,6 +34805,17 @@ func (ec *executionContext) fieldContext_Route_patterns(_ context.Context, field
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return ec.childFields_RouteStopPattern(ctx, field)
 		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Route_patterns_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -35594,6 +35653,38 @@ func (ec *executionContext) _RouteStopPattern_count(ctx context.Context, field g
 }
 func (ec *executionContext) fieldContext_RouteStopPattern_count(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("RouteStopPattern", field, false, false, errors.New("field of type Int does not have child fields"))
+}
+
+func (ec *executionContext) _RouteStopPattern_representative_trip(ctx context.Context, field graphql.CollectedField, obj *model.RouteStopPattern) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_RouteStopPattern_representative_trip(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.RouteStopPattern().RepresentativeTrip(ctx, obj)
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *model.Trip) graphql.Marshaler {
+			return ec.marshalOTrip2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐTrip(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_RouteStopPattern_representative_trip(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RouteStopPattern",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_Trip(ctx, field)
+		},
+	}
+	return fc, nil
 }
 
 func (ec *executionContext) _RouteStopPattern_trips(ctx context.Context, field graphql.CollectedField, obj *model.RouteStopPattern) (ret graphql.Marshaler) {
@@ -44791,6 +44882,50 @@ func (ec *executionContext) unmarshalInputRouteLocationFilter(ctx context.Contex
 				return it, err
 			}
 			it.Focus = data
+		}
+	}
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputRouteStopPatternFilter(ctx context.Context, obj any) (model.RouteStopPatternFilter, error) {
+	var it model.RouteStopPatternFilter
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"service_date", "relative_date", "use_service_window"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "service_date":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("service_date"))
+			data, err := ec.unmarshalODate2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋttᚐDate(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ServiceDate = data
+		case "relative_date":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("relative_date"))
+			data, err := ec.unmarshalORelativeDate2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐRelativeDate(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.RelativeDate = data
+		case "use_service_window":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("use_service_window"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.UseServiceWindow = data
 		}
 	}
 	return it, nil
@@ -54756,6 +54891,39 @@ func (ec *executionContext) _RouteStopPattern(ctx context.Context, sel ast.Selec
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "representative_trip":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._RouteStopPattern_representative_trip(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "trips":
 			field := field
 
@@ -61758,6 +61926,14 @@ func (ec *executionContext) marshalORouteStopPattern2ᚕᚖgithubᚗcomᚋinterl
 	return ret
 }
 
+func (ec *executionContext) unmarshalORouteStopPatternFilter2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐRouteStopPatternFilter(ctx context.Context, v any) (*model.RouteStopPatternFilter, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputRouteStopPatternFilter(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalOScheduleRelationship2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐScheduleRelationship(ctx context.Context, v any) (*model.ScheduleRelationship, error) {
 	if v == nil {
 		return nil, nil
@@ -62275,6 +62451,13 @@ func (ec *executionContext) marshalOTrip2ᚕᚖgithubᚗcomᚋinterlineᚑioᚋt
 	}
 
 	return ret
+}
+
+func (ec *executionContext) marshalOTrip2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐTrip(ctx context.Context, sel ast.SelectionSet, v *model.Trip) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._Trip(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOTripFilter2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐTripFilter(ctx context.Context, v any) (*model.TripFilter, error) {

--- a/schema/graphql/schema.graphqls
+++ b/schema/graphql/schema.graphqls
@@ -803,7 +803,7 @@ type Route {
   route_stop_buffer(radius: Float): RouteStopBuffer!
 
   "Unique stop sequences operated on this route"
-  patterns: [RouteStopPattern!]
+  patterns(where: RouteStopPatternFilter): [RouteStopPattern!]
   
   "GTFS-RT service alerts for this route; pass `active: true` to return only currently active alerts"
   alerts(active: Boolean, limit: Int): [Alert!]
@@ -1751,6 +1751,13 @@ type RouteStopPattern {
 
   "Number of trips that operate this stop pattern"
   count: Int!
+
+  """
+  One trip that follows this stop pattern, for reading the stop sequence without fetching every trip. Every trip sharing a stop pattern visits the same stops in the same order, so any of them describes the pattern; this is the lowest-numbered, scoped to the queried service date when `Route.patterns` was given one.
+
+  Times, headsigns and `timepoint` flags are properties of the trip and can differ between trips of the same pattern — only the stop sequence is guaranteed common.
+  """
+  representative_trip: Trip
 
   "Representative trips that follow this stop pattern; useful for fetching full stop_times"
   trips(limit: Int): [Trip!]
@@ -2877,6 +2884,16 @@ input TripFilter {
   feed_version_sha1: String
   "Search for trips with this feed Onestop ID"
   feed_onestop_id: String
+}
+
+"""Search options for a route's stop patterns"""
+input RouteStopPatternFilter {
+  "GTFS service date. Restricts the patterns returned to those a trip operates on that date, counts them over that date alone, and picks `representative_trip` from it. Ignored if `relative_date` is set"
+  service_date: Date
+  "Calendar date relative to today; see `RelativeDate`. Takes precedence over `service_date`"
+  relative_date: RelativeDate
+  "If true and the requested date falls outside the feed version's normal service window, use the feed version's `fallback_week` instead"
+  use_service_window: Boolean
 }
 
 """Search options for census datasets"""

--- a/server/finders/dbfinder/route.go
+++ b/server/finders/dbfinder/route.go
@@ -85,22 +85,10 @@ func (f *Finder) RouteHeadwaysByRouteIDs(ctx context.Context, limit *int, keys [
 }
 
 // RouteStopPatternsByRouteIDs aggregates each route's trips into its distinct stop
-// patterns. A service date filter applies to the trips before they are grouped, so
-// `count` is that day's trip count and a pattern nobody runs that day drops out.
-//
-// min(id) is the same trip `trips(limit: 1)` returns, since that orders by
-// (feed_version_id, id) — but scoped to the date when one is given, so the
-// representative is a trip that actually runs.
+// patterns, optionally restricted to the trips running on a service date.
 func (f *Finder) RouteStopPatternsByRouteIDs(ctx context.Context, limit *int, where *model.RouteStopPatternFilter, keys []model.FVPair) ([][]*model.RouteStopPattern, error) {
-	var ents []*model.RouteStopPattern
-	// Grouped by feed version: each resolves the requested date against its own
-	// service window, and gtfs_trips is scanned per feed version anyway.
-	groups := map[int][]int{}
-	for _, key := range keys {
-		groups[key.FeedVersionID] = append(groups[key.FeedVersionID], key.EntityID)
-	}
-	for fvid, routeIds := range groups {
-		q := sq.StatementBuilder.
+	patternSelect := func(routeIds []int) sq.SelectBuilder {
+		return sq.StatementBuilder.
 			Select(
 				"gtfs_trips.feed_version_id",
 				"gtfs_trips.route_id",
@@ -110,25 +98,49 @@ func (f *Finder) RouteStopPatternsByRouteIDs(ctx context.Context, limit *int, wh
 				"min(gtfs_trips.id) as representative_trip_id",
 			).
 			From("gtfs_trips").
-			Where(sq.Eq{"gtfs_trips.feed_version_id": fvid}).
 			Where(In("gtfs_trips.route_id", routeIds)).
 			GroupBy("gtfs_trips.feed_version_id,gtfs_trips.route_id,gtfs_trips.direction_id,gtfs_trips.stop_pattern_id").
 			OrderBy("gtfs_trips.route_id,count desc").
 			Limit(finderCheckLimit(limit))
-		// Guarded on a date actually being asked for: the service window costs two
-		// queries of its own, and use_service_window alone resolves to nothing.
-		if where != nil && (where.ServiceDate != nil || where.RelativeDate != nil) {
-			fvsw, err := f.FindFeedVersionServiceWindow(ctx, fvid)
-			if err != nil {
-				return nil, err
-			}
-			serviceDate, err := resolveServiceDate(where.ServiceDate, where.RelativeDate, nilOr(where.UseServiceWindow, false), fvsw)
-			if err != nil {
-				return nil, err
-			}
-			if serviceDate != nil {
-				q = serviceDateLateral(q, *serviceDate)
-			}
+	}
+
+	// Only a relative date or use_service_window needs the feed version's window;
+	// a plain service_date is matched as given. Splitting the batch per feed version
+	// to look one up costs a query per feed version, so it is done only when the
+	// answer can differ between them.
+	var ents []*model.RouteStopPattern
+	if where == nil || (where.RelativeDate == nil && !nilOr(where.UseServiceWindow, false)) {
+		routeIds := make([]int, 0, len(keys))
+		for _, key := range keys {
+			routeIds = append(routeIds, key.EntityID)
+		}
+		q := patternSelect(routeIds)
+		if where != nil && where.ServiceDate != nil {
+			q = serviceDateLateral(q, *where.ServiceDate)
+		}
+		if err := dbutil.Select(ctx, f.db, q, &ents); err != nil {
+			return nil, err
+		}
+		return arrangeGroup(keys, ents, routeStopPatternKey), nil
+	}
+
+	groups := map[int][]int{}
+	for _, key := range keys {
+		groups[key.FeedVersionID] = append(groups[key.FeedVersionID], key.EntityID)
+	}
+	for fvid, routeIds := range groups {
+		// A feed version whose window has not been computed yet resolves the date as
+		// given rather than failing: the lookup errors outright when the row is
+		// missing, and one such feed version would otherwise take down every route in
+		// the batch, including those from healthy feed versions.
+		fvsw, _ := f.FindFeedVersionServiceWindow(ctx, fvid)
+		serviceDate, err := resolveServiceDate(where.ServiceDate, where.RelativeDate, nilOr(where.UseServiceWindow, false), fvsw)
+		if err != nil {
+			return nil, err
+		}
+		q := patternSelect(routeIds)
+		if serviceDate != nil {
+			q = serviceDateLateral(q, *serviceDate)
 		}
 		var groupEnts []*model.RouteStopPattern
 		if err := dbutil.Select(ctx, f.db, q, &groupEnts); err != nil {
@@ -136,9 +148,11 @@ func (f *Finder) RouteStopPatternsByRouteIDs(ctx context.Context, limit *int, wh
 		}
 		ents = append(ents, groupEnts...)
 	}
-	return arrangeGroup(keys, ents, func(ent *model.RouteStopPattern) model.FVPair {
-		return model.FVPair{FeedVersionID: ent.FeedVersionID, EntityID: ent.RouteID}
-	}), nil
+	return arrangeGroup(keys, ents, routeStopPatternKey), nil
+}
+
+func routeStopPatternKey(ent *model.RouteStopPattern) model.FVPair {
+	return model.FVPair{FeedVersionID: ent.FeedVersionID, EntityID: ent.RouteID}
 }
 
 // RouteGeometriesByRouteIDs reconstructs each route's geometry from the shapes it

--- a/server/finders/dbfinder/route.go
+++ b/server/finders/dbfinder/route.go
@@ -84,21 +84,61 @@ func (f *Finder) RouteHeadwaysByRouteIDs(ctx context.Context, limit *int, keys [
 	return arrangeGroup(keys, ents, func(ent *model.RouteHeadway) int { return ent.RouteID }), err
 }
 
-func (f *Finder) RouteStopPatternsByRouteIDs(ctx context.Context, limit *int, keys []int) ([][]*model.RouteStopPattern, error) {
-	q := sq.StatementBuilder.
-		Select("route_id", "direction_id", "stop_pattern_id", "count(*) as count").
-		From("gtfs_trips").
-		Where(In("route_id", keys)).
-		GroupBy("route_id,direction_id,stop_pattern_id").
-		OrderBy("route_id,count desc").
-		Limit(finderCheckLimit(limit))
+// RouteStopPatternsByRouteIDs aggregates each route's trips into its distinct stop
+// patterns. A service date filter applies to the trips before they are grouped, so
+// `count` is that day's trip count and a pattern nobody runs that day drops out.
+//
+// min(id) is the same trip `trips(limit: 1)` returns, since that orders by
+// (feed_version_id, id) — but scoped to the date when one is given, so the
+// representative is a trip that actually runs.
+func (f *Finder) RouteStopPatternsByRouteIDs(ctx context.Context, limit *int, where *model.RouteStopPatternFilter, keys []model.FVPair) ([][]*model.RouteStopPattern, error) {
 	var ents []*model.RouteStopPattern
-	err := dbutil.Select(ctx,
-		f.db,
-		q,
-		&ents,
-	)
-	return arrangeGroup(keys, ents, func(ent *model.RouteStopPattern) int { return ent.RouteID }), err
+	// Grouped by feed version: each resolves the requested date against its own
+	// service window, and gtfs_trips is scanned per feed version anyway.
+	groups := map[int][]int{}
+	for _, key := range keys {
+		groups[key.FeedVersionID] = append(groups[key.FeedVersionID], key.EntityID)
+	}
+	for fvid, routeIds := range groups {
+		q := sq.StatementBuilder.
+			Select(
+				"gtfs_trips.feed_version_id",
+				"gtfs_trips.route_id",
+				"gtfs_trips.direction_id",
+				"gtfs_trips.stop_pattern_id",
+				"count(*) as count",
+				"min(gtfs_trips.id) as representative_trip_id",
+			).
+			From("gtfs_trips").
+			Where(sq.Eq{"gtfs_trips.feed_version_id": fvid}).
+			Where(In("gtfs_trips.route_id", routeIds)).
+			GroupBy("gtfs_trips.feed_version_id,gtfs_trips.route_id,gtfs_trips.direction_id,gtfs_trips.stop_pattern_id").
+			OrderBy("gtfs_trips.route_id,count desc").
+			Limit(finderCheckLimit(limit))
+		// Guarded on a date actually being asked for: the service window costs two
+		// queries of its own, and use_service_window alone resolves to nothing.
+		if where != nil && (where.ServiceDate != nil || where.RelativeDate != nil) {
+			fvsw, err := f.FindFeedVersionServiceWindow(ctx, fvid)
+			if err != nil {
+				return nil, err
+			}
+			serviceDate, err := resolveServiceDate(where.ServiceDate, where.RelativeDate, nilOr(where.UseServiceWindow, false), fvsw)
+			if err != nil {
+				return nil, err
+			}
+			if serviceDate != nil {
+				q = serviceDateLateral(q, *serviceDate)
+			}
+		}
+		var groupEnts []*model.RouteStopPattern
+		if err := dbutil.Select(ctx, f.db, q, &groupEnts); err != nil {
+			return nil, err
+		}
+		ents = append(ents, groupEnts...)
+	}
+	return arrangeGroup(keys, ents, func(ent *model.RouteStopPattern) model.FVPair {
+		return model.FVPair{FeedVersionID: ent.FeedVersionID, EntityID: ent.RouteID}
+	}), nil
 }
 
 // RouteGeometriesByRouteIDs reconstructs each route's geometry from the shapes it

--- a/server/finders/dbfinder/route.go
+++ b/server/finders/dbfinder/route.go
@@ -87,8 +87,15 @@ func (f *Finder) RouteHeadwaysByRouteIDs(ctx context.Context, limit *int, keys [
 // RouteStopPatternsByRouteIDs aggregates each route's trips into its distinct stop
 // patterns, optionally restricted to the trips running on a service date.
 func (f *Finder) RouteStopPatternsByRouteIDs(ctx context.Context, limit *int, where *model.RouteStopPatternFilter, keys []model.FVPair) ([][]*model.RouteStopPattern, error) {
-	patternSelect := func(routeIds []int) sq.SelectBuilder {
-		return sq.StatementBuilder.
+	// Grouped by feed version so each resolves the requested date against its own
+	// service window. A batch spanning several is rare, and the window is cached.
+	groups := map[int][]int{}
+	for _, key := range keys {
+		groups[key.FeedVersionID] = append(groups[key.FeedVersionID], key.EntityID)
+	}
+	var ents []*model.RouteStopPattern
+	for fvid, routeIds := range groups {
+		q := sq.StatementBuilder.
 			Select(
 				"gtfs_trips.feed_version_id",
 				"gtfs_trips.route_id",
@@ -102,45 +109,19 @@ func (f *Finder) RouteStopPatternsByRouteIDs(ctx context.Context, limit *int, wh
 			GroupBy("gtfs_trips.feed_version_id,gtfs_trips.route_id,gtfs_trips.direction_id,gtfs_trips.stop_pattern_id").
 			OrderBy("gtfs_trips.route_id,count desc").
 			Limit(finderCheckLimit(limit))
-	}
-
-	// Only a relative date or use_service_window needs the feed version's window;
-	// a plain service_date is matched as given. Splitting the batch per feed version
-	// to look one up costs a query per feed version, so it is done only when the
-	// answer can differ between them.
-	var ents []*model.RouteStopPattern
-	if where == nil || (where.RelativeDate == nil && !nilOr(where.UseServiceWindow, false)) {
-		routeIds := make([]int, 0, len(keys))
-		for _, key := range keys {
-			routeIds = append(routeIds, key.EntityID)
-		}
-		q := patternSelect(routeIds)
-		if where != nil && where.ServiceDate != nil {
-			q = serviceDateLateral(q, *where.ServiceDate)
-		}
-		if err := dbutil.Select(ctx, f.db, q, &ents); err != nil {
-			return nil, err
-		}
-		return arrangeGroup(keys, ents, routeStopPatternKey), nil
-	}
-
-	groups := map[int][]int{}
-	for _, key := range keys {
-		groups[key.FeedVersionID] = append(groups[key.FeedVersionID], key.EntityID)
-	}
-	for fvid, routeIds := range groups {
-		// A feed version whose window has not been computed yet resolves the date as
-		// given rather than failing: the lookup errors outright when the row is
-		// missing, and one such feed version would otherwise take down every route in
-		// the batch, including those from healthy feed versions.
-		fvsw, _ := f.FindFeedVersionServiceWindow(ctx, fvid)
-		serviceDate, err := resolveServiceDate(where.ServiceDate, where.RelativeDate, nilOr(where.UseServiceWindow, false), fvsw)
-		if err != nil {
-			return nil, err
-		}
-		q := patternSelect(routeIds)
-		if serviceDate != nil {
-			q = serviceDateLateral(q, *serviceDate)
+		if where != nil {
+			// A feed version whose window has not been computed resolves the date as
+			// given rather than failing: the lookup errors outright when the row is
+			// missing, and one such feed version would otherwise take down every route
+			// in the batch, including those from healthy feed versions.
+			fvsw, _ := f.FindFeedVersionServiceWindow(ctx, fvid)
+			serviceDate, err := resolveServiceDate(where.ServiceDate, where.RelativeDate, nilOr(where.UseServiceWindow, false), fvsw)
+			if err != nil {
+				return nil, err
+			}
+			if serviceDate != nil {
+				q = serviceDateLateral(q, *serviceDate)
+			}
 		}
 		var groupEnts []*model.RouteStopPattern
 		if err := dbutil.Select(ctx, f.db, q, &groupEnts); err != nil {
@@ -148,11 +129,9 @@ func (f *Finder) RouteStopPatternsByRouteIDs(ctx context.Context, limit *int, wh
 		}
 		ents = append(ents, groupEnts...)
 	}
-	return arrangeGroup(keys, ents, routeStopPatternKey), nil
-}
-
-func routeStopPatternKey(ent *model.RouteStopPattern) model.FVPair {
-	return model.FVPair{FeedVersionID: ent.FeedVersionID, EntityID: ent.RouteID}
+	return arrangeGroup(keys, ents, func(ent *model.RouteStopPattern) model.FVPair {
+		return model.FVPair{FeedVersionID: ent.FeedVersionID, EntityID: ent.RouteID}
+	}), nil
 }
 
 // RouteGeometriesByRouteIDs reconstructs each route's geometry from the shapes it

--- a/server/finders/dbfinder/trip.go
+++ b/server/finders/dbfinder/trip.go
@@ -73,6 +73,60 @@ func mapIntoServiceWindow(s time.Time, fvsw *model.ServiceWindow) *tt.Date {
 	return tzTruncate(fvsw.FallbackWeek.AddDate(0, 0, dow), loc)
 }
 
+// Resolve a filter's date inputs into the one service date to match, in the feed
+// version's terms: a relative date becomes concrete, and use_service_window
+// relocates a date outside the window into the fallback week.
+func resolveServiceDate(serviceDate *tt.Date, relativeDate *model.RelativeDate, useServiceWindow bool, fvsw *model.ServiceWindow) (*tt.Date, error) {
+	if fvsw == nil {
+		return serviceDate, nil
+	}
+	if relativeDate != nil {
+		s, err := tt.RelativeDate(fvsw.NowLocal, kebabize(string(*relativeDate)))
+		if err != nil {
+			return nil, fmt.Errorf("invalid relative_date %q: %w", *relativeDate, err)
+		}
+		serviceDate = tzTruncate(s, fvsw.NowLocal.Location())
+	}
+	// Guarded: use_service_window with no date at all is a valid filter.
+	if useServiceWindow && serviceDate != nil {
+		serviceDate = mapIntoServiceWindow(serviceDate.Val, fvsw)
+	}
+	return serviceDate, nil
+}
+
+// Restrict a query over gtfs_trips to the trips running on a service date.
+//
+// The join is inner, so a trip whose calendar does not cover the date drops out.
+// LIMIT 1 keeps a service with several calendar_dates rows from multiplying the
+// trip, which is what makes the result safe to aggregate over.
+func serviceDateLateral(q sq.SelectBuilder, serviceDate tt.Date) sq.SelectBuilder {
+	sd := serviceDate.Val
+	return q.JoinClause(`
+	join lateral (
+		select gc.id
+		from gtfs_calendars gc
+		left join gtfs_calendar_dates gcda on gcda.service_id = gc.id and gcda.exception_type = 1 and gcda.date = ?::date
+		left join gtfs_calendar_dates gcdb on gcdb.service_id = gc.id and gcdb.exception_type = 2 and gcdb.date = ?::date
+		where
+			gc.id = gtfs_trips.service_id
+			AND ((
+				gc.start_date <= ?::date AND gc.end_date >= ?::date
+				AND (CASE EXTRACT(isodow FROM ?::date)
+				WHEN 1 THEN monday = 1
+				WHEN 2 THEN tuesday = 1
+				WHEN 3 THEN wednesday = 1
+				WHEN 4 THEN thursday = 1
+				WHEN 5 THEN friday = 1
+				WHEN 6 THEN saturday = 1
+				WHEN 7 THEN sunday = 1
+				END)
+			) OR gcda.date IS NOT NULL)
+			AND gcdb.date is null
+		LIMIT 1
+	) gc on true
+	`, sd, sd, sd, sd, sd)
+}
+
 // tripDate is a service date to match in the database and the dates it is
 // reported as. They differ under use_service_window, which relocates a date
 // into the fallback week; several requested dates can land on the same day.
@@ -289,19 +343,10 @@ func tripSelect(limit *int, after *model.Cursor, ids []int, active bool, permFil
 	// Resolved into a local: `where` is reused for every feed version.
 	var serviceDate *tt.Date
 	if where != nil {
-		serviceDate = where.ServiceDate
-		if fvsw != nil {
-			if where.RelativeDate != nil {
-				s, err := tt.RelativeDate(fvsw.NowLocal, kebabize(string(*where.RelativeDate)))
-				if err != nil {
-					return q, nil, fmt.Errorf("invalid relative_date %q: %w", *where.RelativeDate, err)
-				}
-				serviceDate = tzTruncate(s, fvsw.NowLocal.Location())
-			}
-			// Guarded: use_service_window with no date at all is a valid filter.
-			if nilOr(where.UseServiceWindow, false) && serviceDate != nil {
-				serviceDate = mapIntoServiceWindow(serviceDate.Val, fvsw)
-			}
+		var err error
+		serviceDate, err = resolveServiceDate(where.ServiceDate, where.RelativeDate, nilOr(where.UseServiceWindow, false), fvsw)
+		if err != nil {
+			return q, nil, err
 		}
 	}
 	tripDates := resolveTripDates(where, fvsw)
@@ -359,31 +404,7 @@ func tripSelect(limit *int, after *model.Cursor, ids []int, active bool, permFil
 			) svc on true
 			`, strings.Join(dates, ",")).Where("svc.service_dates_agg is not null")
 		} else if serviceDate != nil {
-			sd := serviceDate.Val
-			q = q.JoinClause(`
-			join lateral (
-				select gc.id
-				from gtfs_calendars gc 
-				left join gtfs_calendar_dates gcda on gcda.service_id = gc.id and gcda.exception_type = 1 and gcda.date = ?::date
-				left join gtfs_calendar_dates gcdb on gcdb.service_id = gc.id and gcdb.exception_type = 2 and gcdb.date = ?::date
-				where 
-					gc.id = gtfs_trips.service_id 
-					AND ((
-						gc.start_date <= ?::date AND gc.end_date >= ?::date
-						AND (CASE EXTRACT(isodow FROM ?::date)
-						WHEN 1 THEN monday = 1
-						WHEN 2 THEN tuesday = 1
-						WHEN 3 THEN wednesday = 1
-						WHEN 4 THEN thursday = 1
-						WHEN 5 THEN friday = 1
-						WHEN 6 THEN saturday = 1
-						WHEN 7 THEN sunday = 1
-						END)
-					) OR gcda.date IS NOT NULL)
-					AND gcdb.date is null
-				LIMIT 1
-			) gc on true
-			`, sd, sd, sd, sd, sd)
+			q = serviceDateLateral(q, *serviceDate)
 		}
 		// Handle license filtering
 		q = licenseFilter(where.License, q)

--- a/server/gql/loader_params.go
+++ b/server/gql/loader_params.go
@@ -204,7 +204,9 @@ type censusSourceTableLoaderParam struct {
 }
 
 type routeStopPatternLoaderParam struct {
-	RouteID int
+	FeedVersionID int
+	RouteID       int
+	Where         *model.RouteStopPatternFilter
 }
 
 type segmentPatternLoaderParam struct {

--- a/server/gql/loaders.go
+++ b/server/gql/loaders.go
@@ -114,6 +114,9 @@ type Loaders struct {
 }
 
 // NewLoaders instantiates data loaders for the middleware
+// Addressable so the grouped loader can pass it; see RESOLVER_PATTERN_MAXLIMIT.
+var routeStopPatternLimit = RESOLVER_PATTERN_MAXLIMIT
+
 func NewLoaders(dbf model.Finder, batchSize int, stopTimeBatchSize int) *Loaders {
 	if batchSize == 0 {
 		batchSize = maxBatch
@@ -369,7 +372,7 @@ func NewLoaders(dbf model.Finder, batchSize int, stopTimeBatchSize int) *Loaders
 		RoutesByIDs: withWaitAndCapacity(waitTime, batchSize, dbf.RoutesByIDs),
 		RouteStopPatternsByRouteIDs: withWaitAndCapacityGroup(waitTime, batchSize, dbf.RouteStopPatternsByRouteIDs,
 			func(p routeStopPatternLoaderParam) (model.FVPair, *model.RouteStopPatternFilter, *int) {
-				return model.FVPair{FeedVersionID: p.FeedVersionID, EntityID: p.RouteID}, p.Where, nil
+				return model.FVPair{FeedVersionID: p.FeedVersionID, EntityID: p.RouteID}, p.Where, &routeStopPatternLimit
 			},
 		),
 		RouteStopsByRouteIDs: withWaitAndCapacityGroup(waitTime, batchSize,

--- a/server/gql/loaders.go
+++ b/server/gql/loaders.go
@@ -367,10 +367,9 @@ func NewLoaders(dbf model.Finder, batchSize int, stopTimeBatchSize int) *Loaders
 			},
 		),
 		RoutesByIDs: withWaitAndCapacity(waitTime, batchSize, dbf.RoutesByIDs),
-		RouteStopPatternsByRouteIDs: withWaitAndCapacityGroup(waitTime, batchSize,
-			paramGroupAdapter(dbf.RouteStopPatternsByRouteIDs),
-			func(p routeStopPatternLoaderParam) (int, bool, *int) {
-				return p.RouteID, false, nil
+		RouteStopPatternsByRouteIDs: withWaitAndCapacityGroup(waitTime, batchSize, dbf.RouteStopPatternsByRouteIDs,
+			func(p routeStopPatternLoaderParam) (model.FVPair, *model.RouteStopPatternFilter, *int) {
+				return model.FVPair{FeedVersionID: p.FeedVersionID, EntityID: p.RouteID}, p.Where, nil
 			},
 		),
 		RouteStopsByRouteIDs: withWaitAndCapacityGroup(waitTime, batchSize,

--- a/server/gql/resolver.go
+++ b/server/gql/resolver.go
@@ -23,6 +23,10 @@ const (
 	// A busy route runs close to 1,000 trips in a week, so the default limit
 	// truncates a multi-week range without an error.
 	RESOLVER_TRIP_MAXLIMIT = 100_000
+	// Route.patterns takes no limit argument, but the grouped loader still needs
+	// one: paramGroupQuery falls back to RESOLVER_DEFAULT_LIMIT when a group's
+	// limit is nil, which would cut a long route's patterns to 100.
+	RESOLVER_PATTERN_MAXLIMIT = 100_000
 )
 
 // RESOLVER_MAXLIMIT is the API limit maximum

--- a/server/gql/route_resolver.go
+++ b/server/gql/route_resolver.go
@@ -75,8 +75,12 @@ func (r *routeResolver) Alerts(ctx context.Context, obj *model.Route, active *bo
 	return model.ForContext(ctx).RTFinder.FindAlertsForRoute(ctx, obj, resolverCheckLimit(limit), active), nil
 }
 
-func (r *routeResolver) Patterns(ctx context.Context, obj *model.Route) ([]*model.RouteStopPattern, error) {
-	return LoaderFor(ctx).RouteStopPatternsByRouteIDs.Load(ctx, routeStopPatternLoaderParam{RouteID: obj.ID})()
+func (r *routeResolver) Patterns(ctx context.Context, obj *model.Route, where *model.RouteStopPatternFilter) ([]*model.RouteStopPattern, error) {
+	return LoaderFor(ctx).RouteStopPatternsByRouteIDs.Load(ctx, routeStopPatternLoaderParam{
+		FeedVersionID: obj.FeedVersionID,
+		RouteID:       obj.ID,
+		Where:         where,
+	})()
 }
 
 func (r *routeResolver) RouteAttribute(ctx context.Context, obj *model.Route) (*model.RouteAttribute, error) {
@@ -127,6 +131,15 @@ func (r *routeStopResolver) Agency(ctx context.Context, obj *model.RouteStop) (*
 // ROUTE PATTERN
 
 type routePatternResolver struct{ *Resolver }
+
+// The trip the pattern was derived from, already known from the aggregate, so this
+// is a batched lookup by id rather than a search for a trip matching the pattern.
+func (r *routePatternResolver) RepresentativeTrip(ctx context.Context, obj *model.RouteStopPattern) (*model.Trip, error) {
+	if obj.RepresentativeTripID == 0 {
+		return nil, nil
+	}
+	return LoaderFor(ctx).TripsByIDs.Load(ctx, obj.RepresentativeTripID)()
+}
 
 func (r *routePatternResolver) Trips(ctx context.Context, obj *model.RouteStopPattern, limit *int) ([]*model.Trip, error) {
 	// TODO: N+1 query

--- a/server/gql/route_resolver_test.go
+++ b/server/gql/route_resolver_test.go
@@ -203,6 +203,28 @@ func TestRouteResolver(t *testing.T) {
 			selectExpect: []string{"132", "124", "56", "50", "2"},
 		},
 		{
+			name: "route patterns representative_trip",
+			query: `{
+				routes(where: {feed_onestop_id: "BA", route_id: "03"}) {
+				  patterns {
+					count
+					representative_trip { trip_id }
+					trips(limit: 1) { trip_id }
+				  }
+				}
+			  }`,
+			f: func(t *testing.T, jj string) {
+				// min(id) in the aggregate is the same trip trips(limit:1) returns,
+				// which orders by (feed_version_id, id).
+				rep := gjson.Get(jj, "routes.0.patterns.#.representative_trip.trip_id").Array()
+				via := gjson.Get(jj, "routes.0.patterns.#.trips.0.trip_id").Array()
+				assert.Equal(t, len(via), len(rep), "a representative trip per pattern")
+				for i := range via {
+					assert.Equal(t, via[i].String(), rep[i].String(), "pattern %d", i)
+				}
+			},
+		},
+		{
 			name: "route patterns inactive fv",
 			query: `{
 				routes(where: {feed_onestop_id: "EX", feed_version_sha1: "43e2278aa272879c79460582152b04e7487f0493", route_id: "AAMV"}) {
@@ -415,6 +437,26 @@ func TestRouteResolver_Date(t *testing.T) {
 				vars:         hw{"route_id": "Bu-130", "service_date": "2018-06-18"}, // use baby bullet
 				selector:     "routes.0.trips.#.trip_id",
 				selectExpect: []string{"305", "309", "313", "319", "323", "329", "365", "371", "375", "381", "385", "310", "314", "320", "324", "330", "360", "366", "370", "376", "380", "386"},
+			},
+		},
+		{
+			whenUtc: "2018-05-30T22:00:00Z",
+			testcase: testcase{
+				name:  "patterns service date",
+				query: `query($route_id: String!, $service_date:Date) { routes(where:{route_id:$route_id}) { patterns(where:{service_date:$service_date}) { count representative_trip { trip_id } } } }`,
+				vars:  hw{"route_id": "Bu-130", "service_date": "2018-06-18"},
+				f: func(t *testing.T, jj string) {
+					// The same 22 trips the trips() query returns for this date,
+					// redistributed across the patterns that run it.
+					total := 0
+					for _, c := range gjson.Get(jj, "routes.0.patterns.#.count").Array() {
+						total += int(c.Int())
+					}
+					assert.Equal(t, 22, total, "day-scoped counts sum to that day's trips")
+					for _, r := range gjson.Get(jj, "routes.0.patterns.#.representative_trip.trip_id").Array() {
+						assert.NotEmpty(t, r.String(), "representative trip resolves")
+					}
+				},
 			},
 		},
 		{

--- a/server/gql/route_resolver_test.go
+++ b/server/gql/route_resolver_test.go
@@ -214,13 +214,20 @@ func TestRouteResolver(t *testing.T) {
 				}
 			  }`,
 			f: func(t *testing.T, jj string) {
-				// min(id) in the aggregate is the same trip trips(limit:1) returns,
-				// which orders by (feed_version_id, id).
-				rep := gjson.Get(jj, "routes.0.patterns.#.representative_trip.trip_id").Array()
-				via := gjson.Get(jj, "routes.0.patterns.#.trips.0.trip_id").Array()
-				assert.Equal(t, len(via), len(rep), "a representative trip per pattern")
-				for i := range via {
-					assert.Equal(t, via[i].String(), rep[i].String(), "pattern %d", i)
+				// Walked per pattern rather than as two `#.` arrays: gjson omits the
+				// elements whose path is missing, so a null representative_trip would
+				// shift one array against the other instead of failing.
+				//
+				// min(id) in the aggregate is the trip trips(limit:1) returns, which
+				// orders by (feed_version_id, id). They agree only where a stop pattern
+				// runs in one direction — trips() does not filter on direction, so a
+				// pattern operated both ways returns the same trip for both rows.
+				pats := gjson.Get(jj, "routes.0.patterns").Array()
+				assert.NotEmpty(t, pats, "patterns returned")
+				for i, pat := range pats {
+					rep := pat.Get("representative_trip.trip_id")
+					assert.True(t, rep.Exists(), "pattern %d resolves a representative trip", i)
+					assert.Equal(t, pat.Get("trips.0.trip_id").String(), rep.String(), "pattern %d", i)
 				}
 			},
 		},
@@ -447,15 +454,16 @@ func TestRouteResolver_Date(t *testing.T) {
 				vars:  hw{"route_id": "Bu-130", "service_date": "2018-06-18"},
 				f: func(t *testing.T, jj string) {
 					// The same 22 trips the trips() query returns for this date,
-					// redistributed across the patterns that run it.
+					// redistributed across the patterns that run it. Walked per pattern
+					// so a null representative_trip fails rather than being skipped.
+					pats := gjson.Get(jj, "routes.0.patterns").Array()
+					assert.NotEmpty(t, pats, "patterns returned for the date")
 					total := 0
-					for _, c := range gjson.Get(jj, "routes.0.patterns.#.count").Array() {
-						total += int(c.Int())
+					for i, pat := range pats {
+						total += int(pat.Get("count").Int())
+						assert.True(t, pat.Get("representative_trip.trip_id").Exists(), "pattern %d resolves a representative trip", i)
 					}
 					assert.Equal(t, 22, total, "day-scoped counts sum to that day's trips")
-					for _, r := range gjson.Get(jj, "routes.0.patterns.#.representative_trip.trip_id").Array() {
-						assert.NotEmpty(t, r.String(), "representative trip resolves")
-					}
 				},
 			},
 		},

--- a/server/model/finders.go
+++ b/server/model/finders.go
@@ -104,7 +104,7 @@ type EntityLoader interface {
 	RoutesByAgencyIDs(context.Context, *int, *RouteFilter, []int) ([][]*Route, error)
 	RoutesByFeedVersionIDs(context.Context, *int, *RouteFilter, []int) ([][]*Route, error)
 	RoutesByIDs(context.Context, []int) ([]*Route, []error)
-	RouteStopPatternsByRouteIDs(context.Context, *int, []int) ([][]*RouteStopPattern, error)
+	RouteStopPatternsByRouteIDs(context.Context, *int, *RouteStopPatternFilter, []FVPair) ([][]*RouteStopPattern, error)
 	RouteStopsByRouteIDs(context.Context, *int, []int) ([][]*RouteStop, error)
 	RouteStopsByStopIDs(context.Context, *int, []int) ([][]*RouteStop, error)
 	SegmentPatternsByRouteIDs(context.Context, *int, *SegmentPatternFilter, []int) ([][]*SegmentPattern, error)

--- a/server/model/models_gen.go
+++ b/server/model/models_gen.go
@@ -1156,9 +1156,25 @@ type RouteStopPattern struct {
 	DirectionID int `json:"direction_id"`
 	// Number of trips that operate this stop pattern
 	Count int `json:"count"`
+	// One trip that follows this stop pattern, for reading the stop sequence without fetching every trip. Every trip sharing a stop pattern visits the same stops in the same order, so any of them describes the pattern; this is the lowest-numbered, scoped to the queried service date when `Route.patterns` was given one.
+	//
+	// Times, headsigns and `timepoint` flags are properties of the trip and can differ between trips of the same pattern — only the stop sequence is guaranteed common.
+	RepresentativeTrip *Trip `json:"representative_trip,omitempty"`
 	// Representative trips that follow this stop pattern; useful for fetching full stop_times
-	Trips   []*Trip `json:"trips,omitempty"`
-	RouteID int     `json:"-"`
+	Trips                []*Trip `json:"trips,omitempty"`
+	FeedVersionID        int     `json:"-"`
+	RepresentativeTripID int     `json:"-"`
+	RouteID              int     `json:"-"`
+}
+
+// Search options for a route's stop patterns
+type RouteStopPatternFilter struct {
+	// GTFS service date. Restricts the patterns returned to those a trip operates on that date, counts them over that date alone, and picks `representative_trip` from it. Ignored if `relative_date` is set
+	ServiceDate *tt.Date `json:"service_date,omitempty"`
+	// Calendar date relative to today; see `RelativeDate`. Takes precedence over `service_date`
+	RelativeDate *RelativeDate `json:"relative_date,omitempty"`
+	// If true and the requested date falls outside the feed version's normal service window, use the feed version's `fallback_week` instead
+	UseServiceWindow *bool `json:"use_service_window,omitempty"`
 }
 
 // A normalized, reusable piece of route geometry, optionally aligned with an OpenStreetMap way. Multiple route patterns may reference the same Segment.

--- a/server/model/unimplemented_finder.go
+++ b/server/model/unimplemented_finder.go
@@ -281,7 +281,7 @@ func (UnimplementedFinder) RoutesByFeedVersionIDs(context.Context, *int, *RouteF
 func (UnimplementedFinder) RoutesByIDs(_ context.Context, ids []int) ([]*Route, []error) {
 	return notImplBatch[*Route](ids)
 }
-func (UnimplementedFinder) RouteStopPatternsByRouteIDs(context.Context, *int, []int) ([][]*RouteStopPattern, error) {
+func (UnimplementedFinder) RouteStopPatternsByRouteIDs(context.Context, *int, *RouteStopPatternFilter, []FVPair) ([][]*RouteStopPattern, error) {
 	return nil, notImplErr()
 }
 func (UnimplementedFinder) RouteStopsByRouteIDs(context.Context, *int, []int) ([][]*RouteStop, error) {


### PR DESCRIPTION
## Summary

`Route.patterns` gains a `where: RouteStopPatternFilter` argument accepting `service_date`, `relative_date` and `use_service_window`, and `RouteStopPattern` gains a `representative_trip` field. Together these let a client get a route's stop patterns, scoped and counted for a single service date, with one representative trip each — in one query, without an N+1.

The date filter applies to `gtfs_trips` before they are grouped, so `count` becomes that date's trip count and a pattern nobody operates that day is not returned at all. Previously a client wanting day-scoped patterns had to fetch every trip on the date in a second query and group them itself.

### Query count

`representative_trip` costs nothing extra to compute: the aggregate already scans the trips it is grouping, so it also selects `min(gtfs_trips.id)` per pattern. That is the same trip `trips(limit: 1)` returns, since `tripSelect` orders by `(feed_version_id, id)` — but scoped to the date when one is given, so the representative is a trip that actually runs that day.

Reading a stop sequence per pattern therefore goes from one query per pattern to one for all of them. `RouteStopPattern.trips` resolves through `FindTrips` filtered on `stop_pattern_id`, which is unindexed, so each of those N calls scans the route's whole trip set to return one row — on a route with 116 patterns and 7,000 trips that is 116 scans of 7,000 rows. `representative_trip` instead resolves the ids the aggregate already returned through the existing `TripsByIDs` loader, a batched primary key lookup. Batching the trips also un-fragments what hangs below them: the `stop_times` and `stops` loaders now see all the representative trips in one dataloader generation rather than one per pattern, so they collapse to a single query each.

### Behaviour

`patterns` with no `where` produces the same rows as before. The aggregate gains `feed_version_id` in its `SELECT` and `GROUP BY`, which cannot change cardinality because `route_id` functionally determines it, and the two existing pattern tests pass untouched.

`RouteStopPattern.trips` is unchanged, including its existing `// TODO: N+1 query` — this PR adds a batched path beside it for callers that only need the stop sequence rather than altering it. A caller that genuinely wants several trips per pattern still pays the old cost.

Times, headsigns and `timepoint` flags are properties of a trip rather than of a pattern, and can differ between trips sharing one — only the stop sequence is guaranteed common. The schema documents this on `representative_trip`.

### Implementation

The service-date resolution and the calendar lateral are extracted from `tripSelect` into `resolveServiceDate` and `serviceDateLateral`, now shared with the patterns aggregate rather than duplicated. The lateral is an inner join, so a trip whose calendar does not cover the date is eliminated, and its `LIMIT 1` keeps a service with several `calendar_dates` rows from multiplying the trip — which is what makes the result safe to aggregate over.

The loader moves from a bare `route_id` key to `model.FVPair{FeedVersionID, RouteID}` so each feed version resolves the requested date against its own service window. It also drops the `paramGroupAdapter` wrapper, which existed only to inject a dummy filter dimension. The service window lookup is guarded on a date actually being requested: it is a hard-error path when the fvsl cache has no entry, so an unguarded call would make a date-free filter fail where bare `patterns` previously succeeded.

### Known gaps

The aggregate applies no permission or license filter, as before, while `representative_trip` resolves through `tripSelect` which applies both. A pattern whose representative trip is filtered out will therefore return `representative_trip: null` rather than being omitted.

`Route.patterns` still takes no `limit`, and the finder's limit remains a cap on the whole grouped result for one feed version rather than per route.

## Test plan

- `patterns(where: {service_date: "2018-06-18"})` on `Bu-130` returns counts summing to 22, matching the trip count the existing `trips(where: {service_date})` test expects for that route and date
- `representative_trip { trip_id }` agrees with `trips(limit: 1) { trip_id }` for every pattern on an undated query, pinning `min(id)` to the existing ordering
- The existing `route patterns` and `route patterns inactive fv` cases pass unchanged, covering backwards compatibility
- Full `go test ./server/...` passes
