### PR TITLE
Rate limit fixes

### DIFF
--- a/doc/openapi/rest.json
+++ b/doc/openapi/rest.json
@@ -3297,6 +3297,9 @@
           },
           "404": {
             "description": "Not found - feed not found"
+          },
+          "429": {
+            "description": "Too many requests - feed version download quota exceeded"
           }
         },
         "summary": "Download feed version",
@@ -4408,6 +4411,9 @@
           },
           "404": {
             "description": "Not found - feed not found"
+          },
+          "429": {
+            "description": "Too many requests - feed version download quota exceeded"
           }
         },
         "summary": "Download latest feed version",

--- a/server/rest/feed_request.go
+++ b/server/rest/feed_request.go
@@ -249,6 +249,11 @@ func (r FeedDownloadLatestFeedVersionRequest) RequestInfo() RequestInfo {
 							Description: toPtr("Not found - feed not found"),
 						},
 					}),
+					oa.WithStatus(429, &oa.ResponseRef{
+						Value: &oa.Response{
+							Description: toPtr("Too many requests - feed version download quota exceeded"),
+						},
+					}),
 				),
 				Parameters: oa.Parameters{
 					&pref{Value: &param{

--- a/server/rest/feed_version_download.go
+++ b/server/rest/feed_version_download.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -121,6 +122,40 @@ func feedDownloadRtHelper(graphqlHandler http.Handler, w http.ResponseWriter, r 
 	w.Write(data)
 }
 
+// feedVersionDownloadMeter is the meter for feed version zip downloads: the
+// quota checked before serving, and the usage recorded after.
+const feedVersionDownloadMeter = "feed-version-downloads"
+
+// downloadDimensions describes one feed version download for metering.
+//
+// The same dimensions gate the quota and record the usage. A limit applies
+// only when its own dimensions are a subset of these, so checking with fewer
+// dimensions than are recorded would silently skip dimension-scoped limits.
+func downloadDimensions(fid string, fvsha1 string, isLatest bool) meters.Dimensions {
+	return meters.Dimensions{
+		{Key: "fv_sha1", Value: fvsha1},
+		{Key: "feed_onestop_id", Value: fid},
+		{Key: "is_latest_feed_version", Value: strconv.FormatBool(isLatest)},
+	}
+}
+
+// checkDownloadQuota reports whether this download is within the caller's
+// quota. It allows the download when no meter is configured, which is the
+// case outside a metered deployment and in tests.
+func checkDownloadQuota(ctx context.Context, dims meters.Dimensions) bool {
+	// The context holds a full Meterer; ForContext narrows it to the
+	// recording half, so reading a quota needs the reader back.
+	meterReader, ok := meters.ForContext(ctx).(meters.MeterReader)
+	if !ok {
+		return true
+	}
+	allowed, err := meterReader.Check(ctx, feedVersionDownloadMeter, 1.0, dims)
+	if err != nil {
+		log.For(ctx).Error().Err(err).Msg("feed version download quota check failed")
+	}
+	return allowed
+}
+
 // Query redirects user to download the given fv from S3 public URL
 // assuming that redistribution is allowed for the feed.
 func feedVersionDownloadLatestHandler(graphqlHandler http.Handler, w http.ResponseWriter, r *http.Request) {
@@ -166,6 +201,12 @@ func feedVersionDownloadLatestHandler(graphqlHandler http.Handler, w http.Respon
 		return
 	}
 
+	dims := downloadDimensions(fid, fvsha1, true)
+	if !checkDownloadQuota(ctx, dims) {
+		util.WriteJsonError(w, "too many requests", http.StatusTooManyRequests)
+		return
+	}
+
 	downloadKey := fmt.Sprintf("%s-%s.zip", fid, fvsha1)
 	cfg := model.ForContext(ctx)
 	if err := serveFromStorage(w, r, cfg.Storage, fvsha1, downloadKey); err != nil {
@@ -176,16 +217,11 @@ func feedVersionDownloadLatestHandler(graphqlHandler http.Handler, w http.Respon
 	// Send request to metering
 	if apiMeter := meters.ForContext(ctx); apiMeter != nil {
 		apiMeter.Meter(ctx, meters.MeterEvent{
-			Name:  "feed-version-downloads",
-			Value: 1.0,
-			Dimensions: []meters.Dimension{
-				{Key: "fv_sha1", Value: fvsha1},
-				{Key: "feed_onestop_id", Value: fid},
-				{Key: "is_latest_feed_version", Value: "true"},
-			},
+			Name:       feedVersionDownloadMeter,
+			Value:      1.0,
+			Dimensions: dims,
 		})
 	}
-
 }
 
 const feedVersionFileQuery = `
@@ -252,6 +288,12 @@ func feedVersionDownloadHandler(graphqlHandler http.Handler, w http.ResponseWrit
 		return
 	}
 
+	dims := downloadDimensions(fid, fvsha1, false)
+	if !checkDownloadQuota(ctx, dims) {
+		util.WriteJsonError(w, "too many requests", http.StatusTooManyRequests)
+		return
+	}
+
 	downloadKey := fmt.Sprintf("%s-%s.zip", fid, fvsha1)
 	cfg := model.ForContext(ctx)
 	if err := serveFromStorage(w, r, cfg.Storage, fvsha1, downloadKey); err != nil {
@@ -262,13 +304,9 @@ func feedVersionDownloadHandler(graphqlHandler http.Handler, w http.ResponseWrit
 	// Send request to metering
 	if apiMeter := meters.ForContext(ctx); apiMeter != nil {
 		apiMeter.Meter(ctx, meters.MeterEvent{
-			Name:  "feed-version-downloads",
-			Value: 1.0,
-			Dimensions: []meters.Dimension{
-				{Key: "fv_sha1", Value: fvsha1},
-				{Key: "feed_onestop_id", Value: fid},
-				{Key: "is_latest_feed_version", Value: "false"},
-			},
+			Name:       feedVersionDownloadMeter,
+			Value:      1.0,
+			Dimensions: dims,
 		})
 	}
 }

--- a/server/rest/feed_version_download.go
+++ b/server/rest/feed_version_download.go
@@ -156,6 +156,23 @@ func checkDownloadQuota(ctx context.Context, dims meters.Dimensions) bool {
 	return allowed
 }
 
+// recordDownload records one served feed version download against the quota
+// that admitted it.
+//
+// The event carries a unique id, which is the delivery's idempotency key: the
+// meter transport retries a failed batch, and without one a retry lands as a
+// second indistinguishable usage record that cannot afterwards be told apart
+// from a real second download.
+func recordDownload(ctx context.Context, dims meters.Dimensions) {
+	apiMeter := meters.ForContext(ctx)
+	if apiMeter == nil {
+		return
+	}
+	if err := apiMeter.Meter(ctx, meters.NewMeterEvent(feedVersionDownloadMeter, 1.0, dims)); err != nil {
+		log.For(ctx).Error().Err(err).Msg("feed version download metering failed")
+	}
+}
+
 // Query redirects user to download the given fv from S3 public URL
 // assuming that redistribution is allowed for the feed.
 func feedVersionDownloadLatestHandler(graphqlHandler http.Handler, w http.ResponseWriter, r *http.Request) {
@@ -214,14 +231,7 @@ func feedVersionDownloadLatestHandler(graphqlHandler http.Handler, w http.Respon
 		log.For(ctx).Error().Err(err).Msg("feed version download failed")
 		return
 	}
-	// Send request to metering
-	if apiMeter := meters.ForContext(ctx); apiMeter != nil {
-		apiMeter.Meter(ctx, meters.MeterEvent{
-			Name:       feedVersionDownloadMeter,
-			Value:      1.0,
-			Dimensions: dims,
-		})
-	}
+	recordDownload(ctx, dims)
 }
 
 const feedVersionFileQuery = `
@@ -301,14 +311,7 @@ func feedVersionDownloadHandler(graphqlHandler http.Handler, w http.ResponseWrit
 		log.For(ctx).Error().Err(err).Msg("feed version download failed")
 		return
 	}
-	// Send request to metering
-	if apiMeter := meters.ForContext(ctx); apiMeter != nil {
-		apiMeter.Meter(ctx, meters.MeterEvent{
-			Name:       feedVersionDownloadMeter,
-			Value:      1.0,
-			Dimensions: dims,
-		})
-	}
+	recordDownload(ctx, dims)
 }
 
 func serveFromStorage(w http.ResponseWriter, r *http.Request, storage string, fvsha1 string, downloadKey string) error {

--- a/server/rest/feed_version_download_test.go
+++ b/server/rest/feed_version_download_test.go
@@ -295,6 +295,24 @@ func TestFeedVersionDownloadQuota(t *testing.T) {
 			})
 		}
 	})
+	t.Run("each download records a unique event id", func(t *testing.T) {
+		// The event id is the delivery's idempotency key: without it a retried
+		// batch lands as a second usage record indistinguishable from a real
+		// second download.
+		mp := &fakeMeterProvider{}
+		get(mp, endpoints[0].path)
+		get(mp, endpoints[0].path)
+		assert.Equal(t, 2, mp.eventCount(feedVersionDownloadMeter), "download events")
+		ids := map[string]bool{}
+		for _, event := range mp.events {
+			if event.Name != feedVersionDownloadMeter {
+				continue
+			}
+			assert.NotEmpty(t, event.EventID, "event id")
+			ids[event.EventID] = true
+		}
+		assert.Len(t, ids, 2, "distinct event ids")
+	})
 	t.Run("not found is not checked", func(t *testing.T) {
 		// The quota is checked only once a download is actually going to be
 		// served, so a miss cannot consume it.

--- a/server/rest/feed_version_download_test.go
+++ b/server/rest/feed_version_download_test.go
@@ -1,16 +1,19 @@
 package rest
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/interline-io/transitland-lib/internal/testconfig"
 	"github.com/interline-io/transitland-lib/rt/pb"
 	"github.com/interline-io/transitland-lib/server/auth/authn"
 	"github.com/interline-io/transitland-lib/server/auth/mw/usercheck"
+	"github.com/interline-io/transitland-lib/server/meters"
 	"github.com/interline-io/transitland-lib/testdata"
 	"github.com/stretchr/testify/assert"
 	"github.com/tidwall/gjson"
@@ -221,6 +224,88 @@ func TestFeedDownloadLatestRequest(t *testing.T) {
 	})
 }
 
+func TestFeedVersionDownloadQuota(t *testing.T) {
+	_, restSrv, _ := testHandlersWithOptions(t, testconfig.Options{
+		Storage: testdata.Path("server", "tmp"),
+	})
+
+	// Both download endpoints, and the is_latest_feed_version value each one
+	// is expected to check and record.
+	endpoints := []struct {
+		name     string
+		path     string
+		isLatest string
+	}{
+		{"historical", "/feed_versions/d2813c293bcfd7a97dde599527ae6c62c98e66c6/download", "false"},
+		{"latest", "/feeds/CT/download_latest_feed_version", "true"},
+	}
+
+	// The admin user clears both download roles, and leaving the "rest" meter
+	// allowed means only the download quota can reject the request.
+	get := func(mp *fakeMeterProvider, path string) *httptest.ResponseRecorder {
+		req, _ := http.NewRequest("GET", path, nil)
+		rr := httptest.NewRecorder()
+		metered := meters.WithMeter(mp, "rest", 1.0, nil)(restSrv)
+		usercheck.AdminDefaultMiddleware("test")(metered).ServeHTTP(rr, req)
+		return rr
+	}
+
+	t.Run("within quota", func(t *testing.T) {
+		for _, tc := range endpoints {
+			t.Run(tc.name, func(t *testing.T) {
+				mp := &fakeMeterProvider{}
+				rr := get(mp, tc.path)
+				assert.Equal(t, 200, rr.Result().StatusCode, "status code")
+				assert.Equal(t, 59324, rr.Body.Len(), "body length")
+				assert.Equal(t, 1, mp.eventCount(feedVersionDownloadMeter), "download events")
+			})
+		}
+	})
+	t.Run("over quota", func(t *testing.T) {
+		for _, tc := range endpoints {
+			t.Run(tc.name, func(t *testing.T) {
+				mp := &fakeMeterProvider{allow: map[string]bool{feedVersionDownloadMeter: false}}
+				rr := get(mp, tc.path)
+				assert.Equal(t, 429, rr.Result().StatusCode, "status code")
+				assert.Equal(t, "application/json", rr.Header().Get("Content-Type"), "content-type")
+				// The zip must not be served alongside the error, and the quota
+				// the download was rejected for must not be consumed.
+				assert.JSONEq(t, `{"error":"too many requests"}`, rr.Body.String(), "body")
+				assert.Equal(t, 0, mp.eventCount(feedVersionDownloadMeter), "download events")
+			})
+		}
+	})
+	t.Run("checked dimensions match the recorded event", func(t *testing.T) {
+		// The quota is dimension-scoped, and a limit matches only when its own
+		// dimensions are contained in the checked ones.
+		for _, tc := range endpoints {
+			t.Run(tc.name, func(t *testing.T) {
+				mp := &fakeMeterProvider{}
+				get(mp, tc.path)
+				checked, ok := mp.lastCheck(feedVersionDownloadMeter)
+				if !assert.True(t, ok, "download quota was checked") {
+					return
+				}
+				assert.Equal(t, 1.0, checked.value, "checked value")
+				assert.Equal(t, tc.isLatest, dimValue(checked.dims, "is_latest_feed_version"), "is_latest_feed_version")
+				assert.Equal(t, "CT", dimValue(checked.dims, "feed_onestop_id"), "feed_onestop_id")
+				assert.NotEmpty(t, dimValue(checked.dims, "fv_sha1"), "fv_sha1")
+				assert.Equal(t, 1, mp.eventCount(feedVersionDownloadMeter), "download events")
+				assert.Equal(t, checked.dims, mp.lastEvent(feedVersionDownloadMeter).Dimensions, "checked and metered dimensions")
+			})
+		}
+	})
+	t.Run("not found is not checked", func(t *testing.T) {
+		// The quota is checked only once a download is actually going to be
+		// served, so a miss cannot consume it.
+		mp := &fakeMeterProvider{}
+		rr := get(mp, "/feed_versions/asdxyz/download")
+		assert.Equal(t, 404, rr.Result().StatusCode, "status code")
+		_, ok := mp.lastCheck(feedVersionDownloadMeter)
+		assert.False(t, ok, "download quota was not checked")
+	})
+}
+
 func TestFeedDownloadRtLatestRequest(t *testing.T) {
 	_, restSrv, _ := testHandlersWithOptions(t, testconfig.Options{
 		Storage: testdata.Path("server", "tmp"),
@@ -426,4 +511,90 @@ func TestFeedDownloadRtVehiclePositions(t *testing.T) {
 		assert.Greater(t, featureCount, 0, "should have at least one feature")
 	})
 
+}
+
+var _ meters.MeterProvider = (*fakeMeterProvider)(nil)
+
+// fakeMeterProvider answers Check from a per-meter allow map, defaulting to
+// allowed, and records every check and event so a test can assert what the
+// handler asked about.
+type fakeMeterProvider struct {
+	allow  map[string]bool
+	checks []fakeMeterCheck
+	events []meters.MeterEvent
+}
+
+type fakeMeterCheck struct {
+	name  string
+	value float64
+	dims  meters.Dimensions
+}
+
+func (p *fakeMeterProvider) NewMeter(meters.MeterUser) meters.Meterer {
+	return &fakeMeter{provider: p}
+}
+
+func (p *fakeMeterProvider) Close() error { return nil }
+
+func (p *fakeMeterProvider) Flush() error { return nil }
+
+func (p *fakeMeterProvider) lastCheck(meterName string) (fakeMeterCheck, bool) {
+	for i := len(p.checks) - 1; i >= 0; i-- {
+		if p.checks[i].name == meterName {
+			return p.checks[i], true
+		}
+	}
+	return fakeMeterCheck{}, false
+}
+
+func (p *fakeMeterProvider) lastEvent(meterName string) meters.MeterEvent {
+	for i := len(p.events) - 1; i >= 0; i-- {
+		if p.events[i].Name == meterName {
+			return p.events[i]
+		}
+	}
+	return meters.MeterEvent{}
+}
+
+func (p *fakeMeterProvider) eventCount(meterName string) int {
+	count := 0
+	for _, event := range p.events {
+		if event.Name == meterName {
+			count++
+		}
+	}
+	return count
+}
+
+type fakeMeter struct {
+	provider *fakeMeterProvider
+}
+
+func (m *fakeMeter) Meter(_ context.Context, event meters.MeterEvent) error {
+	m.provider.events = append(m.provider.events, event)
+	return nil
+}
+
+func (m *fakeMeter) ApplyDimension(_ string, _ string) {}
+
+func (m *fakeMeter) GetValue(_ context.Context, _ string, _ time.Time, _ time.Time, _ meters.Dimensions) (float64, bool) {
+	return 0, false
+}
+
+func (m *fakeMeter) Check(_ context.Context, meterName string, value float64, dims meters.Dimensions) (bool, error) {
+	m.provider.checks = append(m.provider.checks, fakeMeterCheck{name: meterName, value: value, dims: dims})
+	if allow, ok := m.provider.allow[meterName]; ok {
+		return allow, nil
+	}
+	return true, nil
+}
+
+// dimValue returns the value of one dimension, or "" if it is not present.
+func dimValue(dims meters.Dimensions, key string) string {
+	for _, dim := range dims {
+		if dim.Key == key {
+			return dim.Value
+		}
+	}
+	return ""
 }

--- a/server/rest/feed_version_request.go
+++ b/server/rest/feed_version_request.go
@@ -232,6 +232,11 @@ func (r FeedVersionDownloadRequest) RequestInfo() RequestInfo {
 							Description: toPtr("Not found - feed not found"),
 						},
 					}),
+					oa.WithStatus(429, &oa.ResponseRef{
+						Value: &oa.Response{
+							Description: toPtr("Too many requests - feed version download quota exceeded"),
+						},
+					}),
 				),
 			},
 		},


### PR DESCRIPTION
## Summary

The two feed version download handlers metered a download after serving it but never checked a quota first, so a per-plan download cap could not block anything: `Check` runs only inside the `WithMeter` middleware, and `feed-version-downloads` is not a middleware meter name — downloads pass through `Check("rest")` on the way in, which matches REST query limits rather than download caps. This adds the quota check to both handlers, returns 429 when it fails, and declares that response on both endpoints. It also gives each recorded download an idempotency key, which it did not have. No download becomes rejectable by merging this: on a metered deployment the check now runs and consults the usage counter, but that counter is not yet wired and reports zero, so every check passes. On a deployment without metering there is no meter in the request context at all and the download is served exactly as before.

### Quota check on both download handlers

- `feedVersionDownloadLatestHandler` and `feedVersionDownloadHandler` now check the `feed-version-downloads` meter before serving, and return 429 when the check fails.
- The check sits after the not-found and redistribution-not-allowed branches and before `serveFromStorage`, so a request that was going to 404 or 401 cannot consume quota, and nothing has been written to the response when the 429 is emitted. That ordering is load-bearing: `serveFromStorage` commits headers itself, either a 302 `Location` on the presigned path or a streamed body, so a check placed after it could not reject anything.
- The dimensions are built once per request and the same slice is passed to both `Check` and the existing `Meter` call. This matters because the plan caps these handlers are gated by are dimension-scoped on `is_latest_feed_version`, and a limit applies only when the limit's own dimensions are a subset of the ones supplied to `Check` — a dimensionless check would silently match no dimension-scoped limit while still appearing to work. Keeping one slice for both calls means the quota that is checked and the usage that is recorded can never drift apart.
- `meters.ForContext` returns a `MeterRecorder`, which carries `Meter` and `ApplyDimension` but not `Check`; the reader half is recovered with a two-value type assertion to `meters.MeterReader`. The value stored in the context is always a full `meters.Meterer` because `WithMeter` injects `MeterProvider.NewMeter`'s result, so the assertion succeeds wherever a meter is configured, and a failed assertion or absent meter serves the download rather than rejecting it.
- A non-nil error from `Check` is logged and the returned boolean is still honored, mirroring `WithMeter`. This is deliberate rather than incidental: no provider returns `(false, err)` today, so it is currently inert, but the behavior now matches the only other `Check` call site in the codebase instead of inventing a second convention.
- The two `"feed-version-downloads"` string literals are replaced by a single constant, and the duplicated dimension slices by one helper, so the checked meter and the recorded meter cannot diverge by editing one call site and not the other.

### Recorded downloads now carry an idempotency key

Both handlers built their meter event as a bare struct literal, which left the event id empty. That id is the delivery's idempotency key: the meter transport retries a failed batch, and with an empty key a retry lands as a second usage record that cannot afterwards be distinguished from a genuine second download — the deduplication pass on the receiving side explicitly skips records with a blank key, so these were neither preventable nor cleanable. The events are now built through the constructor that assigns one, and the two identical inline metering blocks are replaced by a single helper, symmetric with the quota check, so the pair cannot drift apart again. A failed metering call is also logged rather than silently discarded, matching the middleware.

### Published response codes

Both download endpoints declare explicit response codes in their `RequestInfo`, and explicit responses win over the generated defaults, so a 429 that is not declared there would be missing from the published spec. It is now declared on `FeedVersionDownloadRequest` and `FeedDownloadLatestFeedVersionRequest`, and `doc/openapi/rest.json` has been regenerated — exactly two entries added, with no other drift.

### Tests

- `TestFeedVersionDownloadQuota` covers both endpoints from one table: 200 with the full zip and one recorded event when the quota allows, and 429 with a JSON error body and zero recorded events when it does not.
- A separate case pins that the dimensions supplied to `Check` are the same ones recorded on the meter event, with `is_latest_feed_version` true on the latest-version endpoint and false on the specific-version endpoint, since that pairing is what makes a dimension-scoped cap bind.
- A not-found request is asserted not to check the quota at all, pinning the placement of the check relative to the 404 branch.
- The REST test suite installs no meter provider, so the tests build a small fake whose `Check` answers from a per-meter allow map and records every check and event. The middleware chain nests the meter inside the user middleware, because `WithMeter` reads the user from the context unconditionally.
- A separate case asserts that two downloads record two distinct, non-empty event ids, which fails if the events are built as bare struct literals again.
- The failure cases were confirmed non-vacuous by mutation: stubbing the check to always allow, and separately dropping the `return` after the 429, each make these tests fail, and the second of those was passing an earlier draft of the test.

### Enforcement is still inert after this merges

This closes the call-site half of the gap only. Actual blocking additionally requires the limit wiring in the deployment repo — meter-name reconciliation between the library's internal names and the plan service's names, and a usage counter, tracked there as issues 467 and 468. The second of those is what makes merging this inert: the counter is a stub reporting zero usage, so every limit compares one download against a cap of hundreds and passes. Worth knowing for review: the live deployment does enable limit enforcement, so once its pin moves the check will do real work per download — parsing the plan payload and reading the counter — where previously it did none. That cost was the reason downloads were chosen as the first endpoint to enforce, since it disappears against a multi-megabyte zip.

## Test plan

- Against a deployment with metering configured but limits not enforced, confirm feed version downloads still return 200 and continue to record usage with unchanged dimensions, and that no 429 is ever emitted.
- With a plan cap in place and limit enforcement switched on, confirm that a download past the cap returns 429 with a JSON body, that the zip is not served alongside it, and that no download usage is recorded for the rejected request.
- Confirm a download below the cap still returns the zip and records exactly one usage event, with `is_latest_feed_version` false on `/feed_versions/{key}/download` and true on `/feeds/{key}/download_latest_feed_version`.
- Confirm an unmetered deployment is unaffected: downloads serve normally with no meter in the request context.
- Confirm recorded download usage now carries a non-empty unique id on the receiving side, and that a retried delivery is identifiable as a duplicate rather than landing as a second download.
- Check the published spec renders 429 on both download endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
