### PR TITLE
Fix Trip.frequencies grouping and add Frequency.trip

### DIFF
--- a/internal/generated/gqlout/generated.go
+++ b/internal/generated/gqlout/generated.go
@@ -44,6 +44,7 @@ type ResolverRoot interface {
 	FeedVersion() FeedVersionResolver
 	FeedVersionGtfsImport() FeedVersionGtfsImportResolver
 	FlexStopTime() FlexStopTimeResolver
+	Frequency() FrequencyResolver
 	Group() GroupResolver
 	Level() LevelResolver
 	Location() LocationResolver
@@ -489,6 +490,7 @@ type ComplexityRoot struct {
 		HeadwaySecs func(childComplexity int) int
 		ID          func(childComplexity int) int
 		StartTime   func(childComplexity int) int
+		Trip        func(childComplexity int) int
 	}
 
 	GbfsAlertTime struct {
@@ -1462,6 +1464,9 @@ type FlexStopTimeResolver interface {
 	Departure(ctx context.Context, obj *model.StopTime) (*model.StopTimeEvent, error)
 
 	ScheduleRelationship(ctx context.Context, obj *model.StopTime) (*model.ScheduleRelationship, error)
+}
+type FrequencyResolver interface {
+	Trip(ctx context.Context, obj *model.Frequency) (*model.Trip, error)
 }
 type GroupResolver interface {
 	Tenant(ctx context.Context, obj *model.Group) (*model.Tenant, error)
@@ -3696,6 +3701,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Frequency.StartTime(childComplexity), true
+	case "Frequency.trip":
+		if e.ComplexityRoot.Frequency.Trip == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Frequency.Trip(childComplexity), true
 
 	case "GbfsAlertTime.end":
 		if e.ComplexityRoot.GbfsAlertTime.End == nil {
@@ -10235,6 +10246,9 @@ type Frequency {
   
   "GTFS ` + "`" + `frequencies.exact_times` + "`" + ` [0=frequency-based, not exactly scheduled; 1=schedule-based, same headway throughout]"
   exact_times: Int
+
+  "Trip this headway applies to. Expanding a frequency measures from the trip's first departure, which this reaches even when a filtered ` + "`" + `Trip.stop_times` + "`" + ` selection omits the first stop."
+  trip: Trip!
 }
 
 """
@@ -13196,6 +13210,8 @@ func (ec *executionContext) childFields_Frequency(ctx context.Context, field gra
 		return ec.fieldContext_Frequency_headway_secs(ctx, field)
 	case "exact_times":
 		return ec.fieldContext_Frequency_exact_times(ctx, field)
+	case "trip":
+		return ec.fieldContext_Frequency_trip(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type Frequency", field.Name)
 }
@@ -25392,6 +25408,38 @@ func (ec *executionContext) _Frequency_exact_times(ctx context.Context, field gr
 }
 func (ec *executionContext) fieldContext_Frequency_exact_times(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("Frequency", field, false, false, errors.New("field of type Int does not have child fields"))
+}
+
+func (ec *executionContext) _Frequency_trip(ctx context.Context, field graphql.CollectedField, obj *model.Frequency) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Frequency_trip(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.Frequency().Trip(ctx, obj)
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *model.Trip) graphql.Marshaler {
+			return ec.marshalNTrip2ᚖgithubᚗcomᚋinterlineᚑioᚋtransitlandᚑlibᚋserverᚋmodelᚐTrip(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Frequency_trip(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Frequency",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_Trip(ctx, field)
+		},
+	}
+	return fc, nil
 }
 
 func (ec *executionContext) _GbfsAlertTime_start(ctx context.Context, field graphql.CollectedField, obj *model.GbfsAlertTime) (ret graphql.Marshaler) {
@@ -51384,25 +51432,61 @@ func (ec *executionContext) _Frequency(ctx context.Context, sel ast.SelectionSet
 		case "id":
 			out.Values[i] = ec._Frequency_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "start_time":
 			out.Values[i] = ec._Frequency_start_time(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "end_time":
 			out.Values[i] = ec._Frequency_end_time(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "headway_secs":
 			out.Values[i] = ec._Frequency_headway_secs(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "exact_times":
 			out.Values[i] = ec._Frequency_exact_times(ctx, field, obj)
+		case "trip":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Frequency_trip(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/schema/graphql/schema.graphqls
+++ b/schema/graphql/schema.graphqls
@@ -1208,6 +1208,9 @@ type Frequency {
   
   "GTFS `frequencies.exact_times` [0=frequency-based, not exactly scheduled; 1=schedule-based, same headway throughout]"
   exact_times: Int
+
+  "Trip this headway applies to. Expanding a frequency measures from the trip's first departure, which this reaches even when a filtered `Trip.stop_times` selection omits the first stop."
+  trip: Trip!
 }
 
 """

--- a/server/finders/dbfinder/trip.go
+++ b/server/finders/dbfinder/trip.go
@@ -72,7 +72,7 @@ func (f *Finder) FrequenciesByTripIDs(ctx context.Context, limit *int, keys []in
 		),
 		&ents,
 	)
-	return arrangeGroup(keys, ents, func(ent *model.Frequency) int { return ent.FeedVersionID }), err
+	return arrangeGroup(keys, ents, func(ent *model.Frequency) int { return ent.TripID.Int() }), err
 }
 
 // Replaces a date outside the feed version's service window with the same

--- a/server/gql/resolver.go
+++ b/server/gql/resolver.go
@@ -218,6 +218,9 @@ func (r *Resolver) Trip() gqlout.TripResolver { return &tripResolver{r} }
 // StopTime .
 func (r *Resolver) StopTime() gqlout.StopTimeResolver { return &stopTimeResolver{r} }
 
+// Frequency .
+func (r *Resolver) Frequency() gqlout.FrequencyResolver { return &frequencyResolver{r} }
+
 // VehiclePosition .
 func (r *Resolver) VehiclePosition() gqlout.VehiclePositionResolver {
 	return &vehiclePositionResolver{r}

--- a/server/gql/trip_resolver.go
+++ b/server/gql/trip_resolver.go
@@ -90,3 +90,11 @@ func (r *tripResolver) Alerts(ctx context.Context, obj *model.Trip, active *bool
 	rtAlerts := model.ForContext(ctx).RTFinder.FindAlertsForTrip(ctx, obj, resolverCheckLimit(limit), active)
 	return rtAlerts, nil
 }
+
+// FREQUENCY
+
+type frequencyResolver struct{ *Resolver }
+
+func (r *frequencyResolver) Trip(ctx context.Context, obj *model.Frequency) (*model.Trip, error) {
+	return LoaderFor(ctx).TripsByIDs.Load(ctx, obj.TripID.Int())()
+}

--- a/server/gql/trip_resolver_test.go
+++ b/server/gql/trip_resolver_test.go
@@ -178,7 +178,67 @@ func TestTripResolver(t *testing.T) {
 		},
 
 		// TODO: check where feed_version_sha1, feed_onestop_id but only check count
-		// TODO: frequencies
+	}
+	c, _ := newTestClient(t)
+	queryTestcases(t, c, testcases)
+}
+
+func TestTripResolver_Frequencies(t *testing.T) {
+	// CITY1 runs five headway bands; its first stop departs at 06:00:00.
+	const q = `query($trip_id:String!) {trips(where:{feed_onestop_id:"EX", feed_version_sha1:"43e2278aa272879c79460582152b04e7487f0493", trip_id:$trip_id}) {frequencies{start_time end_time headway_secs trip{trip_id stop_times(limit:1){departure_time}}}}}`
+	vars := hw{"trip_id": "CITY1"}
+	testcases := []testcase{
+		{
+			name:         "start_time",
+			query:        q,
+			vars:         vars,
+			selector:     "trips.0.frequencies.#.start_time",
+			selectExpect: []string{"06:00:00", "08:00:00", "10:00:00", "16:00:00", "19:00:00"},
+		},
+		{
+			name:         "end_time",
+			query:        q,
+			vars:         vars,
+			selector:     "trips.0.frequencies.#.end_time",
+			selectExpect: []string{"07:59:59", "09:59:59", "15:59:59", "18:59:59", "22:00:00"},
+		},
+		{
+			name:         "headway_secs",
+			query:        q,
+			vars:         vars,
+			selector:     "trips.0.frequencies.#.headway_secs",
+			selectExpect: []string{"1800", "600", "1800", "600", "1800"},
+		},
+		{
+			name:         "trip back reference",
+			query:        q,
+			vars:         vars,
+			selector:     "trips.0.frequencies.#.trip.trip_id",
+			selectExpect: []string{"CITY1", "CITY1", "CITY1", "CITY1", "CITY1"},
+		},
+		{
+			// The anchor a caller expands from. It comes from the trip rather
+			// than the band, so every band reports the same first departure.
+			name:         "first departure through the trip",
+			query:        q,
+			vars:         vars,
+			selector:     "trips.0.frequencies.#.trip.stop_times.0.departure_time",
+			selectExpect: []string{"06:00:00", "06:00:00", "06:00:00", "06:00:00", "06:00:00"},
+		},
+		{
+			name:         "trip with one frequency",
+			query:        q,
+			vars:         hw{"trip_id": "STBA"},
+			selector:     "trips.0.frequencies.#.headway_secs",
+			selectExpect: []string{"1800"},
+		},
+		{
+			name:         "trip with no frequencies",
+			query:        q,
+			vars:         hw{"trip_id": "AB1"},
+			selector:     "trips.0.frequencies.#.headway_secs",
+			selectExpect: []string{},
+		},
 	}
 	c, _ := newTestClient(t)
 	queryTestcases(t, c, testcases)


### PR DESCRIPTION
## Summary

`Trip.frequencies` returned an empty list for every trip, and there was no way to reach a trip's own stop times from a frequency. This fixes the first and adds `Frequency.trip` for the second, which together make frequency-based service usable through the trip-oriented query shape.

### Trip.frequencies returned nothing

- `FrequenciesByTripIDs` grouped its results by `ent.FeedVersionID` while its keys are `gtfs_trips.id`, so `arrangeGroup` looked up every trip id in a map keyed by feed version and found nothing. Every trip got an empty list, except a trip whose id happened to equal a feed version id, which got that feed version's entire set. Grouping now uses `ent.TripID.Int()`, matching the pattern every other loader in `dbfinder` follows.
- The field had no coverage at all — `trip_resolver_test.go` carried a `// TODO: frequencies` where the test should have been — which is why this survived. `Trip.frequencies` is the only path to `Frequency` in the schema, so the type was unreachable in practice, and the `frequencies` block in the REST trip and stop departure payloads was silently empty as well.

### Frequency.trip

- Adds `Frequency.trip: Trip!`, resolved through the existing `TripsByIDs` loader, following the same back-reference pattern as `StopTime.trip` and `FlexStopTime.trip`.
- Expanding a frequency into departures requires the trip's first departure as an anchor: the nth departure reaches a stop at `start_time + n * headway_secs + (departure_time - first_departure_time)`. A caller that filters `Trip.stop_times` by `stop_ids` may not receive the first stop, and so cannot compute that anchor from the filtered selection. Reaching the trip from the frequency gives an unfiltered `Trip.stop_times`, where `stop_sequence` ordering makes the first element the anchor, already carrying `journey_pattern_offset`.
- The traversal costs nothing for trips without frequencies: an empty `frequencies` list means no `Frequency` object exists to resolve `trip` on, so neither the trip lookup nor the stop time lookup runs.

### Tests

- `TestTripResolver_Frequencies` covers the bands returned for a multi-band trip, a single-band trip, a trip with no frequencies, the `trip` back reference, and the first departure reached through it. Verified to fail with `got []string{}` against the previous grouping.

## Test plan

Against a database with the `EX` example feed imported:

```graphql
{
  trips(where: {feed_onestop_id: "EX", trip_id: "CITY1"}) {
    frequencies {
      start_time
      end_time
      headway_secs
      trip { trip_id stop_times(limit: 1) { departure_time } }
    }
  }
}
```

Expect five bands starting 06:00:00, 08:00:00, 10:00:00, 16:00:00 and 19:00:00 with headways 1800, 600, 1800, 600 and 1800, each reporting `trip.trip_id` of `CITY1` and a first `departure_time` of 06:00:00. Confirm `AB1`, which has no frequencies.txt rows, returns an empty list rather than an error.
