### PR TITLE
Correct frequency expansion offset and apply Trip.stop_times limit in SQL

### DIFF
--- a/server/finders/dbfinder/stop_time.go
+++ b/server/finders/dbfinder/stop_time.go
@@ -14,7 +14,7 @@ func (f *Finder) StopTimesByTripIDs(ctx context.Context, limit *int, where *mode
 	var ents []*model.StopTime
 	err := dbutil.Select(ctx,
 		f.db,
-		stopTimeSelect(keys, stopTimeEntityTrip, where),
+		stopTimeSelect(keys, stopTimeEntityTrip, where, limit),
 		&ents,
 	)
 	return arrangeGroup(keys, ents, func(ent *model.StopTime) model.FVPair {
@@ -105,7 +105,7 @@ func (f *Finder) stopTimesByEntityIDs(ctx context.Context, entityType stopTimeEn
 				q = stopDeparturesSelect(fvid, entityKeys, entityType, w)
 			} else {
 				// Otherwise get all stop_times for entity
-				q = stopTimeSelect(entityPairs, entityType, nil)
+				q = stopTimeSelect(entityPairs, entityType, nil, nil)
 			}
 			// Run query
 			if err := dbutil.Select(ctx, f.db, q, &sts); err != nil {
@@ -138,7 +138,7 @@ const (
 	stopTimeEntityLocationGroup
 )
 
-func stopTimeSelect(pairs []model.FVPair, entityType stopTimeEntityType, where *model.TripStopTimeFilter) sq.SelectBuilder {
+func stopTimeSelect(pairs []model.FVPair, entityType stopTimeEntityType, where *model.TripStopTimeFilter, limit *int) sq.SelectBuilder {
 	q := sq.StatementBuilder.Select(
 		"gtfs_trips.journey_pattern_id",
 		"gtfs_trips.journey_pattern_offset",
@@ -167,37 +167,61 @@ func stopTimeSelect(pairs []model.FVPair, entityType stopTimeEntityType, where *
 		Join("feed_versions on feed_versions.id = gtfs_trips.feed_version_id").
 		Join("current_feeds on current_feeds.id = feed_versions.feed_id").
 		Join("gtfs_trips t2 ON t2.trip_id::text = gtfs_trips.journey_pattern_id AND gtfs_trips.feed_version_id = t2.feed_version_id").
-		Join("gtfs_stop_times sts ON sts.trip_id = t2.id AND sts.feed_version_id = t2.feed_version_id").
 		OrderBy("sts.stop_sequence, sts.arrival_time")
 
+	// Predicates selecting stop times, kept together because a per-trip limit
+	// has to be applied after all of them rather than before.
+	var stsWhere []sq.Sqlizer
 	if where != nil {
 		if where.Start != nil {
-			q = q.Where(sq.GtOrEq{"sts.departure_time + gtfs_trips.journey_pattern_offset": where.Start.Int()})
+			stsWhere = append(stsWhere, sq.GtOrEq{"sts.departure_time + gtfs_trips.journey_pattern_offset": where.Start.Int()})
 		}
 		if where.End != nil {
-			q = q.Where(sq.LtOrEq{"sts.arrival_time + gtfs_trips.journey_pattern_offset": where.End.Int()})
+			stsWhere = append(stsWhere, sq.LtOrEq{"sts.arrival_time + gtfs_trips.journey_pattern_offset": where.End.Int()})
 		}
 		// Without this a route crossing a small query area returns every stop
 		// on the route.
 		if len(where.StopIds) > 0 {
-			q = q.Where(In("sts.stop_id", where.StopIds))
+			stsWhere = append(stsWhere, In("sts.stop_id", where.StopIds))
 		}
 	}
 	if len(pairs) > 0 {
 		eids, fvids := pairKeys(pairs)
-		q = q.Where(In("sts.feed_version_id", fvids))
+		stsWhere = append(stsWhere, In("sts.feed_version_id", fvids))
 		switch entityType {
 		case stopTimeEntityTrip:
 			q = q.Where(In("gtfs_trips.id", eids), In("gtfs_trips.feed_version_id", fvids))
 		case stopTimeEntityStop:
-			q = q.Where(In("sts.stop_id", eids))
+			stsWhere = append(stsWhere, In("sts.stop_id", eids))
 		case stopTimeEntityLocation:
-			q = q.Where(In("sts.location_id", eids))
+			stsWhere = append(stsWhere, In("sts.location_id", eids))
 		case stopTimeEntityLocationGroup:
-			q = q.Where(In("sts.location_group_id", eids))
+			stsWhere = append(stsWhere, In("sts.location_group_id", eids))
 		}
 	}
-	return q
+
+	if limit == nil {
+		q = q.Join("gtfs_stop_times sts ON sts.trip_id = t2.id AND sts.feed_version_id = t2.feed_version_id")
+		if len(stsWhere) > 0 {
+			q = q.Where(sq.And(stsWhere))
+		}
+		return q
+	}
+	// One trip at a time, so the limit bounds each trip rather than the batch,
+	// and the (feed_version_id, trip_id, stop_sequence) primary key lets
+	// Postgres stop early instead of reading every trip in full.
+	inner := sq.StatementBuilder.
+		Select("sts.*").
+		From("gtfs_stop_times sts").
+		Where("sts.trip_id = t2.id and sts.feed_version_id = t2.feed_version_id").
+		// stop_sequence alone is a total order here, and matches the primary
+		// key, so the limit can be taken in index order.
+		OrderBy("sts.stop_sequence").
+		Limit(uint64(*limit))
+	if len(stsWhere) > 0 {
+		inner = inner.Where(sq.And(stsWhere))
+	}
+	return q.JoinClause(inner.Prefix("join lateral (").Suffix(") sts on true"))
 }
 
 // activeServicesCTE returns a CTE that finds all active service IDs for a given date and feed version.
@@ -286,19 +310,22 @@ func stopDeparturesSelect(fvid int, entityIDs []int, entityType stopTimeEntityTy
 			from gtfs_stop_times sts2 
 			where sts2.trip_id = base_trip.id and sts2.feed_version_id = base_trip.feed_version_id
 			) trip_stop_sequence on true`).
+		// A generated departure is anchored by freq_start, which is already an
+		// absolute time, so the journey pattern offset shifts scheduled times
+		// only. Adding it to both double-counted it for a derived trip.
 		JoinClause(`join lateral (
-			select 
+			select
 				sts.*,
-				sts.arrival_time + gtfs_trips.journey_pattern_offset + coalesce(
-					- trip_stop_sequence.first_departure_time + freq.freq_start,
-					0
+				sts.arrival_time + coalesce(
+					freq.freq_start - trip_stop_sequence.first_departure_time,
+					gtfs_trips.journey_pattern_offset
 				) AS arrival_time_freq,
-				sts.departure_time + gtfs_trips.journey_pattern_offset + coalesce(
-					- trip_stop_sequence.first_departure_time + freq.freq_start,
-					0
+				sts.departure_time + coalesce(
+					freq.freq_start - trip_stop_sequence.first_departure_time,
+					gtfs_trips.journey_pattern_offset
 				) AS departure_time_freq
 			from gtfs_stop_times sts
-			where sts.trip_id = base_trip.id and sts.feed_version_id = base_trip.feed_version_id		
+			where sts.trip_id = base_trip.id and sts.feed_version_id = base_trip.feed_version_id
 			) sts on true`).
 		Where(sq.Eq{"sts.feed_version_id": fvid}).
 		OrderBy("sts.departure_time_freq", "sts.trip_id") // base + offset


### PR DESCRIPTION
## Summary

Two independent changes to the stop time queries, split out from the frequencies resolver work so they can be measured on their own. The first corrects an arithmetic error in frequency expansion; the second applies `Trip.stop_times`' limit in SQL rather than discarding rows in Go. Both need performance validation before merging: the second changes the plan shape of a heavily used query, and neither has been measured on anything larger than the test fixture.

### Frequency expansion double-counted the journey pattern offset

- `stopDeparturesSelect` expanded a frequency as `departure_time + journey_pattern_offset + (freq_start - first_departure_time)`. `freq_start` is already an absolute clock time, so for a trip that is also a journey pattern derivative the offset was applied twice and every generated departure landed late by exactly `journey_pattern_offset`.
- Concretely: two trips departing 06:00 and 09:00 with the same run times hash to one journey pattern, the second gets `journey_pattern_offset = 10800` and its stop times discarded. Its frequencies running 09:00 to 10:00 at 1800 second headways rendered as 12:00, 12:30 and 13:00 rather than 09:00, 09:30 and 10:00.
- The offset is now the `coalesce` default rather than an unconditional addend, which states the rule directly: a generated departure is anchored by `freq_start`, a scheduled one is shifted by the journey pattern offset, never both. Verified that all five combinations of derived/base trip and frequency/no-frequency are unchanged except the double-counted one.
- Affects trips that are both frequency-bearing and journey-pattern-derived. Journey pattern deduplication is on during import and off in the CLI by default, so the arithmetic is only reachable through an import.

### Trip.stop_times discarded rows in Go rather than limiting in SQL

- `StopTimesByTripIDs` accepted a limit and ignored it. `stopTimeSelect` emitted no `LIMIT`, so every stop time of every trip in a batch was read and the dataloader then truncated each trip's slice to the same value the resolver had already computed. Results were correct; the work was wasted.
- `stopTimeSelect` now takes a limit and applies it per trip through a lateral. The predicates that select stop times are collected together and moved inside that lateral, because a limit applied before them would return the first N rows and then filter, dropping rows that should have been returned.
- Two paths: with no limit the original flat join is unchanged, which is the only form `stopTimesByEntityIDs` uses; with a limit the lateral applies. `StopTimesByTripIDs` always receives one, so the lateral is the `Trip.stop_times` path.
- The lateral orders by `stop_sequence` alone. It is a total order within a trip, being the trailing column of the `(feed_version_id, trip_id, stop_sequence)` primary key with both leading columns fixed, so the previous `arrival_time` tiebreaker could never fire and dropping it allows the limit to be taken in index order.
- Semantics are unchanged: the Go truncation used the identical value, so it becomes a no-op rather than the enforcement point.

## Performance validation needed

Measured on the test fixture only: 40,719 trips, 899k stop times, 11 `gtfs_frequencies` rows. A batch of 1,000 trips at `limit: 1` went from 13.47ms and 12,291 rows to 9.66ms and 1,000 rows, with buffer counts essentially unchanged at 3,907 and 3,886. The saving is in rows materialized and passed through Go, not in I/O, because an index probe into each of the ten `gtfs_stop_times` partitions dominates at roughly twelve stop times per trip.

That is not enough to predict behaviour on a large data set. The lateral removes the planner's freedom to choose a hash join for stop times and forces a per-trip nested loop, which is the kind of change that can invert on a table that does not fit in cache or where statistics differ. Wanted before merge:

- `EXPLAIN (ANALYZE, BUFFERS)` on the before and after forms of `stopTimeSelect` over realistic batch sizes, including a batch large enough that the flat join would prefer a hash.
- The same for a query with `start`, `end` and `stop_ids` filters set, where the lateral scans further before reaching its limit.
- Confirmation that the no-limit path's plan is unchanged, since it is shared with the stop, location and location group entry points.

## Test plan

The frequency change has no test coverage and none is possible against the current fixtures: no trip in `testdata` is both frequency-bearing and journey-pattern-derived, which is why the arithmetic was never exercised. `TestStopResolver_StopTimes_Frequencies` continues to pass because its trips have `journey_pattern_offset` of zero. Adding a fixture feed with a frequency-based trip that deduplicates against another would cover it.

For the limit change, the existing `TestTripResolver` stop time cases cover the lateral path, including explicit limits, start and end filters, and two aliased selections with different limits in one query. Verify by hand that a trip returns its full stop time list when no limit is given, and exactly N in `stop_sequence` order when one is.
