### PR TITLE
Write pathways.txt reversed_signposted_as with the spec spelling

### DIFF
--- a/gtfs/pathway.go
+++ b/gtfs/pathway.go
@@ -8,6 +8,10 @@ import (
 )
 
 // Pathway pathways.txt
+//
+// Note: ReverseSignpostedAs needs an explicit csv tag. The GTFS field is
+// "reversed_signposted_as", which is not what the column name derivation
+// produces from the Go field name.
 type Pathway struct {
 	PathwayID           tt.String `csv:",required" standardized_sort:"1"`
 	FromStopID          tt.String `csv:",required" target:"stops.txt"`
@@ -20,7 +24,7 @@ type Pathway struct {
 	MaxSlope            tt.Float
 	StairCount          tt.Int
 	SignpostedAs        tt.String
-	ReverseSignpostedAs tt.String
+	ReverseSignpostedAs tt.String `csv:"reversed_signposted_as"`
 	tt.BaseEntity
 }
 

--- a/gtfs/pathway.go
+++ b/gtfs/pathway.go
@@ -11,7 +11,8 @@ import (
 //
 // Note: ReverseSignpostedAs needs an explicit csv tag. The GTFS field is
 // "reversed_signposted_as", which is not what the column name derivation
-// produces from the Go field name.
+// produces from the Go field name. The alias reads the derived name that
+// earlier versions of this library wrote.
 type Pathway struct {
 	PathwayID           tt.String `csv:",required" standardized_sort:"1"`
 	FromStopID          tt.String `csv:",required" target:"stops.txt"`
@@ -24,7 +25,7 @@ type Pathway struct {
 	MaxSlope            tt.Float
 	StairCount          tt.Int
 	SignpostedAs        tt.String
-	ReverseSignpostedAs tt.String `csv:"reversed_signposted_as"`
+	ReverseSignpostedAs tt.String `csv:"reversed_signposted_as" alias:"reverse_signposted_as"`
 	tt.BaseEntity
 }
 

--- a/gtfs/pathway.go
+++ b/gtfs/pathway.go
@@ -13,6 +13,10 @@ import (
 // "reversed_signposted_as", which is not what the column name derivation
 // produces from the Go field name. The alias reads the derived name that
 // earlier versions of this library wrote.
+//
+// Aliases are honored on the reflect load path. StopTime and Shape implement
+// SetString and load through their own switch statements instead, so an alias
+// on those entities would have no effect.
 type Pathway struct {
 	PathwayID           tt.String `csv:",required" standardized_sort:"1"`
 	FromStopID          tt.String `csv:",required" target:"stops.txt"`
@@ -25,7 +29,7 @@ type Pathway struct {
 	MaxSlope            tt.Float
 	StairCount          tt.Int
 	SignpostedAs        tt.String
-	ReverseSignpostedAs tt.String `csv:"reversed_signposted_as" alias:"reverse_signposted_as"`
+	ReverseSignpostedAs tt.String `csv:"reversed_signposted_as,alias=reverse_signposted_as"`
 	tt.BaseEntity
 }
 

--- a/internal/tags/tags.go
+++ b/internal/tags/tags.go
@@ -73,6 +73,7 @@ func ToSnakeCase(str string) string {
 // FieldInfo contains the parsed tag values for a single attribute.
 type FieldInfo struct {
 	Name           string
+	Alias          bool
 	Required       bool
 	Target         string
 	Index          []int
@@ -120,6 +121,7 @@ func (c *Cache) GetStructTagMap(ent interface{}) FieldMap {
 			)
 		}
 		m = FieldMap{}
+		aliases := map[string]*FieldInfo{}
 		fields := c.Mapper.TypeMap(reflect.TypeOf(ent))
 		for i, fi := range fields.Index {
 			_ = i
@@ -212,7 +214,23 @@ func (c *Cache) GetStructTagMap(ent interface{}) FieldMap {
 					mfi.SortOrder = optParse
 				}
 			}
+			if optVal := fi.Field.Tag.Get("alias"); optVal != "" {
+				aliases[optVal] = &mfi
+			}
 			m[fi.Name] = &mfi
+		}
+		// Register aliases after every field is mapped, so a field's own name is
+		// never displaced by another field's alias. Aliases are read-only: they
+		// resolve an incoming column name to a field, and GetHeader skips them so
+		// the field is written under its canonical name exactly once.
+		for aliasName, fi := range aliases {
+			if _, exists := m[aliasName]; exists {
+				continue
+			}
+			aliasFi := *fi
+			aliasFi.Alias = true
+			aliasFi.SortOrder = 0
+			m[aliasName] = &aliasFi
 		}
 		c.typemap[t] = m
 	}
@@ -226,6 +244,9 @@ func (c *Cache) GetSortColumns(ent interface{}) []*FieldInfo {
 	fmap := c.GetStructTagMap(ent)
 	var cols []*FieldInfo
 	for _, fi := range fmap {
+		if fi.Alias {
+			continue
+		}
 		if fi.SortOrder > 0 {
 			cols = append(cols, fi)
 		}
@@ -240,6 +261,9 @@ func (c *Cache) GetHeader(ent interface{}) ([]string, error) {
 	fmap := c.GetStructTagMap(ent)
 	stms := []*FieldInfo{}
 	for _, stm := range fmap {
+		if stm.Alias {
+			continue
+		}
 		stms = append(stms, stm)
 	}
 	sort.Slice(stms, func(i, j int) bool {

--- a/internal/tags/tags.go
+++ b/internal/tags/tags.go
@@ -73,7 +73,7 @@ func ToSnakeCase(str string) string {
 // FieldInfo contains the parsed tag values for a single attribute.
 type FieldInfo struct {
 	Name           string
-	Alias          bool
+	AliasOf        string
 	Required       bool
 	Target         string
 	Index          []int
@@ -84,6 +84,12 @@ type FieldInfo struct {
 	EnumValues     []int64
 	SortOrder      int
 	Kind           SortKind
+}
+
+// IsAlias reports whether this entry is an additional name for another field
+// rather than the field's own name.
+func (fi *FieldInfo) IsAlias() bool {
+	return fi.AliasOf != ""
 }
 
 // FieldMap contains all the parsed tags for a struct.
@@ -214,23 +220,37 @@ func (c *Cache) GetStructTagMap(ent interface{}) FieldMap {
 					mfi.SortOrder = optParse
 				}
 			}
-			if optVal := fi.Field.Tag.Get("alias"); optVal != "" {
+			// The alias is read from this mapper's own tag options, so an alias
+			// declared for one tag namespace stays invisible to the others.
+			if optVal := fi.Options["alias"]; optVal != "" {
+				if prev, exists := aliases[optVal]; exists {
+					log.For(ctx).Error().Msgf(
+						"error constructing field map for type %T: fields '%s' and '%s' both declare the alias '%s'; ignoring the one on '%s'",
+						ent, prev.Name, fi.Name, optVal, prev.Name,
+					)
+				}
 				aliases[optVal] = &mfi
 			}
 			m[fi.Name] = &mfi
 		}
 		// Register aliases after every field is mapped, so a field's own name is
-		// never displaced by another field's alias. Aliases are read-only: they
-		// resolve an incoming column name to a field, and GetHeader skips them so
-		// the field is written under its canonical name exactly once.
+		// never displaced by another field's alias. An alias entry carries only
+		// what is needed to locate the field: validation tags stay on the field's
+		// own entry, so a value is checked once, under the name the file uses.
 		for aliasName, fi := range aliases {
 			if _, exists := m[aliasName]; exists {
+				log.For(ctx).Error().Msgf(
+					"error constructing field map for type %T: alias '%s' is already the name of a field; ignoring it",
+					ent, aliasName,
+				)
 				continue
 			}
-			aliasFi := *fi
-			aliasFi.Alias = true
-			aliasFi.SortOrder = 0
-			m[aliasName] = &aliasFi
+			m[aliasName] = &FieldInfo{
+				Name:    aliasName,
+				AliasOf: fi.Name,
+				Index:   fi.Index,
+				Kind:    fi.Kind,
+			}
 		}
 		c.typemap[t] = m
 	}
@@ -244,9 +264,6 @@ func (c *Cache) GetSortColumns(ent interface{}) []*FieldInfo {
 	fmap := c.GetStructTagMap(ent)
 	var cols []*FieldInfo
 	for _, fi := range fmap {
-		if fi.Alias {
-			continue
-		}
 		if fi.SortOrder > 0 {
 			cols = append(cols, fi)
 		}
@@ -261,7 +278,7 @@ func (c *Cache) GetHeader(ent interface{}) ([]string, error) {
 	fmap := c.GetStructTagMap(ent)
 	stms := []*FieldInfo{}
 	for _, stm := range fmap {
-		if stm.Alias {
+		if stm.IsAlias() {
 			continue
 		}
 		stms = append(stms, stm)
@@ -269,7 +286,7 @@ func (c *Cache) GetHeader(ent interface{}) ([]string, error) {
 	sort.Slice(stms, func(i, j int) bool {
 		for pos := 0; ; pos++ {
 			if pos >= len(stms[i].Index) {
-				return true
+				return pos < len(stms[j].Index)
 			}
 			if pos >= len(stms[j].Index) {
 				return false

--- a/internal/tags/tags_test.go
+++ b/internal/tags/tags_test.go
@@ -13,6 +13,55 @@ type testEntity struct {
 	NotTagged  string `csv:"-"`
 }
 
+// aliasEntity covers the two ways an alias can interact with a real field name:
+// Renamed reads an old name that is no longer written, and Collides declares an
+// alias that is another field's actual name.
+type aliasEntity struct {
+	Renamed  string `csv:"new_name" alias:"old_name"`
+	Collides string `csv:"collides" alias:"new_name"`
+}
+
+func TestCache_GetStructTagMap_Alias(t *testing.T) {
+	c := NewCache(reflectx.NewMapperFunc("csv", ToSnakeCase))
+	stg := c.GetStructTagMap(&aliasEntity{})
+	renamed, ok := stg["new_name"]
+	if !ok {
+		t.Fatalf("did not get field for tag 'new_name'")
+	}
+	if renamed.Alias {
+		t.Errorf("expected 'new_name' to be a field, not an alias")
+	}
+	old, ok := stg["old_name"]
+	if !ok {
+		t.Fatalf("did not get field for alias 'old_name'")
+	}
+	if !old.Alias {
+		t.Errorf("expected 'old_name' to be marked as an alias")
+	}
+	// An alias must never displace a field that owns the name. Compare by index
+	// rather than pointer: the alias entry is a copy.
+	if old.Index[0] != renamed.Index[0] {
+		t.Errorf("alias 'old_name' resolves to field %v, expected %v", old.Index, renamed.Index)
+	}
+	if renamed.Index[0] != 0 {
+		t.Errorf("'new_name' resolves to field %v, expected the field that declares it", renamed.Index)
+	}
+}
+
+func TestCache_GetHeader_Alias(t *testing.T) {
+	c := NewCache(reflectx.NewMapperFunc("csv", ToSnakeCase))
+	header, _ := c.GetHeader(&aliasEntity{})
+	expect := []string{"new_name", "collides"}
+	if len(header) != len(expect) {
+		t.Fatalf("got header %v, expected %v", header, expect)
+	}
+	for i := range header {
+		if header[i] != expect[i] {
+			t.Errorf("got %s at position %d, expected %s", header[i], i, expect[i])
+		}
+	}
+}
+
 func TestCache_GetStructTagMap(t *testing.T) {
 	c := NewCache(reflectx.NewMapperFunc("csv", ToSnakeCase))
 	ent := &testEntity{}

--- a/internal/tags/tags_test.go
+++ b/internal/tags/tags_test.go
@@ -17,8 +17,8 @@ type testEntity struct {
 // Renamed reads an old name that is no longer written, and Collides declares an
 // alias that is another field's actual name.
 type aliasEntity struct {
-	Renamed  string `csv:"new_name" alias:"old_name"`
-	Collides string `csv:"collides" alias:"new_name"`
+	Renamed  string `csv:"new_name,alias=old_name,required" enum:"1,2"`
+	Collides string `csv:"collides,alias=new_name"`
 }
 
 func TestCache_GetStructTagMap_Alias(t *testing.T) {
@@ -28,15 +28,26 @@ func TestCache_GetStructTagMap_Alias(t *testing.T) {
 	if !ok {
 		t.Fatalf("did not get field for tag 'new_name'")
 	}
-	if renamed.Alias {
+	if renamed.IsAlias() {
 		t.Errorf("expected 'new_name' to be a field, not an alias")
 	}
 	old, ok := stg["old_name"]
 	if !ok {
 		t.Fatalf("did not get field for alias 'old_name'")
 	}
-	if !old.Alias {
+	if !old.IsAlias() {
 		t.Errorf("expected 'old_name' to be marked as an alias")
+	}
+	if old.Name != "old_name" || old.AliasOf != "new_name" {
+		t.Errorf("got alias entry Name=%q AliasOf=%q, expected 'old_name' and 'new_name'", old.Name, old.AliasOf)
+	}
+	// Validation tags stay on the field's own entry, so a value is checked once,
+	// under the name the file actually uses.
+	if old.Required {
+		t.Errorf("expected the alias entry not to carry the field's required tag")
+	}
+	if len(old.EnumValues) > 0 {
+		t.Errorf("expected the alias entry not to carry the field's enum values, got %v", old.EnumValues)
 	}
 	// An alias must never displace a field that owns the name. Compare by index
 	// rather than pointer: the alias entry is a copy.

--- a/tlcsv/reader_test.go
+++ b/tlcsv/reader_test.go
@@ -5,14 +5,17 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"slices"
 	"testing"
 
 	"github.com/interline-io/transitland-lib/adapters"
 	"github.com/interline-io/transitland-lib/causes"
+	"github.com/interline-io/transitland-lib/gtfs"
 	"github.com/interline-io/transitland-lib/internal/testreader"
 	"github.com/interline-io/transitland-lib/request"
 	"github.com/interline-io/transitland-lib/tt"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestReader_TripsWithStopTimes(t *testing.T) {
@@ -462,4 +465,72 @@ func TestValidateStructure_Partial(t *testing.T) {
 			}
 		}
 	})
+}
+
+// writePathways writes a one-row pathways.txt with the given header into a temp
+// directory and returns a reader for it.
+func readPathwaysWithHeader(t *testing.T, header string, row string) []gtfs.Pathway {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "pathways.txt"), []byte(header+"\n"+row+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	reader, err := NewReader(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []gtfs.Pathway
+	for ent := range reader.Pathways() {
+		out = append(out, ent)
+	}
+	return out
+}
+
+// Feeds exported by earlier versions of this library carry the derived column
+// name; the csv alias keeps that signage text from being dropped on read.
+func TestReader_PathwayReverseSignpostedAsAlias(t *testing.T) {
+	pathways := readPathwaysWithHeader(t,
+		"pathway_id,from_stop_id,to_stop_id,pathway_mode,is_bidirectional,signposted_as,reverse_signposted_as",
+		"pathway1,stop1,stop2,1,1,To Platform 1,To Exit")
+	if len(pathways) != 1 {
+		t.Fatalf("got %d pathways, expected 1", len(pathways))
+	}
+	assert.Equal(t, "To Platform 1", pathways[0].SignpostedAs.Val)
+	assert.Equal(t, "To Exit", pathways[0].ReverseSignpostedAs.Val)
+	// The alias resolves to the field, so it is not kept as an extra column.
+	_, extraOk := pathways[0].GetExtra("reverse_signposted_as")
+	assert.False(t, extraOk, "expected the alias to load as a field, not an extra column")
+}
+
+// A file written midway through the rename can carry both spellings. The field's
+// own column wins regardless of column order, and the alias column is kept as an
+// extra rather than silently overwriting it.
+func TestReader_PathwayBothSignpostedSpellings(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		header string
+		row    string
+	}{
+		{
+			name:   "spec column first",
+			header: "pathway_id,from_stop_id,to_stop_id,pathway_mode,is_bidirectional,reversed_signposted_as,reverse_signposted_as",
+			row:    "pathway1,stop1,stop2,1,1,SPEC,LEGACY",
+		},
+		{
+			name:   "alias column first",
+			header: "pathway_id,from_stop_id,to_stop_id,pathway_mode,is_bidirectional,reverse_signposted_as,reversed_signposted_as",
+			row:    "pathway1,stop1,stop2,1,1,LEGACY,SPEC",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pathways := readPathwaysWithHeader(t, tc.header, tc.row)
+			if len(pathways) != 1 {
+				t.Fatalf("got %d pathways, expected 1", len(pathways))
+			}
+			assert.Equal(t, "SPEC", pathways[0].ReverseSignpostedAs.Val)
+			extra, extraOk := pathways[0].GetExtra("reverse_signposted_as")
+			assert.True(t, extraOk, "expected the alias column to survive as an extra")
+			assert.Equal(t, "LEGACY", extra)
+		})
+	}
 }

--- a/tlcsv/reflect.go
+++ b/tlcsv/reflect.go
@@ -116,6 +116,14 @@ func loadRowReflect(ent interface{}, row Row) []error {
 	} else {
 		// Get the struct tag map
 		fmap := MapperCache.GetStructTagMap(ent)
+		// A file can carry both a field's own name and an alias for it, e.g. a
+		// feed written midway through a rename. The field's own column wins; the
+		// alias column is kept as an extra instead of overwriting it, so nothing
+		// depends on which column comes first.
+		headerNames := make(map[string]bool, len(row.Header))
+		for _, h := range row.Header {
+			headerNames[h] = true
+		}
 		// For each struct tag, set the field value
 		entValue := reflect.ValueOf(ent).Elem()
 		for i := 0; i < len(row.Header); i++ {
@@ -125,6 +133,9 @@ func loadRowReflect(ent interface{}, row Row) []error {
 				strv = row.Row[i]
 			}
 			fieldInfo, ok := fmap[fieldName]
+			if ok && fieldInfo.IsAlias() && headerNames[fieldInfo.AliasOf] {
+				ok = false
+			}
 			// Add to extra fields if there's no struct tag
 			if !ok {
 				if extEnt, ok2 := ent.(tt.EntityWithExtra); ok2 {

--- a/tlcsv/reflect.go
+++ b/tlcsv/reflect.go
@@ -116,14 +116,6 @@ func loadRowReflect(ent interface{}, row Row) []error {
 	} else {
 		// Get the struct tag map
 		fmap := MapperCache.GetStructTagMap(ent)
-		// A file can carry both a field's own name and an alias for it, e.g. a
-		// feed written midway through a rename. The field's own column wins; the
-		// alias column is kept as an extra instead of overwriting it, so nothing
-		// depends on which column comes first.
-		headerNames := make(map[string]bool, len(row.Header))
-		for _, h := range row.Header {
-			headerNames[h] = true
-		}
 		// For each struct tag, set the field value
 		entValue := reflect.ValueOf(ent).Elem()
 		for i := 0; i < len(row.Header); i++ {
@@ -133,8 +125,14 @@ func loadRowReflect(ent interface{}, row Row) []error {
 				strv = row.Row[i]
 			}
 			fieldInfo, ok := fmap[fieldName]
-			if ok && fieldInfo.IsAlias() && headerNames[fieldInfo.AliasOf] {
-				ok = false
+			if ok && fieldInfo.IsAlias() {
+				// A file can carry both a field's own name and an alias for it,
+				// e.g. a feed written midway through a rename. The field's own
+				// column wins; the alias column falls through to extras instead
+				// of overwriting it, so nothing depends on column order.
+				if _, hasOwn := row.Hindex[fieldInfo.AliasOf]; hasOwn {
+					ok = false
+				}
 			}
 			// Add to extra fields if there's no struct tag
 			if !ok {

--- a/tlcsv/writer_test.go
+++ b/tlcsv/writer_test.go
@@ -148,3 +148,32 @@ func TestWriterPathwayReversedSignpostedAs(t *testing.T) {
 	}
 	assert.True(t, found, "expected to read back a pathway")
 }
+
+// Feeds exported by earlier versions of this library carry the derived column
+// name; the csv alias keeps that signage text from being dropped on read.
+func TestReaderPathwayReverseSignpostedAsAlias(t *testing.T) {
+	tmpdir, err := os.MkdirTemp("", "gtfs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpdir)
+	legacy := "pathway_id,from_stop_id,to_stop_id,pathway_mode,is_bidirectional,signposted_as,reverse_signposted_as\n" +
+		"pathway1,stop1,stop2,1,1,To Platform 1,To Exit\n"
+	if err := os.WriteFile(filepath.Join(tmpdir, "pathways.txt"), []byte(legacy), 0644); err != nil {
+		t.Fatal(err)
+	}
+	reader, err := NewReader(tmpdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for ent := range reader.Pathways() {
+		assert.Equal(t, "To Platform 1", ent.SignpostedAs.Val)
+		assert.Equal(t, "To Exit", ent.ReverseSignpostedAs.Val)
+		// The alias resolves to the field, so it is not kept as an extra column.
+		_, extraOk := ent.GetExtra("reverse_signposted_as")
+		assert.False(t, extraOk, "expected the alias to load as a field, not an extra column")
+		found = true
+	}
+	assert.True(t, found, "expected to read back a pathway")
+}

--- a/tlcsv/writer_test.go
+++ b/tlcsv/writer_test.go
@@ -2,11 +2,14 @@ package tlcsv
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/interline-io/transitland-lib/adapters"
 	"github.com/interline-io/transitland-lib/gtfs"
 	"github.com/interline-io/transitland-lib/internal/testreader"
+	"github.com/interline-io/transitland-lib/tt"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -85,4 +88,63 @@ func TestWriterExtraColumn(t *testing.T) {
 	if !found {
 		t.Error("expected to get a stop with extra columns")
 	}
+}
+
+// The GTFS field is "reversed_signposted_as"; a previous refactor derived the column
+// name from the Go field name and silently wrote (and read) "reverse_signposted_as",
+// which spec-compliant consumers ignore. See gtfs/pathway.go.
+func TestWriterPathwayReversedSignpostedAs(t *testing.T) {
+	tmpdir, err := os.MkdirTemp("", "gtfs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpdir)
+	writer, err := NewWriter(tmpdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Open(); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Create(); err != nil {
+		t.Fatal(err)
+	}
+	testEnt := gtfs.Pathway{
+		PathwayID:           tt.NewString("pathway1"),
+		FromStopID:          tt.NewString("stop1"),
+		ToStopID:            tt.NewString("stop2"),
+		PathwayMode:         tt.NewInt(1),
+		IsBidirectional:     tt.NewInt(1),
+		SignpostedAs:        tt.NewString("To Platform 1"),
+		ReverseSignpostedAs: tt.NewString("To Exit"),
+	}
+	if _, err := writer.AddEntity(&testEnt); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Written header must use the spec field name.
+	data, err := os.ReadFile(filepath.Join(tmpdir, "pathways.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	header, _, _ := strings.Cut(string(data), "\n")
+	cols := strings.Split(strings.TrimSpace(header), ",")
+	assert.Contains(t, cols, "reversed_signposted_as")
+	assert.NotContains(t, cols, "reverse_signposted_as")
+
+	// And a feed using the spec field name must round trip.
+	reader, err := NewReader(tmpdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for ent := range reader.Pathways() {
+		assert.Equal(t, "To Platform 1", ent.SignpostedAs.Val)
+		assert.Equal(t, "To Exit", ent.ReverseSignpostedAs.Val)
+		found = true
+	}
+	assert.True(t, found, "expected to read back a pathway")
 }

--- a/tlcsv/writer_test.go
+++ b/tlcsv/writer_test.go
@@ -148,32 +148,3 @@ func TestWriterPathwayReversedSignpostedAs(t *testing.T) {
 	}
 	assert.True(t, found, "expected to read back a pathway")
 }
-
-// Feeds exported by earlier versions of this library carry the derived column
-// name; the csv alias keeps that signage text from being dropped on read.
-func TestReaderPathwayReverseSignpostedAsAlias(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "gtfs")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
-	legacy := "pathway_id,from_stop_id,to_stop_id,pathway_mode,is_bidirectional,signposted_as,reverse_signposted_as\n" +
-		"pathway1,stop1,stop2,1,1,To Platform 1,To Exit\n"
-	if err := os.WriteFile(filepath.Join(tmpdir, "pathways.txt"), []byte(legacy), 0644); err != nil {
-		t.Fatal(err)
-	}
-	reader, err := NewReader(tmpdir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	found := false
-	for ent := range reader.Pathways() {
-		assert.Equal(t, "To Platform 1", ent.SignpostedAs.Val)
-		assert.Equal(t, "To Exit", ent.ReverseSignpostedAs.Val)
-		// The alias resolves to the field, so it is not kept as an extra column.
-		_, extraOk := ent.GetExtra("reverse_signposted_as")
-		assert.False(t, extraOk, "expected the alias to load as a field, not an extra column")
-		found = true
-	}
-	assert.True(t, found, "expected to read back a pathway")
-}

--- a/tldb/mapper_test.go
+++ b/tldb/mapper_test.go
@@ -8,14 +8,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// The csv and db mappers share the same tag cache, and Pathway.ReverseSignpostedAs
-// carries a csv alias that is exactly the column name the db mapper derives. The
-// insert header must still name the database column, not the GTFS one.
-func TestMapperCacheHeaderIgnoresCsvAlias(t *testing.T) {
+// tlcsv and tldb keep separate tag caches that share one parser, and an alias is
+// read from the options of the mapper's own tag. A csv alias must therefore stay
+// out of the db field map: Pathway's alias is the column name the db mapper
+// derives for that same field, so leaking it here would displace the real entry
+// and drop the column from every insert.
+func TestMapperCacheIgnoresCsvAlias(t *testing.T) {
+	fmap := tldb.MapperCache.GetStructTagMap(&gtfs.Pathway{})
+	for name, fi := range fmap {
+		assert.False(t, fi.IsAlias(), "db field map should hold no aliases, got %q aliasing %q", name, fi.AliasOf)
+	}
 	header, err := tldb.MapperCache.GetHeader(&gtfs.Pathway{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Contains(t, header, "reverse_signposted_as")
-	assert.NotContains(t, header, "reversed_signposted_as")
+	assert.Contains(t, header, "reverse_signposted_as", "the db column name must still be written")
 }

--- a/tldb/mapper_test.go
+++ b/tldb/mapper_test.go
@@ -1,0 +1,21 @@
+package tldb_test
+
+import (
+	"testing"
+
+	"github.com/interline-io/transitland-lib/gtfs"
+	"github.com/interline-io/transitland-lib/tldb"
+	"github.com/stretchr/testify/assert"
+)
+
+// The csv and db mappers share the same tag cache, and Pathway.ReverseSignpostedAs
+// carries a csv alias that is exactly the column name the db mapper derives. The
+// insert header must still name the database column, not the GTFS one.
+func TestMapperCacheHeaderIgnoresCsvAlias(t *testing.T) {
+	header, err := tldb.MapperCache.GetHeader(&gtfs.Pathway{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Contains(t, header, "reverse_signposted_as")
+	assert.NotContains(t, header, "reversed_signposted_as")
+}

--- a/tt/reflect.go
+++ b/tt/reflect.go
@@ -67,6 +67,12 @@ func ReflectCheckErrors(ent any) []error {
 	entValue := reflect.ValueOf(ent).Elem()
 	fmap := mapperCache.GetStructTagMap(ent)
 	for fieldName, fieldInfo := range fmap {
+		// An alias is another name for a field that is checked under its own
+		// name; checking it again would report the same value twice, once under
+		// a name the file may not even contain.
+		if fieldInfo.IsAlias() {
+			continue
+		}
 		// Get field
 		field := reflectx.FieldByIndexes(entValue, fieldInfo.Index)
 		fieldAddr := field.Addr().Interface()

--- a/tt/reflect_test.go
+++ b/tt/reflect_test.go
@@ -162,3 +162,33 @@ func firstError(v []error) error {
 	}
 	return nil
 }
+
+// An alias is an additional name for a field on the load path. It must not make
+// the field look like a second field here: the value is checked once, and a
+// reference is remapped once, under the name the field is written as.
+func TestReflect_AliasIsNotASecondField(t *testing.T) {
+	t.Run("value is checked once", func(t *testing.T) {
+		ent := struct {
+			Value Timezone `csv:"tz,alias=legacy_tz"`
+		}{Value: NewTimezone("Not/AZone")}
+		errs := ReflectCheckErrors(&ent)
+		assert.Len(t, errs, 1, "expected one error, got %v", errs)
+	})
+	t.Run("tag-based check runs once", func(t *testing.T) {
+		ent := struct {
+			Value Int `csv:"mode,alias=legacy_mode" enum:"1,2,3"`
+		}{Value: NewInt(9)}
+		errs := ReflectCheckErrors(&ent)
+		assert.Len(t, errs, 1, "expected one error, got %v", errs)
+	})
+	t.Run("reference is remapped once", func(t *testing.T) {
+		ent := struct {
+			Ref String `csv:"ref,alias=old_ref" target:"stops.txt"`
+		}{Ref: NewString("src1")}
+		emap := NewEntityMap()
+		emap.Set("stops.txt", "src1", "db1")
+		errs := ReflectUpdateKeys(emap, &ent)
+		assert.Empty(t, errs, "expected no errors, got %v", errs)
+		assert.Equal(t, "db1", ent.Ref.Val)
+	})
+}


### PR DESCRIPTION
closes https://github.com/interline-io/tlv2/issues/515

## Summary

The GTFS field is `reversed_signposted_as` ([spec](https://gtfs.org/documentation/schedule/reference/#pathwaystxt)). `Pathway.ReverseSignpostedAs` carried an explicit `csv:"reversed_signposted_as"` tag from the initial commit until #376 removed the explicit csv tags in favor of deriving column names from Go field names. The derived name is `reverse_signposted_as`, so since then:

- exported `pathways.txt` writes signage text under a column name that spec-compliant consumers ignore, and
- a source feed that spells the field correctly has the value silently dropped on read — no error, and no warning from `transitland validate`.

Restores the explicit tag, and adds an alias so feeds we already exported still load.

Checked the other entities: across all GTFS structs at `68ce5f4a^`, only two fields had an explicit csv name that differed from its derived form — this one, and `Translation.TableNameValue`, which kept its tag. No other spec field is affected.

## The alias

Without it this change would trade one silent data loss for another: every feed exported by v1.0.0 through v1.3.4 uses `reverse_signposted_as`, and after the rename that column would no longer match a field.

`csv:"reversed_signposted_as,alias=reverse_signposted_as"` registers a second lookup key for the field, so both spellings load and output is always the spec name. The alias is read from the options of the mapper's own tag, so an alias declared for csv is invisible to the db mapper by construction — which matters here, because this alias is exactly the column name the db mapper derives for the same field.

An alias entry is deliberately minimal — name, target field, kind. It carries none of the field's validation tags, so a value is still checked once, under the name the file actually uses. `GetHeader` skips aliases, so the field is written exactly once under its canonical name, and `ReflectCheckErrors` skips them, because type-level `Check()` runs whether or not a field has constraint tags.

A file carrying both spellings (a feed written midway through the rename) resolves deterministically: the field's own column wins regardless of column order, and the alias column is kept as an extra rather than overwriting it.

## Still unchanged

The database column (`gtfs_pathways.reverse_signposted_as`, misspelled separately in #30) and the GraphQL field of the same name. Renaming those is a breaking API change and a separate decision.

Note also that this fixes exports going forward but does not backfill: feed versions imported before this change dropped the value at import and still hold NULL, so recovering that data needs a re-import.

Aliases are honored on the reflect load path only. `StopTime` and `Shape` implement `SetString` and load through their own switch statements, so an alias on those entities would have no effect; that limitation is noted on the struct.

## Test plan

New tests, each verified to fail without the code it covers:

- `TestWriterPathwayReversedSignpostedAs` (tlcsv) — written header uses the spec name; pathway round trips.
- `TestReader_PathwayReverseSignpostedAsAlias` (tlcsv) — a feed with the old column loads the value into the field rather than dropping it into extras.
- `TestReader_PathwayBothSignpostedSpellings` (tlcsv) — both spellings present, in either column order: the spec column wins, the alias column survives as an extra.
- `TestReflect_AliasIsNotASecondField` (tt) — an aliased value is checked once and a reference remapped once. Without the skip the same invalid value is reported twice, the second time under a name the file may not contain.
- `TestCache_GetStructTagMap_Alias` / `TestCache_GetHeader_Alias` (internal/tags) — an alias resolves to its field, carries none of its validation tags, is excluded from the header, and never displaces a field that owns the name.
- `TestMapperCacheIgnoresCsvAlias` (tldb) — the db field map holds no aliases and still writes the database column.

End to end, a feed written by the current release now reads back and upgrades on copy:

```
in:  …,reverse_signposted_as,signposted_as,…      →  "To Exit" / "To Platform 1"
out: …,signposted_as,reversed_signposted_as       →  "To Platform 1" / "To Exit"
```

`go test ./...` is otherwise unchanged (the failures in `server/finders/dbfinder` and `server/finders/actions/test` are pre-existing local database-connection failures, identical on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VWs4fzXGCktmBqjzE43Fw
