### PR TITLE
Emit generated calendars in a stable order

### DIFF
--- a/copier/copier.go
+++ b/copier/copier.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"maps"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -773,7 +775,11 @@ func (copier *Copier) copyCalendars() error {
 	{
 		batchCals := make([]*gtfs.Calendar, 0, len(calDates))
 		cdCount := 0
-		for serviceId, cds := range calDates {
+		// Sorted: these calendars have no source order to preserve, and writers
+		// that assign ids in arrival order would otherwise number them
+		// differently on every run.
+		for _, serviceId := range slices.Sorted(maps.Keys(calDates)) {
+			cds := calDates[serviceId]
 			cal := gtfs.Calendar{}
 			cal.ServiceID.Set(serviceId)
 			// Set generated


### PR DESCRIPTION
## Summary

`copyCalendars` emits generated calendars — services that appear in `calendar_dates.txt` but have no `calendar.txt` row — by ranging a Go map, so they reach the writer in a different order on every run. Any consumer that assigns ids in arrival order therefore gets different ids for those services run to run, and that difference propagates to everything referencing them. Sorting the service ids before the loop makes the order stable.

The effect is invisible to a copy that just writes rows, which is why it has gone unnoticed, but it defeats byte-level reproducibility for anything that builds a derived artifact from the copy.

## Impact

Verified against a downstream consumer that assigns entity ids from a monotonic counter in arrival order and writes protobuf tiles. On a large European feed with 171 calendar-dates-only services, two runs of the same unmodified binary produced 89 differing tiles out of 223, with 9 messages differing per tile — journey patterns, trips and calendars, and in every case the differing field was the service id. With this change, all 223 tiles are byte-identical across runs.

Feeds with an empty or absent `calendar.txt` route every service through this path, so they are affected in full rather than partially.

## Test plan

- `go test ./copier/... ./service/... ./stats/...` passes.
- To reproduce the original behaviour: copy any feed that has services appearing only in `calendar_dates.txt` twice through a writer that assigns ids in arrival order, and compare the outputs. Feeds with at most one such service are stable by coincidence and will not show it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
