### PR TITLE
Hold decoded RT sources in a kvcache.Cache

### DIFF
--- a/server/caches/kvcache/kvcache.go
+++ b/server/caches/kvcache/kvcache.go
@@ -150,6 +150,37 @@ func (c *Cache[K, V]) Refresh(ctx context.Context, key K) (V, error) {
 	return it.Value, nil
 }
 
+// Reload re-runs the refresh function for key and installs the value it
+// returns. Unlike Refresh, a key that turns out absent or unreadable leaves
+// whatever is held in place: reloading is for a key already known to have
+// changed, so a failure is a failure to observe that change rather than
+// evidence the key is gone.
+//
+// The call is bounded by RefreshTimeout and by the caller's own context, since
+// unlike a flight leader's refresh its result is nobody else's.
+func (c *Cache[K, V]) Reload(ctx context.Context, key K) (V, error) {
+	var zero V
+	if c.refreshFn == nil {
+		return zero, errors.New("kvcache: no refresh function")
+	}
+	rctx, cancel := context.WithTimeout(ctx, c.RefreshTimeout)
+	defer cancel()
+	value, err := c.refreshFn(rctx, key)
+	if err != nil {
+		return zero, err
+	}
+	n := c.now()
+	it := Item[V]{
+		Value:     value,
+		RecheckAt: n.Add(c.Recheck),
+		ExpiresAt: n.Add(c.Expires),
+	}
+	c.setLocal(key, it)
+	// The storage write gets its own budget, not whatever the refresh left.
+	_ = c.setStore(context.WithoutCancel(rctx), key, it, c.Expires)
+	return value, nil
+}
+
 // GetRecheckKeys reconciles the local tier against the shared tier in a
 // single multi-get — adopting entries refreshed by other processes and
 // pruning expired ones — and returns the keys still due for refresh.

--- a/server/caches/kvcache/kvcache.go
+++ b/server/caches/kvcache/kvcache.go
@@ -96,10 +96,7 @@ func (c *Cache[K, V]) Get(ctx context.Context, key K) (V, bool) {
 // GetItem returns the full envelope for key; ok is true when a valid
 // envelope is known, including negative tombstones (check Missing).
 func (c *Cache[K, V]) GetItem(ctx context.Context, key K) (Item[V], bool) {
-	c.lock.RLock()
-	it, ok := c.items[key]
-	c.lock.RUnlock()
-	if ok && it.ExpiresAt.After(c.now()) {
+	if it, ok := c.localState(key); ok && it.ExpiresAt.After(c.now()) {
 		return it, true
 	}
 	return c.loadOrRefresh(ctx, key)
@@ -157,7 +154,8 @@ func (c *Cache[K, V]) Refresh(ctx context.Context, key K) (V, error) {
 // evidence the key is gone.
 //
 // The call is bounded by RefreshTimeout and by the caller's own context, since
-// unlike a flight leader's refresh its result is nobody else's.
+// unlike a flight leader's refresh its result is nobody else's. Concurrent
+// Reloads of one key are not serialized: the last to finish wins.
 func (c *Cache[K, V]) Reload(ctx context.Context, key K) (V, error) {
 	var zero V
 	if c.refreshFn == nil {
@@ -192,10 +190,16 @@ func (c *Cache[K, V]) GetRecheckKeys(ctx context.Context) []K {
 // exactly when Get would return one without loading. Tombstoned keys are
 // not held. It consults neither the shared tier nor the refresh function.
 func (c *Cache[K, V]) Has(key K) bool {
-	c.lock.RLock()
-	it, ok := c.items[key]
-	c.lock.RUnlock()
+	it, ok := c.localState(key)
 	return ok && !it.Missing && it.ExpiresAt.After(c.now())
+}
+
+// Contains reports whether the local tier has any record of key — a live
+// value, a tombstone, or an expired entry not yet pruned. It consults
+// neither the shared tier nor the refresh function.
+func (c *Cache[K, V]) Contains(key K) bool {
+	_, ok := c.localState(key)
+	return ok
 }
 
 // LocalKeys returns a snapshot of locally known keys.
@@ -279,8 +283,9 @@ func (c *Cache[K, V]) loadOrRefresh(ctx context.Context, key K) (Item[V], bool) 
 		// detached from the leader's cancellation; backends apply their
 		// own per-op timeouts.
 		fctx := context.WithoutCancel(ctx)
+		prev, hadPrev := c.localState(key)
 		if it, ok := c.getStore(fctx, key); ok {
-			c.setLocal(key, it)
+			it, _ = c.installLocal(key, prev, hadPrev, it)
 			return result{item: it, ok: true}, nil
 		}
 		if c.refreshFn != nil {
@@ -304,7 +309,11 @@ func (c *Cache[K, V]) loadOrRefresh(ctx context.Context, key K) (Item[V], bool) 
 
 // runRefresh calls refreshFn detached from the caller's cancellation so
 // a canceled flight leader cannot fail the waiters sharing its result.
+// Installs go through installLocal: a Set or Reload landing mid-refresh saw
+// the key later than this refresh read it, and must not be overwritten —
+// least of all by a record of absence.
 func (c *Cache[K, V]) runRefresh(ctx context.Context, key K) (Item[V], error) {
+	prev, hadPrev := c.localState(key)
 	rctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), c.RefreshTimeout)
 	defer cancel()
 	value, err := c.refreshFn(rctx, key)
@@ -313,19 +322,21 @@ func (c *Cache[K, V]) runRefresh(ctx context.Context, key K) (Item[V], error) {
 	sctx := context.WithoutCancel(rctx)
 	if err == nil {
 		n := c.now()
-		it := Item[V]{
+		it, installed := c.installLocal(key, prev, hadPrev, Item[V]{
 			Value:     value,
 			RecheckAt: n.Add(c.Recheck),
 			ExpiresAt: n.Add(c.Expires),
+		})
+		if installed {
+			_ = c.setStore(sctx, key, it, c.Expires)
 		}
-		c.setLocal(key, it)
-		_ = c.setStore(sctx, key, it, c.Expires)
 		return it, nil
 	}
 	if errors.Is(err, ErrNotFound) && c.NegativeTTL > 0 {
-		it := c.missingItem(c.NegativeTTL)
-		c.setLocal(key, it)
-		_ = c.setStore(sctx, key, it, c.NegativeTTL)
+		it, installed := c.installLocal(key, prev, hadPrev, c.missingItem(c.NegativeTTL))
+		if installed {
+			_ = c.setStore(sctx, key, it, c.NegativeTTL)
+		}
 		return it, nil
 	}
 	return Item[V]{}, err
@@ -415,6 +426,37 @@ func (c *Cache[K, V]) setLocal(key K, it Item[V]) {
 	c.lock.Lock()
 	c.items[key] = it
 	c.lock.Unlock()
+}
+
+// localState returns key's local entry in whatever state — live, expired,
+// or tombstoned — without consulting the shared tier.
+func (c *Cache[K, V]) localState(key K) (Item[V], bool) {
+	c.lock.RLock()
+	it, ok := c.items[key]
+	c.lock.RUnlock()
+	return it, ok
+}
+
+// installLocal installs a load's result for key, unless a concurrent writer
+// replaced the entry mid-load and its entry is still live — whatever landed
+// during the load is newer information than what the load read. Returns the
+// winning entry and whether it was the offered one.
+func (c *Cache[K, V]) installLocal(key K, prev Item[V], hadPrev bool, it Item[V]) (Item[V], bool) {
+	n := c.now()
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	cur, ok := c.items[key]
+	if raced := ok != hadPrev || (ok && !sameItem(cur, prev)); raced && ok && cur.ExpiresAt.After(n) {
+		return cur, false
+	}
+	c.items[key] = it
+	return it, true
+}
+
+// sameItem reports whether two envelopes are the same installation. The
+// stamps stand in for identity, since values are not comparable in general.
+func sameItem[V any](a, b Item[V]) bool {
+	return a.Missing == b.Missing && a.ExpiresAt.Equal(b.ExpiresAt) && a.RecheckAt.Equal(b.RecheckAt)
 }
 
 // deleteExpiredLocal removes key's local entry if it is still expired,

--- a/server/caches/kvcache/kvcache.go
+++ b/server/caches/kvcache/kvcache.go
@@ -157,15 +157,14 @@ func (c *Cache[K, V]) GetRecheckKeys(ctx context.Context) []K {
 	return c.scan(ctx)
 }
 
-// Has reports whether key has a live local entry, counting negative
-// tombstones. It consults neither the shared tier nor the refresh
-// function, so a caller can ask what this process already holds without
-// causing the load that Get would.
+// Has reports whether the local tier holds a live value for key: true
+// exactly when Get would return one without loading. Tombstoned keys are
+// not held. It consults neither the shared tier nor the refresh function.
 func (c *Cache[K, V]) Has(key K) bool {
 	c.lock.RLock()
 	it, ok := c.items[key]
 	c.lock.RUnlock()
-	return ok && it.ExpiresAt.After(c.now())
+	return ok && !it.Missing && it.ExpiresAt.After(c.now())
 }
 
 // LocalKeys returns a snapshot of locally known keys.

--- a/server/caches/kvcache/kvcache.go
+++ b/server/caches/kvcache/kvcache.go
@@ -154,13 +154,16 @@ func (c *Cache[K, V]) Refresh(ctx context.Context, key K) (V, error) {
 // evidence the key is gone.
 //
 // The call is bounded by RefreshTimeout and by the caller's own context, since
-// unlike a flight leader's refresh its result is nobody else's. Concurrent
-// Reloads of one key are not serialized: the last to finish wins.
+// unlike a flight leader's refresh its result is nobody else's. Installs go
+// through installLocal: whatever landed mid-reload — a Set, a flight, or
+// another Reload — saw the key later than this reload read it and is kept,
+// and the returned value is the one actually held.
 func (c *Cache[K, V]) Reload(ctx context.Context, key K) (V, error) {
 	var zero V
 	if c.refreshFn == nil {
 		return zero, errors.New("kvcache: no refresh function")
 	}
+	prev, hadPrev := c.localState(key)
 	rctx, cancel := context.WithTimeout(ctx, c.RefreshTimeout)
 	defer cancel()
 	value, err := c.refreshFn(rctx, key)
@@ -168,15 +171,16 @@ func (c *Cache[K, V]) Reload(ctx context.Context, key K) (V, error) {
 		return zero, err
 	}
 	n := c.now()
-	it := Item[V]{
+	it, installed := c.installLocal(key, prev, hadPrev, Item[V]{
 		Value:     value,
 		RecheckAt: n.Add(c.Recheck),
 		ExpiresAt: n.Add(c.Expires),
+	})
+	if installed {
+		// The storage write gets its own budget, not whatever the refresh left.
+		_ = c.setStore(context.WithoutCancel(rctx), key, it, c.Expires)
 	}
-	c.setLocal(key, it)
-	// The storage write gets its own budget, not whatever the refresh left.
-	_ = c.setStore(context.WithoutCancel(rctx), key, it, c.Expires)
-	return value, nil
+	return it.Value, nil
 }
 
 // GetRecheckKeys reconciles the local tier against the shared tier in a
@@ -186,12 +190,22 @@ func (c *Cache[K, V]) GetRecheckKeys(ctx context.Context) []K {
 	return c.scan(ctx)
 }
 
+// Peek returns the live local value for key: exactly what Get would return
+// without loading. Tombstoned keys are not held. It consults neither the
+// shared tier nor the refresh function.
+func (c *Cache[K, V]) Peek(key K) (V, bool) {
+	if it, ok := c.localState(key); ok && !it.Missing && it.ExpiresAt.After(c.now()) {
+		return it.Value, true
+	}
+	var zero V
+	return zero, false
+}
+
 // Has reports whether the local tier holds a live value for key: true
-// exactly when Get would return one without loading. Tombstoned keys are
-// not held. It consults neither the shared tier nor the refresh function.
+// exactly when Peek would return one.
 func (c *Cache[K, V]) Has(key K) bool {
-	it, ok := c.localState(key)
-	return ok && !it.Missing && it.ExpiresAt.After(c.now())
+	_, ok := c.Peek(key)
+	return ok
 }
 
 // Contains reports whether the local tier has any record of key — a live

--- a/server/caches/kvcache/kvcache.go
+++ b/server/caches/kvcache/kvcache.go
@@ -157,6 +157,17 @@ func (c *Cache[K, V]) GetRecheckKeys(ctx context.Context) []K {
 	return c.scan(ctx)
 }
 
+// Has reports whether key has a live local entry, counting negative
+// tombstones. It consults neither the shared tier nor the refresh
+// function, so a caller can ask what this process already holds without
+// causing the load that Get would.
+func (c *Cache[K, V]) Has(key K) bool {
+	c.lock.RLock()
+	it, ok := c.items[key]
+	c.lock.RUnlock()
+	return ok && it.ExpiresAt.After(c.now())
+}
+
 // LocalKeys returns a snapshot of locally known keys.
 func (c *Cache[K, V]) LocalKeys() []K {
 	c.lock.RLock()

--- a/server/caches/kvcache/kvcache_test.go
+++ b/server/caches/kvcache/kvcache_test.go
@@ -292,6 +292,35 @@ func TestCache_SetMissing(t *testing.T) {
 	assert.True(t, it.Missing)
 }
 
+func TestCache_Has(t *testing.T) {
+	// Has answers from the local tier alone, so a consumer fanning a
+	// notification stream out to its own keys can ask what it holds without
+	// the load Get would trigger.
+	ctx := context.Background()
+	clock := newTestClock()
+	store := &recordingStore{Store: kvcache.NewMemoryStore()}
+	c := kvcache.NewCache[string, string](store, "test")
+	c.Clock = clock.Now
+	c.Expires = time.Minute
+	c.NegativeTTL = time.Minute
+
+	assert.False(t, c.Has("absent"), "an unknown key is not held")
+	assert.Equal(t, 0, store.getCount(), "Has must not consult storage")
+
+	assert.NoError(t, c.Set(ctx, "here", "value"))
+	assert.True(t, c.Has("here"))
+
+	// A tombstone is held too: the key is one this process was asked for.
+	assert.NoError(t, c.SetMissing(ctx, "ghost"))
+	assert.True(t, c.Has("ghost"))
+
+	// Both lapse with their TTL rather than lingering as phantom keys.
+	clock.Advance(2 * time.Minute)
+	assert.False(t, c.Has("here"))
+	assert.False(t, c.Has("ghost"))
+	assert.Equal(t, 0, store.getCount(), "Has must not consult storage")
+}
+
 func TestCache_NegativeMissNotTombstoned(t *testing.T) {
 	// A bare storage miss is not authoritative absence: even with
 	// NegativeTTL set, it must not install a tombstone that could mask a

--- a/server/caches/kvcache/kvcache_test.go
+++ b/server/caches/kvcache/kvcache_test.go
@@ -329,6 +329,46 @@ func TestCache_Has(t *testing.T) {
 	assert.EqualValues(t, 0, refreshes.Load(), "Has must not invoke the refresh function")
 }
 
+func TestCache_ReloadKeepsHeldValueOnFailure(t *testing.T) {
+	// Reload is for a key already known to have changed, so a refresh that
+	// cannot say what it changed to must leave the held value alone — where
+	// Refresh, told the key is absent, replaces it with a tombstone.
+	ctx := context.Background()
+	var fail atomic.Bool
+	c := kvcache.NewRefreshCache[string, string](nil, "test", func(_ context.Context, _ string) (string, error) {
+		if fail.Load() {
+			return "", kvcache.ErrNotFound
+		}
+		return "v1", nil
+	})
+	c.NegativeTTL = time.Minute
+
+	v, err := c.Reload(ctx, "k")
+	assert.NoError(t, err)
+	assert.Equal(t, "v1", v)
+	assert.True(t, c.Has("k"))
+
+	fail.Store(true)
+	_, err = c.Reload(ctx, "k")
+	assert.ErrorIs(t, err, kvcache.ErrNotFound)
+	got, ok := c.Get(ctx, "k")
+	assert.True(t, ok, "a failed reload must not discard the held value")
+	assert.Equal(t, "v1", got)
+
+	// Refresh is the other half of the contract: told the key is absent, it
+	// installs the tombstone Reload declined to.
+	_, err = c.Refresh(ctx, "k")
+	assert.NoError(t, err)
+	_, ok = c.Get(ctx, "k")
+	assert.False(t, ok, "Refresh replaces a held value with an absence")
+}
+
+func TestCache_ReloadWithoutRefreshFunc(t *testing.T) {
+	c := kvcache.NewCache[string, string](nil, "test")
+	_, err := c.Reload(context.Background(), "k")
+	assert.Error(t, err)
+}
+
 func TestCache_NegativeMissNotTombstoned(t *testing.T) {
 	// A bare storage miss is not authoritative absence: even with
 	// NegativeTTL set, it must not install a tombstone that could mask a

--- a/server/caches/kvcache/kvcache_test.go
+++ b/server/caches/kvcache/kvcache_test.go
@@ -369,6 +369,92 @@ func TestCache_ReloadWithoutRefreshFunc(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// A Set landing while a cold read is in flight saw the key later than the
+// flight read it, so the flight must not install its stale result over it —
+// and its waiters should be handed the fresher value.
+func TestCache_RefreshDoesNotClobberConcurrentSet(t *testing.T) {
+	ctx := context.Background()
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	c := kvcache.NewRefreshCache[string, string](nil, "test", func(ctx context.Context, key string) (string, error) {
+		close(entered)
+		<-release
+		return "stale", nil
+	})
+
+	var flightV string
+	var flightOk bool
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		flightV, flightOk = c.Get(ctx, "k")
+	}()
+	<-entered
+	assert.NoError(t, c.Set(ctx, "k", "fresh"))
+	close(release)
+	<-done
+
+	assert.True(t, flightOk)
+	assert.Equal(t, "fresh", flightV, "the flight's waiters get the mid-flight Set's value")
+	v, ok := c.Get(ctx, "k")
+	assert.True(t, ok)
+	assert.Equal(t, "fresh", v, "a mid-flight Set must not be overwritten by the flight's stale read")
+}
+
+// The absence a cold read observed is stale the moment a Set lands mid-flight:
+// told the key is absent, the flight must not tombstone the fresher value.
+func TestCache_RefreshAbsenceDoesNotClobberConcurrentSet(t *testing.T) {
+	ctx := context.Background()
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	c := kvcache.NewRefreshCache[string, string](nil, "test", func(ctx context.Context, key string) (string, error) {
+		close(entered)
+		<-release
+		return "", kvcache.ErrNotFound
+	})
+	c.NegativeTTL = time.Minute
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = c.Get(ctx, "k")
+	}()
+	<-entered
+	assert.NoError(t, c.Set(ctx, "k", "fresh"))
+	close(release)
+	<-done
+
+	v, ok := c.Get(ctx, "k")
+	assert.True(t, ok, "a mid-flight Set must not be masked by a tombstone")
+	assert.Equal(t, "fresh", v)
+}
+
+// Contains is the notification-fanout predicate: any local record counts,
+// including a tombstone or an expired entry awaiting the scan, because those
+// are exactly the keys whose next update matters.
+func TestCache_Contains(t *testing.T) {
+	ctx := context.Background()
+	clock := newTestClock()
+	c := kvcache.NewCache[string, string](nil, "test")
+	c.Clock = clock.Now
+	c.Expires = time.Minute
+	c.NegativeTTL = time.Minute
+
+	assert.False(t, c.Contains("absent"))
+	assert.NoError(t, c.Set(ctx, "here", "v"))
+	assert.True(t, c.Contains("here"))
+
+	assert.NoError(t, c.SetMissing(ctx, "ghost"))
+	assert.True(t, c.Contains("ghost"), "a tombstone is a record")
+	assert.False(t, c.Has("ghost"), "but not a held value")
+
+	clock.Advance(2 * time.Minute)
+	assert.False(t, c.Has("here"))
+	assert.True(t, c.Contains("here"), "an expired entry counts until pruned")
+	c.GetRecheckKeys(ctx)
+	assert.False(t, c.Contains("here"), "the scan prunes expired entries")
+}
+
 func TestCache_NegativeMissNotTombstoned(t *testing.T) {
 	// A bare storage miss is not authoritative absence: even with
 	// NegativeTTL set, it must not install a tombstone that could mask a

--- a/server/caches/kvcache/kvcache_test.go
+++ b/server/caches/kvcache/kvcache_test.go
@@ -299,26 +299,34 @@ func TestCache_Has(t *testing.T) {
 	ctx := context.Background()
 	clock := newTestClock()
 	store := &recordingStore{Store: kvcache.NewMemoryStore()}
-	c := kvcache.NewCache[string, string](store, "test")
+	var refreshes atomic.Int64
+	c := kvcache.NewRefreshCache[string, string](store, "test", func(_ context.Context, _ string) (string, error) {
+		refreshes.Add(1)
+		return "refreshed", nil
+	})
 	c.Clock = clock.Now
 	c.Expires = time.Minute
 	c.NegativeTTL = time.Minute
 
 	assert.False(t, c.Has("absent"), "an unknown key is not held")
-	assert.Equal(t, 0, store.getCount(), "Has must not consult storage")
 
 	assert.NoError(t, c.Set(ctx, "here", "value"))
 	assert.True(t, c.Has("here"))
 
-	// A tombstone is held too: the key is one this process was asked for.
+	// A tombstone is not a held value: Get reports a miss for it, and so must
+	// Has, or a consumer keying work off Has does that work for keys it has
+	// only ever failed to find.
 	assert.NoError(t, c.SetMissing(ctx, "ghost"))
-	assert.True(t, c.Has("ghost"))
+	_, ok := c.Get(ctx, "ghost")
+	assert.False(t, ok)
+	assert.False(t, c.Has("ghost"))
 
-	// Both lapse with their TTL rather than lingering as phantom keys.
+	// A held value lapses with its TTL rather than lingering as a phantom key.
 	clock.Advance(2 * time.Minute)
 	assert.False(t, c.Has("here"))
-	assert.False(t, c.Has("ghost"))
+
 	assert.Equal(t, 0, store.getCount(), "Has must not consult storage")
+	assert.EqualValues(t, 0, refreshes.Load(), "Has must not invoke the refresh function")
 }
 
 func TestCache_NegativeMissNotTombstoned(t *testing.T) {

--- a/server/caches/kvcache/kvcache_test.go
+++ b/server/caches/kvcache/kvcache_test.go
@@ -313,6 +313,11 @@ func TestCache_Has(t *testing.T) {
 	assert.NoError(t, c.Set(ctx, "here", "value"))
 	assert.True(t, c.Has("here"))
 
+	// Peek is Has returning the held value itself.
+	pv, pok := c.Peek("here")
+	assert.True(t, pok)
+	assert.Equal(t, "value", pv)
+
 	// A tombstone is not a held value: Get reports a miss for it, and so must
 	// Has, or a consumer keying work off Has does that work for keys it has
 	// only ever failed to find.
@@ -427,6 +432,43 @@ func TestCache_RefreshAbsenceDoesNotClobberConcurrentSet(t *testing.T) {
 	v, ok := c.Get(ctx, "k")
 	assert.True(t, ok, "a mid-flight Set must not be masked by a tombstone")
 	assert.Equal(t, "fresh", v)
+}
+
+// Reload shares the flights' install discipline: its read is stale the moment
+// a Set lands mid-reload, and must not overwrite it — locally or in the store.
+func TestCache_ReloadDoesNotClobberConcurrentSet(t *testing.T) {
+	ctx := context.Background()
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	store := kvcache.NewMemoryStore()
+	c := kvcache.NewRefreshCache[string, string](store, "test", func(ctx context.Context, key string) (string, error) {
+		close(entered)
+		<-release
+		return "stale", nil
+	})
+
+	var reloadV string
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		reloadV, _ = c.Reload(ctx, "k")
+	}()
+	<-entered
+	assert.NoError(t, c.Set(ctx, "k", "fresh"))
+	close(release)
+	<-done
+
+	assert.Equal(t, "fresh", reloadV, "the reload's caller gets the value actually held")
+	v, ok := c.Get(ctx, "k")
+	assert.True(t, ok)
+	assert.Equal(t, "fresh", v, "a mid-reload Set must not be overwritten by the reload's stale read")
+
+	// The refused install must not reach the shared tier either, where it
+	// would poison sibling processes.
+	c2 := kvcache.NewCache[string, string](store, "test")
+	v2, ok2 := c2.Get(ctx, "k")
+	assert.True(t, ok2)
+	assert.Equal(t, "fresh", v2)
 }
 
 // Contains is the notification-fanout predicate: any local record counts,

--- a/server/finders/rtfinder/cache.go
+++ b/server/finders/rtfinder/cache.go
@@ -53,12 +53,16 @@ func newStoreCache(store kvcache.Store) *storeCache {
 	}
 	c.sources = kvcache.NewRefreshCache[string, *Source](nil, "rtsource", c.readTopic)
 	// A decoded Source is only as good as the payload behind it, which the
-	// store drops after lastTTL. Nothing rechecks in the background — updates
-	// arrive by publication — so Recheck never has to come due.
+	// store drops after lastTTL. Recheck is left at its default because it
+	// cannot come due: scan drops an entry as expired before it tests it, and
+	// nothing refreshes in the background — updates arrive by publication.
 	c.sources.Expires = lastTTL
-	c.sources.Recheck = lastTTL
 	c.sources.NegativeTTL = missingTTL
 	c.sources.RefreshTimeout = storeReadTimeout
+	// Expiry alone stops an entry being served but does not release the decoded
+	// message behind it, which for a large feed is megabytes. Scanning prunes
+	// them; with nothing ever due, that is all this does.
+	c.sources.Start(missingTTL)
 	if ps, ok := store.(kvcache.PubSubStore); ok {
 		c.pubsub = ps
 		c.wg.Add(1)
@@ -86,19 +90,20 @@ func (c *storeCache) AddData(ctx context.Context, topic string, data []byte) err
 	}
 	// No shared distribution: decode straight into the local tier, replacing
 	// any record of absence.
-	s, err := c.decode(ctx, topic, data)
+	s, err := c.decode(rctx, topic, data)
 	if err != nil {
 		return err
 	}
-	return c.sources.Set(ctx, topic, s)
+	return c.sources.Set(rctx, topic, s)
 }
 
 func (c *storeCache) GetSource(ctx context.Context, topic string) (*Source, bool) {
-	// A caller that has already gone away is shed rather than started. A read is
-	// detached from its caller by design, so beginning one here would spend a
-	// store round trip on a result nobody waits for — and a client disconnecting
-	// mid-request leaves a resolver still looping over dozens of topics.
-	if ctx.Err() != nil {
+	// What is already held costs a map lookup and is served whatever state the
+	// caller is in. Only a load is shed: it is detached from its caller by
+	// design, so starting one for a caller that has gone away spends a store
+	// round trip nobody waits for, and a client disconnecting mid-request
+	// leaves a resolver still looping over dozens of topics.
+	if !c.sources.Has(topic) && ctx.Err() != nil {
 		return nil, false
 	}
 	return c.sources.Get(ctx, topic)
@@ -107,19 +112,18 @@ func (c *storeCache) GetSource(ctx context.Context, topic string) (*Source, bool
 func (c *storeCache) Close() error {
 	c.cancel()
 	c.wg.Wait()
+	c.sources.Stop()
 	return nil
 }
 
 // readTopic reads and decodes a topic's last payload. It is the cache's
-// refresh function, so concurrent callers for one topic share a single call
-// and its result is stored for them.
-//
-// Every failure reports kvcache.ErrNotFound, which records the topic as absent
-// for NegativeTTL. A caller loops over every feed associated with a feed
-// version, so a store that cannot answer must not be asked again for each of
-// them; the cases are logged apart, since absent is a quiet feed and failed is
-// the store not answering.
+// refresh function, and reports every failure as kvcache.ErrNotFound so the
+// topic is remembered as absent for NegativeTTL.
 func (c *storeCache) readTopic(ctx context.Context, topic string) (*Source, error) {
+	// A resolver sweeps every feed associated with a feed version, so a store
+	// that cannot answer must not be asked once per feed — an unreadable topic
+	// is remembered exactly like an empty one. They are logged apart because
+	// absent is a quiet feed and failed is the store not answering.
 	data, ok, err := c.store.Get(ctx, lastKey(topic))
 	if err != nil {
 		log.For(ctx).Error().Err(err).Str("topic", topic).Dur("retry_after", missingTTL).Msg("rtcache: topic read failed, not retried until this expires")
@@ -170,24 +174,39 @@ func (c *storeCache) drain(sub kvcache.Subscription) {
 			if !ok {
 				return
 			}
-			topic := string(msg)
-			// Every RT fetch in the fleet announces on this one channel, so a
-			// process must take only what it serves. Without this each process
-			// reads and decodes every feed in the system on every fetch.
-			if !c.watching(topic) {
-				continue
-			}
-			if s, err := c.sources.Refresh(c.ctx, topic); err == nil && s != nil {
-				log.For(c.ctx).Trace().Str("topic", topic).Msg("rtcache: processed update")
-			}
+			c.handleUpdate(string(msg))
 		}
 	}
 }
 
-// watching reports whether this process holds an entry for topic, which is
-// true only of topics a caller has asked for. A topic found absent counts:
-// somebody wants it, so an announcement that it now has data is worth taking
-// rather than waiting out the rest of missingTTL.
+// handleUpdate re-reads an announced topic, replacing this process's snapshot
+// of it.
+func (c *storeCache) handleUpdate(topic string) {
+	// Every RT fetch in the fleet announces on this one channel, so a process
+	// must take only what it serves. Without this each process reads and
+	// decodes every feed in the system on every fetch.
+	if !c.watching(topic) {
+		return
+	}
+	// Read directly rather than through the cache's own Refresh, which would
+	// install a record of absence when the read fails. An update this process
+	// could not fetch is not evidence the topic went away, and replacing a good
+	// snapshot with an absence would blank the feed for missingTTL over what
+	// may be a one-second hiccup. Bounded by the cache's context so Close is
+	// not held up by a store that has stopped answering.
+	rctx, cancel := context.WithTimeout(c.ctx, storeReadTimeout)
+	defer cancel()
+	s, err := c.readTopic(rctx, topic)
+	if err != nil || s == nil {
+		return
+	}
+	if err := c.sources.Set(rctx, topic, s); err == nil {
+		log.For(rctx).Trace().Str("topic", topic).Msg("rtcache: processed update")
+	}
+}
+
+// watching reports whether this process holds a snapshot for topic, which is
+// true only of topics a caller has asked for and the store had data for.
 func (c *storeCache) watching(topic string) bool {
 	return c.sources.Has(topic)
 }

--- a/server/finders/rtfinder/cache.go
+++ b/server/finders/rtfinder/cache.go
@@ -94,6 +94,13 @@ func (c *storeCache) AddData(ctx context.Context, topic string, data []byte) err
 }
 
 func (c *storeCache) GetSource(ctx context.Context, topic string) (*Source, bool) {
+	// A caller that has already gone away is shed rather than started. A read is
+	// detached from its caller by design, so beginning one here would spend a
+	// store round trip on a result nobody waits for — and a client disconnecting
+	// mid-request leaves a resolver still looping over dozens of topics.
+	if ctx.Err() != nil {
+		return nil, false
+	}
 	return c.sources.Get(ctx, topic)
 }
 

--- a/server/finders/rtfinder/cache.go
+++ b/server/finders/rtfinder/cache.go
@@ -188,20 +188,12 @@ func (c *storeCache) handleUpdate(topic string) {
 	if !c.watching(topic) {
 		return
 	}
-	// Read directly rather than through the cache's own Refresh, which would
-	// install a record of absence when the read fails. An update this process
-	// could not fetch is not evidence the topic went away, and replacing a good
-	// snapshot with an absence would blank the feed for missingTTL over what
-	// may be a one-second hiccup. Bounded by the cache's context so Close is
-	// not held up by a store that has stopped answering.
-	rctx, cancel := context.WithTimeout(c.ctx, storeReadTimeout)
-	defer cancel()
-	s, err := c.readTopic(rctx, topic)
-	if err != nil || s == nil {
-		return
-	}
-	if err := c.sources.Set(rctx, topic, s); err == nil {
-		log.For(rctx).Trace().Str("topic", topic).Msg("rtcache: processed update")
+	// Reload rather than Refresh: an update this process could not fetch is a
+	// failure to observe a change, not evidence the topic went away, and must
+	// not replace a good snapshot with a record of absence — that would blank
+	// the feed for missingTTL over what may be a one-second hiccup.
+	if _, err := c.sources.Reload(c.ctx, topic); err == nil {
+		log.For(c.ctx).Trace().Str("topic", topic).Msg("rtcache: processed update")
 	}
 }
 

--- a/server/finders/rtfinder/cache.go
+++ b/server/finders/rtfinder/cache.go
@@ -106,7 +106,10 @@ func (c *storeCache) GetSource(ctx context.Context, topic string) (*Source, bool
 	// design, so starting one for a caller that has gone away spends a store
 	// round trip nobody waits for, and a client disconnecting mid-request
 	// leaves a resolver still looping over dozens of topics.
-	if !c.sources.Has(topic) && ctx.Err() != nil {
+	if s, ok := c.sources.Peek(topic); ok {
+		return s, true
+	}
+	if ctx.Err() != nil {
 		return nil, false
 	}
 	return c.sources.Get(ctx, topic)

--- a/server/finders/rtfinder/cache.go
+++ b/server/finders/rtfinder/cache.go
@@ -18,42 +18,47 @@ const (
 	missingTTL = 1 * time.Minute
 	// reconnectDelay paces re-subscription attempts.
 	reconnectDelay = 1 * time.Second
+	// storeReadTimeout bounds one shared read and decode.
+	storeReadTimeout = 1 * time.Second
 	// updatesChannel carries topic pointers to the notify-then-read listeners.
 	updatesChannel = "rtfetch:updates"
 )
 
-// storeCache is the RT Cache backed by a kvcache.Store. It keeps decoded
-// Sources locally and, when the store supports pub/sub, learns of updates
-// from other processes via notify-then-read: a publish carries only the
+// storeCache is the RT Cache backed by a kvcache.Store. Decoded Sources are
+// held in a kvcache.Cache and, when the store supports pub/sub, updates from
+// other processes arrive by notify-then-read: a publish carries only the
 // topic, and the receiver re-reads the payload from the store.
 //
-// This is deliberately non-generic. The two-tier local map plus the
-// notify-then-read loop could be lifted into kvcache as a generic
-// PushCache[V] parameterized by a decoder (bytes -> V); it lives here
-// concretely for simplicity while rtfinder is the only consumer, and is
-// worth promoting only once a second push-distributed decoded cache appears.
+// The kvcache.Cache is local-tier only. Its shared tier would be a JSON
+// envelope this cache wrote itself, whereas the payload here is raw protobuf
+// written by the fetcher under its own key, and a decoded Source is not
+// something worth sharing between processes anyway — re-decoding the protobuf
+// is cheaper than encoding the result. So reading and decoding that payload is
+// the refresh function, and distribution stays with pub/sub.
 type storeCache struct {
 	store   kvcache.Store
 	pubsub  kvcache.PubSubStore // nil when the store has no pub/sub
+	sources *kvcache.Cache[string, *Source]
 	ctx     context.Context
 	cancel  context.CancelFunc
 	wg      sync.WaitGroup
-	lock    sync.Mutex
-	sources map[string]*Source
-	// missing records topics the store had nothing for, so a caller looping
-	// over dozens of associated feeds does not re-read each one every time.
-	missing map[string]time.Time
 }
 
 func newStoreCache(store kvcache.Store) *storeCache {
 	ctx, cancel := context.WithCancel(context.Background())
 	c := &storeCache{
-		store:   store,
-		ctx:     ctx,
-		cancel:  cancel,
-		sources: map[string]*Source{},
-		missing: map[string]time.Time{},
+		store:  store,
+		ctx:    ctx,
+		cancel: cancel,
 	}
+	c.sources = kvcache.NewRefreshCache[string, *Source](nil, "rtsource", c.readTopic)
+	// A decoded Source is only as good as the payload behind it, which the
+	// store drops after lastTTL. Nothing rechecks in the background — updates
+	// arrive by publication — so Recheck never has to come due.
+	c.sources.Expires = lastTTL
+	c.sources.Recheck = lastTTL
+	c.sources.NegativeTTL = missingTTL
+	c.sources.RefreshTimeout = storeReadTimeout
 	if ps, ok := store.(kvcache.PubSubStore); ok {
 		c.pubsub = ps
 		c.wg.Add(1)
@@ -79,67 +84,53 @@ func (c *storeCache) AddData(ctx context.Context, topic string, data []byte) err
 		// the topic changed; they re-read the payload from the store.
 		return c.pubsub.Publish(rctx, updatesChannel, []byte(topic))
 	}
-	// No shared distribution: decode straight into the local map.
+	// No shared distribution: decode straight into the local tier, replacing
+	// any record of absence.
 	s, err := c.decode(ctx, topic, data)
 	if err != nil {
 		return err
 	}
-	c.putSource(topic, s)
-	return nil
+	return c.sources.Set(ctx, topic, s)
 }
 
 func (c *storeCache) GetSource(ctx context.Context, topic string) (*Source, bool) {
-	c.lock.Lock()
-	if s, ok := c.sources[topic]; ok {
-		c.lock.Unlock()
-		return s, true
-	}
-	if at, ok := c.missing[topic]; ok && time.Since(at) < missingTTL {
-		c.lock.Unlock()
-		return nil, false
-	}
-	c.lock.Unlock()
-	// Cold read from the shared store without holding the lock.
-	s, err := c.loadFromStore(ctx, topic)
-	if s == nil {
-		// A caller that has gone away taught us nothing about the topic, so
-		// its cancellation must not be remembered as an absence.
-		if ctx.Err() != nil {
-			log.For(ctx).Trace().Str("topic", topic).Msg("rtcache: topic read abandoned by caller")
-			return nil, false
-		}
-		c.lock.Lock()
-		c.missing[topic] = time.Now()
-		c.lock.Unlock()
-		// Both outcomes are remembered so a caller looping over every
-		// associated feed does not re-read each one, but they are logged
-		// apart: absent is a quiet feed, failed is the store not answering.
-		if err != nil {
-			log.For(ctx).Trace().Str("topic", topic).Dur("retry_after", missingTTL).Msg("rtcache: topic read failed, not retried until this expires")
-		} else {
-			log.For(ctx).Trace().Str("topic", topic).Dur("retry_after", missingTTL).Msg("rtcache: topic absent from store, not retried until this expires")
-		}
-		return nil, false
-	}
-	// Only store reads are logged. The local and remembered paths are map
-	// hits, and a caller looping over every associated feed for every stop
-	// time makes logging them thousands of lines a request.
-	log.For(ctx).Trace().Str("topic", topic).Msg("rtcache: topic read")
-	c.lock.Lock()
-	// Double-check: a concurrent update may have inserted it meanwhile.
-	if existing, ok := c.sources[topic]; ok {
-		c.lock.Unlock()
-		return existing, true
-	}
-	c.sources[topic] = s
-	c.lock.Unlock()
-	return s, true
+	return c.sources.Get(ctx, topic)
 }
 
 func (c *storeCache) Close() error {
 	c.cancel()
 	c.wg.Wait()
 	return nil
+}
+
+// readTopic reads and decodes a topic's last payload. It is the cache's
+// refresh function, so concurrent callers for one topic share a single call
+// and its result is stored for them.
+//
+// Every failure reports kvcache.ErrNotFound, which records the topic as absent
+// for NegativeTTL. A caller loops over every feed associated with a feed
+// version, so a store that cannot answer must not be asked again for each of
+// them; the cases are logged apart, since absent is a quiet feed and failed is
+// the store not answering.
+func (c *storeCache) readTopic(ctx context.Context, topic string) (*Source, error) {
+	data, ok, err := c.store.Get(ctx, lastKey(topic))
+	if err != nil {
+		log.For(ctx).Error().Err(err).Str("topic", topic).Dur("retry_after", missingTTL).Msg("rtcache: topic read failed, not retried until this expires")
+		return nil, kvcache.ErrNotFound
+	}
+	if !ok || len(data) == 0 {
+		log.For(ctx).Trace().Str("topic", topic).Dur("retry_after", missingTTL).Msg("rtcache: topic absent from store, not retried until this expires")
+		return nil, kvcache.ErrNotFound
+	}
+	s, err := c.decode(ctx, topic, data)
+	if err != nil {
+		log.For(ctx).Error().Err(err).Str("topic", topic).Dur("retry_after", missingTTL).Msg("rtcache: topic decode failed, not retried until this expires")
+		return nil, kvcache.ErrNotFound
+	}
+	// Only store reads are logged, and only the one that happened: local hits
+	// and the callers that shared this read are not each an event.
+	log.For(ctx).Trace().Str("topic", topic).Msg("rtcache: topic read")
+	return s, nil
 }
 
 // subscribe keeps a subscription to the updates channel alive, re-reading
@@ -179,57 +170,19 @@ func (c *storeCache) drain(sub kvcache.Subscription) {
 			if !c.watching(topic) {
 				continue
 			}
-			if s, _ := c.loadFromStore(c.ctx, topic); s != nil {
-				c.putSource(topic, s)
+			if s, err := c.sources.Refresh(c.ctx, topic); err == nil && s != nil {
 				log.For(c.ctx).Trace().Str("topic", topic).Msg("rtcache: processed update")
 			}
 		}
 	}
 }
 
-// loadFromStore reads and decodes a topic's last payload.
-//
-// A nil Source with a nil error means the store definitely held nothing; a
-// non-nil error means it could not say. Callers treat both as a miss, but must
-// check their own context before concluding anything: a read cut short by the
-// caller says nothing about the topic.
-func (c *storeCache) loadFromStore(ctx context.Context, topic string) (*Source, error) {
-	rctx, cancel := context.WithTimeout(ctx, 1*time.Second)
-	defer cancel()
-	data, ok, err := c.store.Get(rctx, lastKey(topic))
-	if err != nil {
-		// A read that failed because the caller went away is not a store
-		// problem, and logging it as one floods on every client disconnect.
-		if ctx.Err() == nil {
-			log.For(ctx).Error().Err(err).Str("topic", topic).Msg("rtcache: error reading last data")
-		}
-		return nil, err
-	}
-	if !ok || len(data) == 0 {
-		return nil, nil
-	}
-	s, err := c.decode(ctx, topic, data)
-	if err != nil {
-		log.For(ctx).Error().Err(err).Str("topic", topic).Msg("rtcache: error decoding last data")
-		return nil, err
-	}
-	return s, nil
-}
-
-// watching reports whether this process holds a snapshot for topic, which is
-// true only of topics a caller has asked for.
+// watching reports whether this process holds an entry for topic, which is
+// true only of topics a caller has asked for. A topic found absent counts:
+// somebody wants it, so an announcement that it now has data is worth taking
+// rather than waiting out the rest of missingTTL.
 func (c *storeCache) watching(topic string) bool {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	_, ok := c.sources[topic]
-	return ok
-}
-
-// putSource installs s as the local snapshot for topic, replacing any prior one.
-func (c *storeCache) putSource(topic string, s *Source) {
-	c.lock.Lock()
-	c.sources[topic] = s
-	c.lock.Unlock()
+	return c.sources.Has(topic)
 }
 
 func (c *storeCache) decode(ctx context.Context, topic string, data []byte) (*Source, error) {

--- a/server/finders/rtfinder/cache.go
+++ b/server/finders/rtfinder/cache.go
@@ -10,8 +10,11 @@ import (
 )
 
 const (
-	// lastTTL bounds how long a topic's last-seen payload survives in the store.
-	lastTTL = 5 * time.Minute
+	// lastTTL bounds how long a topic's last-seen payload survives in the store,
+	// and with it how long a held snapshot is served after the last successful
+	// fetch. Generous so a feed fetched on any sane cadence never lapses between
+	// fetches; it only decides when a dead feed's last data finally disappears.
+	lastTTL = 24 * time.Hour
 	// missingTTL is how long a topic the store could not answer for is
 	// remembered as absent. Roughly a feed's publish cadence: checking more
 	// often cannot find anything new.
@@ -52,11 +55,11 @@ func newStoreCache(store kvcache.Store) *storeCache {
 		cancel: cancel,
 	}
 	c.sources = kvcache.NewRefreshCache[string, *Source](nil, "rtsource", c.readTopic)
-	// A decoded Source is only as good as the payload behind it, which the
-	// store drops after lastTTL. Recheck is left at its default because it
-	// cannot come due: scan drops an entry as expired before it tests it, and
-	// nothing refreshes in the background — updates arrive by publication.
+	// A snapshot and the payload behind it live lastTTL. Recheck is pinned to
+	// the same bound so it can never come due first: nothing refreshes in the
+	// background — updates arrive by publication.
 	c.sources.Expires = lastTTL
+	c.sources.Recheck = lastTTL
 	c.sources.NegativeTTL = missingTTL
 	c.sources.RefreshTimeout = storeReadTimeout
 	// Expiry alone stops an entry being served but does not release the decoded
@@ -197,10 +200,13 @@ func (c *storeCache) handleUpdate(topic string) {
 	}
 }
 
-// watching reports whether this process holds a snapshot for topic, which is
-// true only of topics a caller has asked for and the store had data for.
+// watching reports whether this process has any local record of topic: a held
+// snapshot, a record of absence, or an expired entry not yet pruned. A
+// tombstoned topic is one a caller recently wanted, so its announcements
+// matter most — adopting one revives the topic immediately instead of leaving
+// it blank until the tombstone lapses.
 func (c *storeCache) watching(topic string) bool {
-	return c.sources.Has(topic)
+	return c.sources.Contains(topic)
 }
 
 func (c *storeCache) decode(ctx context.Context, topic string, data []byte) (*Source, error) {

--- a/server/finders/rtfinder/cache_test.go
+++ b/server/finders/rtfinder/cache_test.go
@@ -211,6 +211,29 @@ func TestStoreCache_RemembersFailedReads(t *testing.T) {
 	assert.EqualValues(t, 1, store.gets.Load(), "a failing store should be read once, not once per lookup")
 }
 
+// The first payload for a topic this process remembered as absent must be
+// adopted when announced: the record of absence marks a topic a caller wanted,
+// not one to stay blind to until the record lapses.
+func TestStoreCache_UpdateRevivesTombstonedTopic(t *testing.T) {
+	store := &countingStore{MemoryStore: kvcache.NewMemoryStore()}
+	c := newStoreCache(store)
+	defer c.Close()
+
+	ctx := context.Background()
+	const topic = "rtrevive"
+	if _, ok := c.GetSource(ctx, topic); ok {
+		t.Fatal("the topic starts absent")
+	}
+
+	// The first fetch lands in the store and its announcement arrives.
+	require.NoError(t, store.Set(ctx, lastKey(topic), mkRTData(4321), lastTTL))
+	c.handleUpdate(topic)
+
+	s, ok := c.GetSource(ctx, topic)
+	require.True(t, ok, "an announced first payload must clear the record of absence")
+	assert.EqualValues(t, uint64(4321), s.GetTimestamp())
+}
+
 // A caller that has already gone away is shed: it must neither resolve nor
 // spend a store read nobody is waiting for, and its cancellation must not be
 // remembered as an absence that blinds every later caller for a minute.

--- a/server/finders/rtfinder/cache_test.go
+++ b/server/finders/rtfinder/cache_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -147,15 +148,20 @@ func TestStoreCache_IgnoresUnwatchedTopics(t *testing.T) {
 }
 
 // countingStore counts reads so a test can assert what a sequence of lookups
-// costs in round trips.
+// costs in round trips, and can hold each read open so a test can decide who
+// is in flight when.
 type countingStore struct {
 	*kvcache.MemoryStore
-	gets atomic.Int64
-	fail atomic.Bool
+	gets  atomic.Int64
+	fail  atomic.Bool
+	delay time.Duration
 }
 
 func (s *countingStore) Get(ctx context.Context, key string) ([]byte, bool, error) {
 	s.gets.Add(1)
+	if s.delay > 0 {
+		time.Sleep(s.delay)
+	}
 	if s.fail.Load() {
 		return nil, false, errors.New("store unavailable")
 	}
@@ -205,10 +211,11 @@ func TestStoreCache_RemembersFailedReads(t *testing.T) {
 	assert.EqualValues(t, 1, store.gets.Load(), "a failing store should be read once, not once per lookup")
 }
 
-// A read cut short because the caller went away says nothing about the topic,
-// so it must not be remembered as an absence — otherwise one canceled request
-// blinds every later one for a minute.
-func TestStoreCache_DoesNotRememberAbandonedReads(t *testing.T) {
+// A caller going away must not blind every later one for a minute. The read is
+// shared, so it is detached from whichever caller led it and finishes anyway,
+// and the later caller is answered from what that read learned rather than from
+// someone else's cancellation — which is why one store read is enough here.
+func TestStoreCache_SharedReadOutlivesItsCaller(t *testing.T) {
 	store := &countingStore{MemoryStore: kvcache.NewMemoryStore()}
 	c := newStoreCache(store)
 	defer c.Close()
@@ -220,9 +227,34 @@ func TestStoreCache_DoesNotRememberAbandonedReads(t *testing.T) {
 		t.Fatal("an abandoned read must not resolve")
 	}
 
-	// A later live lookup still has to reach the store.
 	if _, ok := c.GetSource(context.Background(), topic); ok {
 		t.Fatal("the topic is genuinely absent")
 	}
-	assert.EqualValues(t, 2, store.gets.Load(), "an abandoned read must not be remembered as absence")
+	assert.EqualValues(t, 1, store.gets.Load(), "the abandoned read still recorded what it learned")
+}
+
+// A request resolves many entities in parallel and each one asks for the same
+// topic, so without collapsing they all miss together and each reaches the
+// store. The store is held open for the duration so every caller is provably
+// in flight before the leader finishes, which is what makes the exact count
+// assertable rather than a timing bet.
+func TestStoreCache_CollapsesConcurrentReadsOfOneTopic(t *testing.T) {
+	store := &countingStore{MemoryStore: kvcache.NewMemoryStore(), delay: 50 * time.Millisecond}
+	c := newStoreCache(store)
+	defer c.Close()
+
+	const topic = "rtconcurrent"
+	const callers = 148
+	var wg sync.WaitGroup
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, ok := c.GetSource(context.Background(), topic); ok {
+				t.Error("the topic is absent")
+			}
+		}()
+	}
+	wg.Wait()
+	assert.EqualValues(t, 1, store.gets.Load(), "concurrent callers must share one store read")
 }

--- a/server/finders/rtfinder/cache_test.go
+++ b/server/finders/rtfinder/cache_test.go
@@ -211,11 +211,14 @@ func TestStoreCache_RemembersFailedReads(t *testing.T) {
 	assert.EqualValues(t, 1, store.gets.Load(), "a failing store should be read once, not once per lookup")
 }
 
-// A caller going away must not blind every later one for a minute. The read is
-// shared, so it is detached from whichever caller led it and finishes anyway,
-// and the later caller is answered from what that read learned rather than from
-// someone else's cancellation — which is why one store read is enough here.
-func TestStoreCache_SharedReadOutlivesItsCaller(t *testing.T) {
+// A caller that has already gone away is shed: it must neither resolve nor
+// spend a store read nobody is waiting for, and its cancellation must not be
+// remembered as an absence that blinds every later caller for a minute.
+//
+// The other half — a read whose caller leaves while it is already in flight
+// finishes anyway and serves the callers still waiting — belongs to the shared
+// cache, and kvcache's TestCache_SingleflightLeaderCancel covers it.
+func TestStoreCache_ShedsCanceledCallers(t *testing.T) {
 	store := &countingStore{MemoryStore: kvcache.NewMemoryStore()}
 	c := newStoreCache(store)
 	defer c.Close()
@@ -226,11 +229,12 @@ func TestStoreCache_SharedReadOutlivesItsCaller(t *testing.T) {
 	if _, ok := c.GetSource(canceled, topic); ok {
 		t.Fatal("an abandoned read must not resolve")
 	}
+	assert.EqualValues(t, 0, store.gets.Load(), "a canceled caller must not reach the store")
 
 	if _, ok := c.GetSource(context.Background(), topic); ok {
 		t.Fatal("the topic is genuinely absent")
 	}
-	assert.EqualValues(t, 1, store.gets.Load(), "the abandoned read still recorded what it learned")
+	assert.EqualValues(t, 1, store.gets.Load(), "a cancellation must not be remembered as an absence")
 }
 
 // A request resolves many entities in parallel and each one asks for the same

--- a/server/finders/rtfinder/cache_test.go
+++ b/server/finders/rtfinder/cache_test.go
@@ -34,7 +34,7 @@ func TestStoreCache_Redis(t *testing.T) {
 
 // TestStoreCache_PubSubUpdate exercises the notify-then-read distribution
 // path: a published notification must refresh an already-cached Source that
-// a plain GetSource (a local map hit) would not.
+// a plain GetSource, served from what is already held, would not.
 func TestStoreCache_PubSubUpdate(t *testing.T) {
 	if a, ok := testutil.CheckTestRedisClient(); !ok {
 		t.Skip(a)
@@ -186,7 +186,7 @@ func TestStoreCache_RemembersMissingTopics(t *testing.T) {
 	assert.EqualValues(t, 1, store.gets.Load(), "an absent topic should be read once, not once per lookup")
 
 	// A topic that arrives is served straight away rather than waiting out the
-	// TTL: the local snapshot is consulted before the record of absence.
+	// TTL: the payload replaces the record of absence.
 	require.NoError(t, c.AddData(ctx, topic, mkRTData(1234)))
 	s, ok := c.GetSource(ctx, topic)
 	require.True(t, ok)
@@ -239,15 +239,19 @@ func TestStoreCache_ShedsCanceledCallers(t *testing.T) {
 
 // A request resolves many entities in parallel and each one asks for the same
 // topic, so without collapsing they all miss together and each reaches the
-// store. The store is held open for the duration so every caller is provably
-// in flight before the leader finishes, which is what makes the exact count
-// assertable rather than a timing bet.
+// store.
+//
+// The store holds each read open for far longer than it takes every caller to
+// arrive, so in practice they all join one flight. It is not a guarantee: a
+// caller descheduled between the local check and the flight, for the whole
+// 50ms, would start a second read.
 func TestStoreCache_CollapsesConcurrentReadsOfOneTopic(t *testing.T) {
 	store := &countingStore{MemoryStore: kvcache.NewMemoryStore(), delay: 50 * time.Millisecond}
 	c := newStoreCache(store)
 	defer c.Close()
 
 	const topic = "rtconcurrent"
+	// The size of the feed whose resolvers first made this cost visible.
 	const callers = 148
 	var wg sync.WaitGroup
 	for i := 0; i < callers; i++ {
@@ -261,4 +265,75 @@ func TestStoreCache_CollapsesConcurrentReadsOfOneTopic(t *testing.T) {
 	}
 	wg.Wait()
 	assert.EqualValues(t, 1, store.gets.Load(), "concurrent callers must share one store read")
+}
+
+// An update this process could not fetch says nothing about whether the topic
+// still has data, so it must leave the snapshot alone. Replacing it with a
+// record of absence would blank the feed for missingTTL over what may be a
+// one-second store hiccup.
+func TestStoreCache_FailedUpdateKeepsSnapshot(t *testing.T) {
+	store := &countingStore{MemoryStore: kvcache.NewMemoryStore()}
+	c := newStoreCache(store)
+	defer c.Close()
+
+	ctx := context.Background()
+	const topic = "rtkeep"
+	require.NoError(t, c.AddData(ctx, topic, mkRTData(1000)))
+	s, ok := c.GetSource(ctx, topic)
+	require.True(t, ok)
+	require.EqualValues(t, uint64(1000), s.GetTimestamp())
+
+	// The store stops answering and an announcement arrives for the topic.
+	store.fail.Store(true)
+	c.handleUpdate(topic)
+
+	s, ok = c.GetSource(ctx, topic)
+	require.True(t, ok, "a failed update must not blank a live topic")
+	assert.EqualValues(t, uint64(1000), s.GetTimestamp())
+}
+
+// A decoded Source is only as good as the payload behind it, which the store
+// drops after lastTTL. Past that the snapshot stops being served from memory
+// and the store is asked again, so a feed that goes quiet goes quiet here too
+// instead of being pinned for the life of the process.
+func TestStoreCache_SnapshotDoesNotOutliveItsTTL(t *testing.T) {
+	store := &countingStore{MemoryStore: kvcache.NewMemoryStore()}
+	c := newStoreCache(store)
+	defer c.Close()
+
+	clock := newCacheClock()
+	c.sources.Clock = clock.Now
+
+	ctx := context.Background()
+	const topic = "rtexpiring"
+	require.NoError(t, c.AddData(ctx, topic, mkRTData(1000)))
+	_, ok := c.GetSource(ctx, topic)
+	require.True(t, ok)
+	require.EqualValues(t, 0, store.gets.Load(), "a fresh snapshot is served without a read")
+
+	clock.Advance(lastTTL + time.Minute)
+	_, _ = c.GetSource(ctx, topic)
+	assert.EqualValues(t, 1, store.gets.Load(), "an expired snapshot must be re-read, not served")
+}
+
+// cacheClock is a settable clock for driving cache TTL transitions.
+type cacheClock struct {
+	lock sync.Mutex
+	t    time.Time
+}
+
+func newCacheClock() *cacheClock {
+	return &cacheClock{t: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+}
+
+func (c *cacheClock) Now() time.Time {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.t
+}
+
+func (c *cacheClock) Advance(d time.Duration) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.t = c.t.Add(d)
 }

--- a/server/finders/rtfinder/finder.go
+++ b/server/finders/rtfinder/finder.go
@@ -76,7 +76,7 @@ func (f *Finder) FindAlertsForTrip(ctx context.Context, t *model.Trip, limit *in
 	for _, topic := range topics {
 		a, ok := f.cache.GetSource(ctx, getTopicKey(topic, "realtime_alerts"))
 		if a == nil || !ok {
-			return foundAlerts
+			continue
 		}
 		for _, alert := range a.alerts {
 			if alert == nil {


### PR DESCRIPTION
## Summary

`rtfinder`'s `storeCache` was hand-rolling what `kvcache.Cache` already provides: a local map in front of a shared tier, a negative-result memo with its own TTL, and — the reason this started — a way for the many resolvers of one request to share a single read instead of each making their own. #717 moved rtfinder onto the kvcache `Store` abstraction but left the cache built on top of it bespoke; this finishes that migration. The decoded `*Source` map, the `missing` map, `loadFromStore` and the mutex guarding them are replaced by one `kvcache.Cache[string, *Source]`, and `GetSource` becomes a delegation.

### The cache is local-tier only, on purpose

`NewRefreshCache[string, *Source](nil, "rtsource", c.readTopic)`, and the nil store is load-bearing. kvcache's shared tier holds a JSON `Item[V]` envelope that the cache writes itself, whereas the payload here is raw protobuf written by the fetch worker under `rtfetch:last:<topic>`, in a format this side does not own. A decoded `Source` is also not worth sharing between processes — it is a `*pb.FeedMessage` plus derived maps, and re-decoding the protobuf is cheaper than encoding the result. So reading and decoding that payload is the refresh function, and cross-process distribution stays where it already was, on pub/sub notify-then-read.

### What moving to the shared type gets

- Concurrent readers of one topic share a single read and decode. This is the behavior the migration was for: a request resolves many entities in parallel and each asks for the same handful of topics, so on a cold cache they previously all missed together and each went to the store.
- The shared call is detached from whichever caller led it, so a caller going away neither aborts the read for everyone waiting on it nor records its own cancellation as an absence.
- A read's result — a flight's or a `Reload`'s — installs through a guard: a write that lands while the read is in flight saw the key later than the read did, so the slower read defers to it — its callers are handed the fresher entry, its store write is skipped, and a record of absence can never be installed over a live value that arrived mid-flight. This preserves the old code's "a concurrent update may have inserted it meanwhile" check, which the migration would otherwise have lost: without it, a cold read racing `AddData` could overwrite the fresh `Source` with a stale payload, or blank it with a tombstone for `missingTTL`.
- `missing` and `missingTTL` become `NegativeTTL` plus a refresh function reporting `kvcache.ErrNotFound`. `readTopic` reports it for absent, unreadable and undecodable alike, because a resolver sweeps every feed associated with a feed version and a store that cannot answer must not be asked once per feed. The three cases are still logged apart.
- One `RefreshTimeout` bounds a load, replacing the nested five-second and one-second deadlines that previously wrapped each other, only one of which could ever fire.
- Local entries now expire, at `lastTTL`, matching the TTL the store applies to the payload behind them. A feed that stops publishing now stops being served instead of pinning its last decoded message for the life of the process, and the ticker prunes the entry so the message is released rather than merely unserved. `lastTTL` itself is raised from 5 minutes to 24 hours: at 5 minutes, a feed fetched less often than that would flicker absent between fetches once its snapshot expired, where the old immortal map served it continuously — the TTL now only decides when a dead feed's last data finally disappears. `Recheck` is pinned to the same bound in the constructor, so the fact that nothing refreshes in the background is stated in code rather than resting on kvcache's default happening to exceed the expiry.
- `GetSource` sheds a caller whose context is already done, but only when a load would follow. What is already held costs a map lookup and is served whatever state the caller is in.
- `FindAlertsForTrip` treats a topic it cannot get a source for like its three siblings do — skip it and keep going — instead of returning early with whatever it had. The early return was a pre-existing bug this migration would have promoted: with snapshots that lapse, one dead alerts topic would have dropped every remaining topic's alerts and skipped the limit.

### kvcache gains four methods

`Peek(key) (V, bool)` answers from the local tier alone: exactly what `Get` would return without loading, so tombstoned keys do not count as held. `Has(key) bool` is the same question without the value. `GetSource` serves a held snapshot straight off one `Peek`, and its shed turns a caller away only when a load would follow.

`Contains(key) bool` is the weaker question: is there any local record of the key — a live value, a tombstone, or an expired entry not yet pruned. `storeCache.watching` uses this one, because every RT fetch in the fleet announces on one channel and a process must decide whether an announcement concerns it without triggering a load. A tombstoned topic is precisely one a caller recently wanted, so its announcement matters most: adopting it replaces the record of absence with the payload immediately, instead of leaving the topic blank until the tombstone lapses. The same goes for an entry that expired but has not yet been pruned, which keeps a live feed watched across its own expiry.

`Reload(ctx, key) (V, error)` re-runs the refresh function and installs the value, but unlike `Refresh` a key that turns out absent or unreadable leaves whatever is held in place. The two express the difference between filling an empty slot and replacing a held value, which is a property of the call site rather than of the key. The pub/sub path needs the second: an update this process could not fetch is a failure to observe a change, not evidence the topic went away, and `Refresh` would replace a good snapshot with a record of absence — blanking that feed for `missingTTL` over what may be a one-second hiccup. `Reload` is bounded by the caller's context as well as by `RefreshTimeout`, since unlike a flight leader's refresh its result is nobody else's; that is also what keeps `Close` from waiting on a store that has stopped answering. `Reload` installs through the same guard as a flight: whatever landed mid-reload — a `Set`, a flight's install, or another `Reload` — saw the key later and is kept, and the caller is handed the value actually held.

### Tests

- `TestStoreCache_CollapsesConcurrentReadsOfOneTopic` is new. `countingStore` can hold a read open, so the leader is still in the store when every other caller arrives and the assertion is an exact count rather than a bound. Clean over 200 runs at `GOMAXPROCS=2` and 100 at `GOMAXPROCS=1`.
- `TestCache_RefreshDoesNotClobberConcurrentSet`, `TestCache_RefreshAbsenceDoesNotClobberConcurrentSet` and `TestCache_ReloadDoesNotClobberConcurrentSet` pin the install guard deterministically: the refresh function is gated on channels, so the racing `Set` provably lands mid-flight and the assertions are exact rather than timing-dependent. The Reload variant also asserts the refused install never reaches the shared tier.
- `TestStoreCache_UpdateRevivesTombstonedTopic` pins the adoption path: a topic remembered as absent must serve an announced first payload immediately.
- `TestStoreCache_FailedUpdateKeepsSnapshot` pins the pub/sub path: a store that stops answering mid-update must not blank a live topic. Switching `handleUpdate` back to `Refresh` makes it fail, which is what it is for.
- `TestStoreCache_SnapshotDoesNotOutliveItsTTL` pins the new expiry, so a later edit cannot silently desynchronize `Expires` from the store's own TTL.
- `TestStoreCache_DoesNotRememberAbandonedReads` becomes `TestStoreCache_ShedsCanceledCallers`, covering both halves: a caller that has already gone away costs no store read, and its cancellation is not remembered as an absence. The complementary property — a read whose caller leaves mid-flight still serves the callers still waiting — moved into the shared type with the mechanism, where `TestCache_SingleflightLeaderCancel` covers it.
- `TestCache_Has` (now also pinning the value `Peek` returns), `TestCache_Contains` and `TestCache_ReloadKeepsHeldValueOnFailure` cover the new methods — `TestCache_Contains` including the tombstone and expired-but-unpruned cases, and the Reload test asserting both halves of the contract: `Reload` keeps the held value where `Refresh` tombstones it.

## Known gaps

`readTopic` reports a transient store failure as `ErrNotFound`, which the package documents as authoritative absence. That is deliberate — an unreadable topic has to be remembered, or one dead dependency turns a request sweeping hundreds of topics into hundreds of sequential timeouts — but it is rtfinder policy rather than a fact about the key, and `Reload` exists so that policy no longer reaches the update path. The honest design would be a second sentinel for transient unavailability with its own local-only suppression; that is left for a follow-up.

`Reload` does not join the read-through flight, so a publish arriving while a read is in progress costs a second read. That is not an oversight: joining the existing flight would hand back a result read before the notification, which is precisely the change the notification was announcing. The duplicate read is inherent to notify-then-read, and it is the behavior on `main` as well. The install guard means the two cannot mis-order in either direction — a slower flight defers to the entry a `Reload` installed mid-flight, and a slower `Reload` defers to what landed mid-reload.

Two things shared with every other kvcache consumer rather than bespoke to rtfinder. `loadOrRefresh` uses blocking `Do`, so a waiter cannot walk away from a slow leader the way a `DoChan` plus `select` would allow — the trade is that a panic in a refresh function is re-raised on the caller's goroutine, where request-level recovery can catch it, rather than on a bare goroutine where it takes the process down. And a read-through refresh is bounded by `RefreshTimeout` but not tied to `Close`, so a cache closed mid-load has a read running for up to a second afterwards.

## Test plan

- `go test ./server/... -race`. The Redis-backed pub/sub tests need `TL_TEST_REDIS_URL`; confirm `TestStoreCache_PubSubUpdate` and `TestStoreCache_IgnoresUnwatchedTopics` report PASS rather than SKIP, since they cover the distribution path that changed.
- `GOMAXPROCS=2 go test ./server/finders/rtfinder/ -count=200`, since the collapse assertion is an exact count and low core counts are where a lost race would show.
- Against a running API with Redis and a feed publishing realtime data: load a route and a stop, confirm alerts, trip updates and vehicle positions resolve, and that the trace log shows one `rtcache: topic read` per topic per request rather than one per resolver.
- A feed fetched on a slow cadence (less often than every 5 minutes) keeps resolving between fetches instead of flickering absent once its snapshot passes the old TTL; the 24-hour expiry itself is pinned by the fake-clock test rather than manual observation.

