### PR TITLE
Separate feed download license check from handler body

### DIFF
--- a/server/rest/feed_version_download.go
+++ b/server/rest/feed_version_download.go
@@ -59,10 +59,19 @@ func feedDownloadRtHelper(graphqlHandler http.Handler, w http.ResponseWriter, r 
 	}
 
 	// This endpoint serves realtime messages rather than a feed version file, so
-	// only the license answer is used; an RT-only feed has no feed versions.
+	// the feed version is not required; an RT-only feed has no feed versions.
+	//
+	// The feed itself is required. The RT message store is a cache keyed by feed,
+	// with no permission check of its own, so this lookup is the only thing that
+	// establishes the caller may see this feed at all — and a feed they cannot see
+	// resolves with an empty license, which reads as redistributable.
 	d, err := LookupLatestFeedVersionDownload(ctx, graphqlHandler, key)
 	if err != nil {
 		util.WriteJsonError(w, "server error", http.StatusInternalServerError)
+		return
+	}
+	if d.FeedOnestopID == "" {
+		util.WriteJsonError(w, "not found", http.StatusNotFound)
 		return
 	}
 	found := false
@@ -177,9 +186,13 @@ func recordDownload(ctx context.Context, dims meters.Dimensions) {
 // FeedVersionDownload identifies one feed version file and says whether its
 // feed's license permits redistributing it.
 //
-// An empty FeedVersionSHA1 means the key matched no feed version. Redistribution
-// is reported rather than enforced: the status code for a feed that forbids it
-// is the caller's to choose.
+// A caller must have both parts before serving: an empty FeedVersionSHA1 means
+// the key matched no feed version, and an empty FeedOnestopID means its feed was
+// not visible. Those are filtered separately, so a feed version granted
+// explicitly can resolve while its feed does not.
+//
+// Redistribution is reported rather than enforced: the status code for a feed
+// that forbids it is the caller's to choose.
 type FeedVersionDownload struct {
 	FeedOnestopID         string
 	FeedVersionSHA1       string
@@ -270,7 +283,7 @@ func feedVersionDownloadLatestHandler(graphqlHandler http.Handler, w http.Respon
 		util.WriteJsonError(w, "server error", http.StatusInternalServerError)
 		return
 	}
-	if d.FeedVersionSHA1 == "" {
+	if d.FeedVersionSHA1 == "" || d.FeedOnestopID == "" {
 		util.WriteJsonError(w, "not found", http.StatusNotFound)
 		return
 	}
@@ -299,7 +312,7 @@ func feedVersionDownloadHandler(graphqlHandler http.Handler, w http.ResponseWrit
 		util.WriteJsonError(w, "server error", http.StatusInternalServerError)
 		return
 	}
-	if d.FeedVersionSHA1 == "" {
+	if d.FeedVersionSHA1 == "" || d.FeedOnestopID == "" {
 		util.WriteJsonError(w, "not found", http.StatusNotFound)
 		return
 	}

--- a/server/rest/feed_version_download.go
+++ b/server/rest/feed_version_download.go
@@ -79,7 +79,7 @@ func feedDownloadRtHelper(graphqlHandler http.Handler, w http.ResponseWriter, r 
 
 	// Check if we have data
 	rtf := model.ForContext(ctx).RTFinder
-	rtMsg, ok := rtf.GetMessage(ctx, key, rtType)
+	rtMsg, ok := rtf.GetMessage(ctx, d.FeedOnestopID, rtType)
 	if ok && rtMsg != nil {
 		found = true
 	}
@@ -186,13 +186,9 @@ func recordDownload(ctx context.Context, dims meters.Dimensions) {
 // FeedVersionDownload identifies one feed version file and says whether its
 // feed's license permits redistributing it.
 //
-// A caller must have both parts before serving: an empty FeedVersionSHA1 means
-// the key matched no feed version, and an empty FeedOnestopID means its feed was
-// not visible. Those are filtered separately, so a feed version granted
-// explicitly can resolve while its feed does not.
-//
-// Redistribution is reported rather than enforced: the status code for a feed
-// that forbids it is the caller's to choose.
+// Zero values mean the lookup matched nothing: either the key names no feed
+// version, or the caller may not see it. Redistribution is reported, not
+// enforced.
 type FeedVersionDownload struct {
 	FeedOnestopID         string
 	FeedVersionSHA1       string
@@ -243,9 +239,12 @@ func LookupLatestFeedVersionDownload(ctx context.Context, graphqlHandler http.Ha
 
 // ServeFeedVersion writes the feed version file, redirecting to a signed URL
 // when the store supports one.
-func ServeFeedVersion(w http.ResponseWriter, r *http.Request, storage string, d FeedVersionDownload) error {
+//
+// It writes an error response itself before returning a non-nil error, so a
+// caller should log the error rather than answer again.
+func ServeFeedVersion(ctx context.Context, w http.ResponseWriter, storage string, d FeedVersionDownload) error {
 	downloadKey := fmt.Sprintf("%s-%s.zip", d.FeedOnestopID, d.FeedVersionSHA1)
-	return serveFromStorage(w, r, storage, d.FeedVersionSHA1, downloadKey)
+	return serveFromStorage(ctx, w, storage, d.FeedVersionSHA1, downloadKey)
 }
 
 // downloadVars builds the query variables for a key that is either an integer
@@ -297,7 +296,7 @@ func feedVersionDownloadLatestHandler(graphqlHandler http.Handler, w http.Respon
 		util.WriteJsonError(w, "too many requests", http.StatusTooManyRequests)
 		return
 	}
-	if err := ServeFeedVersion(w, r, model.ForContext(ctx).Storage, d); err != nil {
+	if err := ServeFeedVersion(ctx, w, model.ForContext(ctx).Storage, d); err != nil {
 		// Do not meter
 		log.For(ctx).Error().Err(err).Msg("feed version download failed")
 		return
@@ -326,7 +325,7 @@ func feedVersionDownloadHandler(graphqlHandler http.Handler, w http.ResponseWrit
 		util.WriteJsonError(w, "too many requests", http.StatusTooManyRequests)
 		return
 	}
-	if err := ServeFeedVersion(w, r, model.ForContext(ctx).Storage, d); err != nil {
+	if err := ServeFeedVersion(ctx, w, model.ForContext(ctx).Storage, d); err != nil {
 		// Do not meter
 		log.For(ctx).Error().Err(err).Msg("feed version download failed")
 		return
@@ -334,8 +333,7 @@ func feedVersionDownloadHandler(graphqlHandler http.Handler, w http.ResponseWrit
 	recordDownload(ctx, dims)
 }
 
-func serveFromStorage(w http.ResponseWriter, r *http.Request, storage string, fvsha1 string, downloadKey string) error {
-	ctx := r.Context()
+func serveFromStorage(ctx context.Context, w http.ResponseWriter, storage string, fvsha1 string, downloadKey string) error {
 	store, err := request.GetStore(storage)
 	if err != nil {
 		util.WriteJsonError(w, "failed access file", http.StatusInternalServerError)
@@ -356,6 +354,7 @@ func serveFromStorage(w http.ResponseWriter, r *http.Request, storage string, fv
 			util.WriteJsonError(w, "failed access file", http.StatusInternalServerError)
 			return fmt.Errorf("failed to access file; not authorized: %w", err)
 		}
+		defer rdr.Close()
 		if _, err := io.Copy(w, rdr); err != nil {
 			util.WriteJsonError(w, "failed access file", http.StatusInternalServerError)
 			return fmt.Errorf("failed to access file; failed to copy to client: %w", err)

--- a/server/rest/feed_version_download.go
+++ b/server/rest/feed_version_download.go
@@ -34,38 +34,39 @@ query($feed_onestop_id: String, $ids: [Int!]) {
   }
 `
 
+const feedVersionFileQuery = `
+query($feed_version_sha1: String, $ids: [Int!]) {
+	feed_versions(limit:1, ids: $ids, where:{sha1:$feed_version_sha1}) {
+	  sha1
+	  feed {
+		onestop_id
+		license {
+			redistribution_allowed
+		}
+	  }
+	}
+  }
+`
+
 func feedDownloadRtHelper(graphqlHandler http.Handler, w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	key := chi.URLParam(r, "feed_key")
 	rtType := fmt.Sprintf("realtime_%s", chi.URLParam(r, "rt_type"))
 	format := chi.URLParam(r, "format")
-	gvars := hw{}
 	if key == "" {
 		util.WriteJsonError(w, "not found", http.StatusNotFound)
 		return
-	} else if v, err := strconv.Atoi(key); err == nil {
-		gvars["ids"] = []int{v}
-	} else {
-		gvars["feed_onestop_id"] = key
 	}
 
-	// Check if we're allowed to redistribute feed and look up latest feed version
-	feedResponse, err := makeGraphQLRequest(ctx, graphqlHandler, latestFeedVersionQuery, gvars)
+	// This endpoint serves realtime messages rather than a feed version file, so
+	// only the license answer is used; an RT-only feed has no feed versions.
+	d, err := LookupLatestFeedVersionDownload(ctx, graphqlHandler, key)
 	if err != nil {
 		util.WriteJsonError(w, "server error", http.StatusInternalServerError)
 		return
 	}
-
 	found := false
-	allowed := false
-	jj, err := json.Marshal(feedResponse)
-	if err != nil {
-		util.WriteJsonError(w, "server error", http.StatusInternalServerError)
-		return
-	}
-	if gjson.Get(string(jj), "feeds.0.license.redistribution_allowed").String() != "no" {
-		allowed = true
-	}
+	allowed := d.RedistributionAllowed
 
 	// Check if we have data
 	rtf := model.ForContext(ctx).RTFinder
@@ -131,11 +132,11 @@ const feedVersionDownloadMeter = "feed-version-downloads"
 // The same dimensions gate the quota and record the usage. A limit applies
 // only when its own dimensions are a subset of these, so checking with fewer
 // dimensions than are recorded would silently skip dimension-scoped limits.
-func downloadDimensions(fid string, fvsha1 string, isLatest bool) meters.Dimensions {
+func downloadDimensions(d FeedVersionDownload) meters.Dimensions {
 	return meters.Dimensions{
-		{Key: "fv_sha1", Value: fvsha1},
-		{Key: "feed_onestop_id", Value: fid},
-		{Key: "is_latest_feed_version", Value: strconv.FormatBool(isLatest)},
+		{Key: "fv_sha1", Value: d.FeedVersionSHA1},
+		{Key: "feed_onestop_id", Value: d.FeedOnestopID},
+		{Key: "is_latest_feed_version", Value: strconv.FormatBool(d.IsLatestFeedVersion)},
 	}
 }
 
@@ -173,60 +174,117 @@ func recordDownload(ctx context.Context, dims meters.Dimensions) {
 	}
 }
 
+// FeedVersionDownload identifies one feed version file and says whether its
+// feed's license permits redistributing it.
+//
+// An empty FeedVersionSHA1 means the key matched no feed version. Redistribution
+// is reported rather than enforced: the status code for a feed that forbids it
+// is the caller's to choose.
+type FeedVersionDownload struct {
+	FeedOnestopID         string
+	FeedVersionSHA1       string
+	RedistributionAllowed bool
+	// IsLatestFeedVersion records that this was resolved as a feed's current
+	// version rather than requested by key. Download quotas are scoped on it.
+	IsLatestFeedVersion bool
+}
+
+// LookupFeedVersionDownload resolves an integer id or a sha1 to the feed version
+// file it names.
+func LookupFeedVersionDownload(ctx context.Context, graphqlHandler http.Handler, key string) (FeedVersionDownload, error) {
+	var d FeedVersionDownload
+	vars, ok := downloadVars(key, "feed_version_sha1")
+	if !ok {
+		return d, nil
+	}
+	body, err := downloadLookup(ctx, graphqlHandler, feedVersionFileQuery, vars)
+	if err != nil {
+		return d, err
+	}
+	d.FeedVersionSHA1 = gjson.Get(body, "feed_versions.0.sha1").String()
+	d.FeedOnestopID = gjson.Get(body, "feed_versions.0.feed.onestop_id").String()
+	d.RedistributionAllowed = gjson.Get(body, "feed_versions.0.feed.license.redistribution_allowed").String() != "no"
+	return d, nil
+}
+
+// LookupLatestFeedVersionDownload resolves an integer id or a feed Onestop ID to
+// that feed's current version.
+//
+// A feed with no versions is not an error: RT-only feeds have none, and the
+// redistribution answer is still meaningful for them.
+func LookupLatestFeedVersionDownload(ctx context.Context, graphqlHandler http.Handler, feedKey string) (FeedVersionDownload, error) {
+	d := FeedVersionDownload{IsLatestFeedVersion: true}
+	vars, ok := downloadVars(feedKey, "feed_onestop_id")
+	if !ok {
+		return d, nil
+	}
+	body, err := downloadLookup(ctx, graphqlHandler, latestFeedVersionQuery, vars)
+	if err != nil {
+		return d, err
+	}
+	d.FeedVersionSHA1 = gjson.Get(body, "feeds.0.feed_versions.0.sha1").String()
+	d.FeedOnestopID = gjson.Get(body, "feeds.0.onestop_id").String()
+	d.RedistributionAllowed = gjson.Get(body, "feeds.0.license.redistribution_allowed").String() != "no"
+	return d, nil
+}
+
+// ServeFeedVersion writes the feed version file, redirecting to a signed URL
+// when the store supports one.
+func ServeFeedVersion(w http.ResponseWriter, r *http.Request, storage string, d FeedVersionDownload) error {
+	downloadKey := fmt.Sprintf("%s-%s.zip", d.FeedOnestopID, d.FeedVersionSHA1)
+	return serveFromStorage(w, r, storage, d.FeedVersionSHA1, downloadKey)
+}
+
+// downloadVars builds the query variables for a key that is either an integer
+// id or the string identifier named by nameVar. An empty key matches nothing.
+func downloadVars(key string, nameVar string) (hw, bool) {
+	if key == "" {
+		return nil, false
+	}
+	if v, err := strconv.Atoi(key); err == nil {
+		return hw{"ids": []int{v}}, true
+	}
+	return hw{nameVar: key}, true
+}
+
+// downloadLookup runs one lookup query and returns the response as JSON for
+// gjson to read.
+func downloadLookup(ctx context.Context, graphqlHandler http.Handler, query string, vars hw) (string, error) {
+	response, err := makeGraphQLRequest(ctx, graphqlHandler, query, vars)
+	if err != nil {
+		return "", err
+	}
+	body, err := json.Marshal(response)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
 // Query redirects user to download the given fv from S3 public URL
 // assuming that redistribution is allowed for the feed.
 func feedVersionDownloadLatestHandler(graphqlHandler http.Handler, w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	key := chi.URLParam(r, "feed_key")
-	gvars := hw{}
-	if key == "" {
-		util.WriteJsonError(w, "not found", http.StatusNotFound)
-		return
-	} else if v, err := strconv.Atoi(key); err == nil {
-		gvars["ids"] = []int{v}
-	} else {
-		gvars["feed_onestop_id"] = key
-	}
-
-	// Check if we're allowed to redistribute feed and look up latest feed version
-	feedResponse, err := makeGraphQLRequest(ctx, graphqlHandler, latestFeedVersionQuery, gvars)
+	d, err := LookupLatestFeedVersionDownload(ctx, graphqlHandler, chi.URLParam(r, "feed_key"))
 	if err != nil {
 		util.WriteJsonError(w, "server error", http.StatusInternalServerError)
 		return
 	}
-	found := false
-	allowed := false
-	json, err := json.Marshal(feedResponse)
-	if err != nil {
-		util.WriteJsonError(w, "server error", http.StatusInternalServerError)
-		return
-	}
-	if gjson.Get(string(json), "feeds.0.feed_versions.0.sha1").Exists() {
-		found = true
-	}
-	if gjson.Get(string(json), "feeds.0.license.redistribution_allowed").String() != "no" {
-		allowed = true
-	}
-	fid := gjson.Get(string(json), "feeds.0.onestop_id").String()
-	fvsha1 := gjson.Get(string(json), "feeds.0.feed_versions.0.sha1").String()
-	if !found {
+	if d.FeedVersionSHA1 == "" {
 		util.WriteJsonError(w, "not found", http.StatusNotFound)
 		return
 	}
-	if !allowed {
+	if !d.RedistributionAllowed {
 		util.WriteJsonError(w, "not authorized", http.StatusUnauthorized)
 		return
 	}
 
-	dims := downloadDimensions(fid, fvsha1, true)
+	dims := downloadDimensions(d)
 	if !checkDownloadQuota(ctx, dims) {
 		util.WriteJsonError(w, "too many requests", http.StatusTooManyRequests)
 		return
 	}
-
-	downloadKey := fmt.Sprintf("%s-%s.zip", fid, fvsha1)
-	cfg := model.ForContext(ctx)
-	if err := serveFromStorage(w, r, cfg.Storage, fvsha1, downloadKey); err != nil {
+	if err := ServeFeedVersion(w, r, model.ForContext(ctx).Storage, d); err != nil {
 		// Do not meter
 		log.For(ctx).Error().Err(err).Msg("feed version download failed")
 		return
@@ -234,79 +292,28 @@ func feedVersionDownloadLatestHandler(graphqlHandler http.Handler, w http.Respon
 	recordDownload(ctx, dims)
 }
 
-const feedVersionFileQuery = `
-query($feed_version_sha1: String, $ids: [Int!]) {
-	feed_versions(limit:1, ids: $ids, where:{sha1:$feed_version_sha1}) {
-	  sha1
-	  feed {
-		onestop_id
-		license {
-			redistribution_allowed
-		}
-	  }
-	}
-  }
-`
-
-// Query redirects user to download the given fv from S3 public URL
-// assuming that redistribution is allowed for the feed.
 func feedVersionDownloadHandler(graphqlHandler http.Handler, w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	gvars := hw{}
-	key := chi.URLParam(r, "feed_version_key")
-	if key == "" {
-		util.WriteJsonError(w, "not found", http.StatusNotFound)
-		return
-	} else if v, err := strconv.Atoi(key); err == nil {
-		gvars["ids"] = []int{v}
-	} else {
-		gvars["feed_version_sha1"] = key
-	}
-	// Check if we're allowed to redistribute feed
-	checkfv, err := makeGraphQLRequest(ctx, graphqlHandler, feedVersionFileQuery, gvars)
+	d, err := LookupFeedVersionDownload(ctx, graphqlHandler, chi.URLParam(r, "feed_version_key"))
 	if err != nil {
 		util.WriteJsonError(w, "server error", http.StatusInternalServerError)
 		return
 	}
-	// todo: use gjson
-	found := false
-	allowed := false
-	fid := ""
-	fvsha1 := ""
-	if v, ok := checkfv["feed_versions"].([]interface{}); len(v) > 0 && ok {
-		if v2, ok := v[0].(hw); ok {
-			fvsha1 = v2["sha1"].(string)
-			if fvsha1 != "" {
-				found = true
-			}
-			if v3, ok := v2["feed"].(hw); ok {
-				fid = v3["onestop_id"].(string)
-				if v4, ok := v3["license"].(hw); ok {
-					if v4["redistribution_allowed"] != "no" {
-						allowed = true
-					}
-				}
-			}
-		}
-	}
-	if !found {
+	if d.FeedVersionSHA1 == "" {
 		util.WriteJsonError(w, "not found", http.StatusNotFound)
 		return
 	}
-	if !allowed {
+	if !d.RedistributionAllowed {
 		util.WriteJsonError(w, "not authorized", http.StatusUnauthorized)
 		return
 	}
 
-	dims := downloadDimensions(fid, fvsha1, false)
+	dims := downloadDimensions(d)
 	if !checkDownloadQuota(ctx, dims) {
 		util.WriteJsonError(w, "too many requests", http.StatusTooManyRequests)
 		return
 	}
-
-	downloadKey := fmt.Sprintf("%s-%s.zip", fid, fvsha1)
-	cfg := model.ForContext(ctx)
-	if err := serveFromStorage(w, r, cfg.Storage, fvsha1, downloadKey); err != nil {
+	if err := ServeFeedVersion(w, r, model.ForContext(ctx).Storage, d); err != nil {
 		// Do not meter
 		log.For(ctx).Error().Err(err).Msg("feed version download failed")
 		return

--- a/server/rest/feed_version_download_perm_test.go
+++ b/server/rest/feed_version_download_perm_test.go
@@ -1,0 +1,93 @@
+package rest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/interline-io/transitland-lib/internal/testconfig"
+	"github.com/interline-io/transitland-lib/server/auth/authn"
+	"github.com/interline-io/transitland-lib/server/auth/authz"
+	"github.com/interline-io/transitland-lib/server/auth/mw/usercheck"
+	"github.com/interline-io/transitland-lib/server/gql"
+	"github.com/interline-io/transitland-lib/server/model"
+	"github.com/interline-io/transitland-lib/server/testutil"
+	"github.com/interline-io/transitland-lib/testdata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// EG is the only feed with feed_states.public = false in the test fixtures, and
+// this is its one feed version.
+const (
+	privateFeedOnestopID = "EG"
+	privateFeedVersion   = "793c9c759eb54007e57ce2dbb2c927700c5c34d4"
+)
+
+// These endpoints are the only GTFS export open to ordinary users, and the
+// permission filter is the only thing between a caller and a feed they were
+// never granted. Nothing else in this package exercises a non-public feed: the
+// other download tests all use public fixtures, which pass under the default
+// deny-all checker because public wins regardless of grants.
+func TestFeedVersionDownloadPermissions(t *testing.T) {
+	// granted-user reaches EG through a group; nobody-user holds no tuples.
+	tuples := []authz.TupleKey{
+		{Subject: authz.NewEntityKey(authz.TenantType, "tl-tenant"), Object: authz.NewEntityKey(authz.GroupType, "EG-group"), Relation: authz.ParentRelation},
+		{Subject: authz.NewEntityKey(authz.GroupType, "EG-group"), Object: authz.NewEntityKey(authz.FeedType, privateFeedOnestopID), Relation: authz.ParentRelation},
+		{Subject: authz.NewEntityKey(authz.UserType, "granted-user"), Object: authz.NewEntityKey(authz.TenantType, "tl-tenant"), Relation: authz.MemberRelation},
+		{Subject: authz.NewEntityKey(authz.UserType, "granted-user"), Object: authz.NewEntityKey(authz.GroupType, "EG-group"), Relation: authz.ViewerRelation},
+	}
+	cfg := testconfig.Config(t, testconfig.Options{
+		FGAEndpoint:    testutil.FGAServer(t),
+		FGAModelFile:   testdata.Path("server/authz/tls.json"),
+		FGAModelTuples: tuples,
+		Storage:        testdata.Path("server", "tmp"),
+		// The private feed needs realtime data for the realtime case to mean
+		// anything: the RT store is an unfiltered cache, so without a message
+		// present that endpoint answers "not found" whatever the permissions say.
+		RTJsons: []testconfig.RTJsonFile{
+			{Feed: privateFeedOnestopID, Ftype: "realtime_alerts", Fname: "BA-alerts.json"},
+		},
+	})
+
+	graphqlHandler := gql.NewDefaultHandler()
+	restHandler, err := NewServer(graphqlHandler)
+	require.NoError(t, err)
+
+	get := func(user, path string) *httptest.ResponseRecorder {
+		h := model.AddConfigAndPerms(cfg, restHandler)
+		h = usercheck.NewUserDefaultMiddleware(func() authn.User {
+			return authn.NewCtxUser(user, user, user+"@example.com")
+		})(h)
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, path, nil))
+		return rr
+	}
+
+	fvPath := "/feed_versions/" + privateFeedVersion + "/download"
+	latestPath := "/feeds/" + privateFeedOnestopID + "/download_latest_feed_version"
+	rtPath := "/feeds/" + privateFeedOnestopID + "/download_latest_rt/alerts.json"
+
+	// The negative cases are the point. The granted-user cases are the control:
+	// without them a 404 could just mean the fixture is missing.
+	t.Run("no grants cannot download by feed version", func(t *testing.T) {
+		assert.Equal(t, http.StatusNotFound, get("nobody-user", fvPath).Result().StatusCode)
+	})
+	t.Run("no grants cannot download latest", func(t *testing.T) {
+		assert.Equal(t, http.StatusNotFound, get("nobody-user", latestPath).Result().StatusCode)
+	})
+	t.Run("no grants cannot read realtime", func(t *testing.T) {
+		assert.Equal(t, http.StatusNotFound, get("nobody-user", rtPath).Result().StatusCode)
+	})
+
+	t.Run("granted user resolves the private feed version", func(t *testing.T) {
+		// Storage may not hold EG's file, so this asserts only that the request
+		// got past the permission filter — anything but 404 proves that.
+		assert.NotEqual(t, http.StatusNotFound, get("granted-user", fvPath).Result().StatusCode,
+			"a granted user must not be told the private feed version does not exist")
+	})
+	t.Run("granted user resolves the private feed", func(t *testing.T) {
+		assert.NotEqual(t, http.StatusNotFound, get("granted-user", latestPath).Result().StatusCode,
+			"a granted user must not be told the private feed does not exist")
+	})
+}

--- a/server/rest/feed_version_download_perm_test.go
+++ b/server/rest/feed_version_download_perm_test.go
@@ -9,12 +9,9 @@ import (
 	"github.com/interline-io/transitland-lib/server/auth/authn"
 	"github.com/interline-io/transitland-lib/server/auth/authz"
 	"github.com/interline-io/transitland-lib/server/auth/mw/usercheck"
-	"github.com/interline-io/transitland-lib/server/gql"
-	"github.com/interline-io/transitland-lib/server/model"
 	"github.com/interline-io/transitland-lib/server/testutil"
 	"github.com/interline-io/transitland-lib/testdata"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // EG is the only feed with feed_states.public = false in the test fixtures, and
@@ -37,7 +34,7 @@ func TestFeedVersionDownloadPermissions(t *testing.T) {
 		{Subject: authz.NewEntityKey(authz.UserType, "granted-user"), Object: authz.NewEntityKey(authz.TenantType, "tl-tenant"), Relation: authz.MemberRelation},
 		{Subject: authz.NewEntityKey(authz.UserType, "granted-user"), Object: authz.NewEntityKey(authz.GroupType, "EG-group"), Relation: authz.ViewerRelation},
 	}
-	cfg := testconfig.Config(t, testconfig.Options{
+	_, restSrv, _ := testHandlersWithOptions(t, testconfig.Options{
 		FGAEndpoint:    testutil.FGAServer(t),
 		FGAModelFile:   testdata.Path("server/authz/tls.json"),
 		FGAModelTuples: tuples,
@@ -50,15 +47,10 @@ func TestFeedVersionDownloadPermissions(t *testing.T) {
 		},
 	})
 
-	graphqlHandler := gql.NewDefaultHandler()
-	restHandler, err := NewServer(graphqlHandler)
-	require.NoError(t, err)
-
 	get := func(user, path string) *httptest.ResponseRecorder {
-		h := model.AddConfigAndPerms(cfg, restHandler)
-		h = usercheck.NewUserDefaultMiddleware(func() authn.User {
+		h := usercheck.NewUserDefaultMiddleware(func() authn.User {
 			return authn.NewCtxUser(user, user, user+"@example.com")
-		})(h)
+		})(restSrv)
 		rr := httptest.NewRecorder()
 		h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, path, nil))
 		return rr
@@ -80,14 +72,15 @@ func TestFeedVersionDownloadPermissions(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, get("nobody-user", rtPath).Result().StatusCode)
 	})
 
-	t.Run("granted user resolves the private feed version", func(t *testing.T) {
-		// Storage may not hold EG's file, so this asserts only that the request
-		// got past the permission filter — anything but 404 proves that.
-		assert.NotEqual(t, http.StatusNotFound, get("granted-user", fvPath).Result().StatusCode,
-			"a granted user must not be told the private feed version does not exist")
+	t.Run("granted user downloads the private feed version", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, get("granted-user", fvPath).Result().StatusCode)
 	})
-	t.Run("granted user resolves the private feed", func(t *testing.T) {
-		assert.NotEqual(t, http.StatusNotFound, get("granted-user", latestPath).Result().StatusCode,
-			"a granted user must not be told the private feed does not exist")
+	t.Run("granted user downloads the private feed", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, get("granted-user", latestPath).Result().StatusCode)
+	})
+	t.Run("granted user reads the private feed realtime", func(t *testing.T) {
+		// Without this the denial above would pass even if the fixture stopped
+		// loading, since a missing message is a 404 whatever the permissions say.
+		assert.Equal(t, http.StatusOK, get("granted-user", rtPath).Result().StatusCode)
 	})
 }

--- a/server/rest/feed_version_download_test.go
+++ b/server/rest/feed_version_download_test.go
@@ -274,7 +274,7 @@ func TestFeedVersionDownloadQuota(t *testing.T) {
 }
 
 func TestFeedDownloadRtLatestRequest(t *testing.T) {
-	_, restSrv, _ := testHandlersWithOptions(t, testconfig.Options{
+	gqlSrv, restSrv, _ := testHandlersWithOptions(t, testconfig.Options{
 		Storage: testdata.Path("server", "tmp"),
 		RTJsons: []testconfig.RTJsonFile{
 			{Feed: "BA~rt", Ftype: "realtime_alerts", Fname: "BA-alerts.json"},
@@ -295,6 +295,17 @@ func TestFeedDownloadRtLatestRequest(t *testing.T) {
 		rr := httptest.NewRecorder()
 		asAnon := restSrv
 		asAnon.ServeHTTP(rr, req)
+		assert.Equal(t, 200, rr.Result().StatusCode, "status code")
+	})
+	// The realtime store is keyed by Onestop ID, so an integer feed key only
+	// finds a message once it has been resolved through the lookup.
+	t.Run("ok by integer id", func(t *testing.T) {
+		feedID := resolveID(t, gqlSrv,
+			`{"query":"{feeds(where:{onestop_id:\"BA~rt\"}){id}}"}`,
+			"data.feeds.0.id")
+		req, _ := http.NewRequest("GET", "/feeds/"+feedID+"/download_latest_rt/alerts.json", nil)
+		rr := httptest.NewRecorder()
+		restSrv.ServeHTTP(rr, req)
 		assert.Equal(t, 200, rr.Result().StatusCode, "status code")
 	})
 	t.Run("alerts ok json", func(t *testing.T) {

--- a/server/rest/rest.go
+++ b/server/rest/rest.go
@@ -653,3 +653,10 @@ func toPtr[T any, P *T](v T) P {
 	vcopy := v
 	return &vcopy
 }
+
+// WriteJsonError writes an error response in the shape every endpoint in this
+// package uses. Exported so a caller composing its own handlers over the
+// exported request helpers answers failures the same way.
+func WriteJsonError(w http.ResponseWriter, msg string, statusCode int) {
+	util.WriteJsonError(w, msg, statusCode)
+}


### PR DESCRIPTION
## Summary

The feed version download handlers each did their own GraphQL lookup, their own JSON drilling, and their own license check inline. This pulls the lookup and the serve out as exported functions, so the three handlers reduce to the decisions they actually make, and a deployment can build its own download handler over the same pieces — which is what the metering work needs next, since the quota check has to sit between the license decision and the serve.

Also adds a visibility check the handlers were missing, and the first test of this endpoint family under a restrictive permission filter.

### Reading the lookup

`feedVersionDownloadHandler` drilled through `map[string]any` with unchecked type assertions, under a `todo: use gjson` older than the other two handlers, which already used gjson. It now reads the same way they do.

Behavior is unchanged on real data. The old ladder treated a missing `license` object as forbidden while gjson treats it as permitted, but `feedResolver.License` always returns a non-nil license over a value type and `feed` is non-null in the schema, so neither case occurs. What does change: the old code panicked when `sha1` or `onestop_id` was absent from the response, and now returns 404.

### The lookup and serve seam

`LookupFeedVersionDownload` resolves an integer id or a sha1; `LookupLatestFeedVersionDownload` resolves an integer id or a feed Onestop ID to that feed's current version. Both return a `FeedVersionDownload` carrying the feed Onestop ID, the sha1, whether redistribution is permitted, and whether it was resolved as a latest version. `ServeFeedVersion` writes the file, absorbing the `{onestop_id}-{sha1}.zip` key construction so the storage layout stays inside this package.

Redistribution is reported rather than enforced, so the status code for a feed that forbids it belongs to the caller. That matters because this package currently answers 401 here and 403 for the same condition in feed version export; a caller composing its own handler should not have to inherit either.

The realtime endpoint shares the lookup and ignores the feed version: an RT-only feed has none, so a lookup that treated that as an error would have turned a working endpoint into a 404.

### Requiring the feed to be readable

A feed version and its feed are permission-filtered independently — `pfJoinCheckFv` admits a feed version whose id was granted directly, while the nested feed goes through `pfJoinCheck`. The handlers only ever checked the former, so a resolved feed version did not imply a readable feed. All three now require both.

On the two file endpoints this is defence in depth rather than a reachable fix: `FeedVersion.feed` is non-null in the schema, so a visible feed version with an invisible feed makes the GraphQL lookup null-propagate and the handler answers 500. Nothing is served either way. The guard is worth keeping because it does not depend on that schema detail staying true, but it cannot fire today.

The realtime endpoint is where it matters, and there it does fire. That endpoint's only gate was the license check, and a feed the caller cannot see resolves with an empty license string, which `!= "no"` reads as permitted. The realtime message store is a cache keyed by feed with no permission check of its own, so a non-public feed with realtime data would have been served to anyone who knew its key. This is a latent surface rather than an exposure: no private feed in production carries realtime data, so there is nothing behind it today. It is still the wrong shape for the only gate on that endpoint to have.

### Fixes found while composing against the seam

The realtime handler looked its message up with the raw URL key rather than the Onestop ID it had just resolved, so the integer-feed-id form of that route — which the lookup deliberately accepts, and which the sibling download endpoints are tested for — could never return data. It now uses the resolved identifier, with a test that fails on the old behaviour with a 404.

`serveFromStorage` never closed the reader returned by the store, leaking a descriptor per download on any non-presigned store, including on the copy error path. `jobserver.serveArtifact` already does this correctly and its comment cross-references this function.

`ServeFeedVersion` takes a context rather than the request, matching the two lookups, and its doc records that it answers the client itself before returning an error. The request was only ever read for its context, so nothing else needed it.

`WriteJsonError` is exported: composing a handler outside this package means answering failures in the same shape, and the existing helper is internal.

## Test plan

`TestFeedVersionDownloadPermissions` drives the three endpoints against `EG`, the one non-public feed in the fixtures, using the in-process OpenFGA server the permission resolver tests already use. A user reaching `EG` through a group is contrasted with a user holding no tuples at all. The granted cases are controls: without them a 404 could equally mean the fixture is missing.

The private feed is given realtime data through `testconfig.Options.RTJsons`, because the realtime endpoint answers "not found" without a message regardless of permissions — the assertion would otherwise have passed for the wrong reason.

Mutation-checked rather than assumed meaningful. Removing the feed check from the realtime endpoint fails with 200 where 404 is expected, and running the lookup on a background context instead of the request's fails as well. Stated honestly: the same check on the two file endpoints is not covered, because a caller with no grants is already stopped by the empty sha1; covering it needs a feed-version-scoped grant without the feed, which this does not build.

The existing download, export and realtime tests pass unchanged.
