### PR TITLE
Reject extra filenames in dmfr format and fix dmfr lint panic

### DIFF
--- a/cmds/dmfr_format_cmd.go
+++ b/cmds/dmfr_format_cmd.go
@@ -34,10 +34,15 @@ func (cmd *DmfrFormatCommand) AddFlags(fl *pflag.FlagSet) {
 // Parse command line options.
 func (cmd *DmfrFormatCommand) Parse(args []string) error {
 	fl := tlcli.NewNArgs(args)
-	cmd.Filename = fl.Arg(0)
-	if cmd.Filename == "" {
+	if fl.NArg() == 0 {
 		return errors.New("must specify filename")
 	}
+	// Extra arguments were previously ignored, reporting success for files that
+	// were never touched.
+	if fl.NArg() > 1 {
+		return errors.New("only one filename allowed")
+	}
+	cmd.Filename = fl.Arg(0)
 	return nil
 }
 

--- a/cmds/dmfr_format_cmd_test.go
+++ b/cmds/dmfr_format_cmd_test.go
@@ -1,0 +1,49 @@
+package cmds
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDmfrFormatCommandParse(t *testing.T) {
+	testCases := []struct {
+		name        string
+		args        []string
+		errorSubstr string
+	}{
+		{
+			name:        "no arguments",
+			args:        []string{},
+			errorSubstr: "must specify filename",
+		},
+		{
+			name: "one filename",
+			args: []string{"a.dmfr.json"},
+		},
+		{
+			name:        "two filenames",
+			args:        []string{"a.dmfr.json", "b.dmfr.json"},
+			errorSubstr: "only one filename allowed",
+		},
+		{
+			name:        "glob expansion",
+			args:        []string{"a.dmfr.json", "b.dmfr.json", "c.dmfr.json"},
+			errorSubstr: "only one filename allowed",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := DmfrFormatCommand{}
+			err := cmd.Parse(tc.args)
+			if tc.errorSubstr == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.args[0], cmd.Filename)
+				return
+			}
+			if assert.Error(t, err) {
+				assert.Contains(t, err.Error(), tc.errorSubstr)
+			}
+		})
+	}
+}

--- a/cmds/dmfr_lint_cmd.go
+++ b/cmds/dmfr_lint_cmd.go
@@ -58,7 +58,11 @@ func (cmd *DmfrLintCommand) Run(ctx context.Context) error {
 		}
 		rr, err := dmfr.ReadRawRegistry(bytes.NewBuffer(rawJson))
 		if err != nil {
+			// A file that will not parse is a lint failure, not a crash. Without
+			// this the nil registry reaches rr.Write below and panics.
 			log.For(ctx).Error().Err(err).Str("filename", filename).Msg("could not load DMFR")
+			fileErrors = append(fileErrors, filename)
+			continue
 		}
 		var buf bytes.Buffer
 		if err := rr.Write(&buf); err != nil {
@@ -82,7 +86,7 @@ func (cmd *DmfrLintCommand) Run(ctx context.Context) error {
 		}
 	}
 	if len(fileErrors) > 0 {
-		return fmt.Errorf("incorrectly formatted files: %s", strings.Join(fileErrors, ", "))
+		return fmt.Errorf("lint failed for files: %s", strings.Join(fileErrors, ", "))
 
 	}
 	return nil

--- a/cmds/dmfr_lint_cmd_test.go
+++ b/cmds/dmfr_lint_cmd_test.go
@@ -1,0 +1,44 @@
+package cmds
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDmfrLintCommandMalformedJSON(t *testing.T) {
+	ctx := context.TODO()
+	tdir := t.TempDir()
+	good := filepath.Join(tdir, "good.dmfr.json")
+	bad := filepath.Join(tdir, "bad.dmfr.json")
+	if err := os.WriteFile(bad, []byte(`{"feeds": [ this is not json ]}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(good, []byte(`{"feeds":[{"spec":"gtfs","id":"f-9q5-a","urls":{"static_current":"http://example.com/g.zip"}}]}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Run the formatter over it so the file is correctly formatted by
+	// definition, rather than pinning a copy of the formatter's output here.
+	fmtCmd := DmfrFormatCommand{Save: true}
+	if err := fmtCmd.Parse([]string{good}); err != nil {
+		t.Fatal(err)
+	}
+	if err := fmtCmd.Run(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// A file that will not parse must be reported, not panic, and must not stop
+	// the remaining files from being checked.
+	cmd := DmfrLintCommand{}
+	if err := cmd.Parse([]string{bad, good}); err != nil {
+		t.Fatal(err)
+	}
+	err := cmd.Run(ctx)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "bad.dmfr.json")
+		assert.NotContains(t, err.Error(), "good.dmfr.json")
+	}
+}


### PR DESCRIPTION
## Summary

`transitland dmfr format` read a single filename via `fl.Arg(0)` and silently ignored the rest, so `dmfr format --save feeds/*.dmfr.json` formatted the first file, printed nothing, and exited 0. It now errors when given more than one filename. Cobra prints usage on the error, which already documents the argument as `<filename>`, so the code now agrees with the help text rather than the other way around.

Multi-file support is deliberately not added. Every scripted caller in transitland-atlas already invokes the command one file at a time through `find ./feeds -name "*.dmfr.json" -exec transitland dmfr format --save {} \;` (in `format.yaml`, `update-gbfs.yaml`, `update-jp.yaml`, and `scripts/debug/lowercase_feed_onestop_ids.py`), and `update-es-nap.yaml` passes a single explicit path. Nothing in CI changes behavior. The only invocation affected is a hand-typed glob, which is exactly the case that went wrong in transitland/transitland-atlas#2085, where two edited feed files kept a bad operator key order through a `format --save feeds/*.dmfr.json` and CI failed later on the `dmfr lint` step. Keeping the command single-file also leaves the stdout path untouched: without `--save` it still writes one formatted document, so anything piping its output is unaffected.

### dmfr lint panic on unparseable files

Found while working on the above and fixed here because it is a crash in the same pair of commands. `dmfr lint` logged the `ReadRawRegistry` error and then fell through to `rr.Write(&buf)` on a nil `*RawRegistry`, which dereferences immediately in `sort.Slice(r.Feeds, ...)`. Any file with a JSON syntax error panicked instead of being reported:

```
panic: runtime error: invalid memory address or nil pointer dereference
  dmfr.(*RawRegistry).Write(0x0, ...) raw_registry.go:46
  cmds.(*DmfrLintCommand).Run(...) dmfr_lint_cmd.go:64
```

A file that will not parse is now recorded as a lint failure and the remaining files are still checked, which matches the command's existing contract of reporting every bad file at the end. The final error message becomes `lint failed for files: ...` rather than `incorrectly formatted files: ...`, since the list now has two causes.

### Not addressed

Both commands call `dmfr.LoadAndParseRegistry` and log the error without acting on it, so a semantically invalid DMFR still formats and, with `--save`, is written back with exit 0. That is a separate question about whether these commands should gate on validation, and is left alone here.

More broadly, `tlcli.NArgs` has no arity validation at all — `Arg(i)` returns `""` past the end and nothing asks whether extra arguments were supplied. Eight commands read positional arguments through it and none check, so `checksum a.zip b.zip` silently checksums only the first, the same way `dmfr format` did. This PR fixes the one command that has actually caused a problem; the general fix belongs with whoever hits the next one. Tracked as issue 462 in the deployment repo.

## Test plan

New tests cover the arity error and the lint panic. Manually:

```
transitland dmfr format --save a.dmfr.json b.dmfr.json c.dmfr.json   # Error: only one filename allowed, exit 1
transitland dmfr format --save a.dmfr.json                           # formats, exit 0
transitland dmfr format a.dmfr.json                                  # writes formatted JSON to stdout, exit 0
transitland dmfr lint malformed.dmfr.json                            # reports the file, exit 1, no panic
```

Worth confirming the atlas `format.yaml` workflow still passes on a no-op PR, since it is the heaviest user of the command.
